### PR TITLE
Feat: add ObservedGeneration to GameServerSet

### DIFF
--- a/apis/v1alpha1/gameserverset_types.go
+++ b/apis/v1alpha1/gameserverset_types.go
@@ -139,6 +139,9 @@ type GameServerSetStatus struct {
 	WaitToBeDeletedReplicas *int32 `json:"waitToBeDeletedReplicas,omitempty"`
 	// LabelSelector is label selectors for query over pods that should match the replica count used by HPA.
 	LabelSelector string `json:"labelSelector,omitempty"`
+	// The generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+genclient

--- a/apis/v1alpha1/gameserverset_types.go
+++ b/apis/v1alpha1/gameserverset_types.go
@@ -128,6 +128,9 @@ type ScaleStrategy struct {
 
 // GameServerSetStatus defines the observed state of GameServerSet
 type GameServerSetStatus struct {
+	// The generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// replicas from advancedStatefulSet
 	Replicas                int32  `json:"replicas"`
 	ReadyReplicas           int32  `json:"readyReplicas"`
@@ -139,9 +142,6 @@ type GameServerSetStatus struct {
 	WaitToBeDeletedReplicas *int32 `json:"waitToBeDeletedReplicas,omitempty"`
 	// LabelSelector is label selectors for query over pods that should match the replica count used by HPA.
 	LabelSelector string `json:"labelSelector,omitempty"`
-	// The generation observed by the controller.
-	// +optional
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+genclient

--- a/config/crd/bases/game.kruise.io_gameserversets.yaml
+++ b/config/crd/bases/game.kruise.io_gameserversets.yaml
@@ -638,6 +638,10 @@ spec:
               maintainingReplicas:
                 format: int32
                 type: integer
+              observedGeneration:
+                description: The generation observed by the controller.
+                format: int64
+                type: integer
               readyReplicas:
                 format: int32
                 type: integer

--- a/pkg/controllers/gameserverset/gameserverset_manager.go
+++ b/pkg/controllers/gameserverset/gameserverset_manager.go
@@ -18,10 +18,13 @@ package gameserverset
 
 import (
 	"context"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
 	kruiseV1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	kruiseV1beta1 "github.com/openkruise/kruise-api/apps/v1beta1"
-	gameKruiseV1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
-	"github.com/openkruise/kruise-game/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,10 +33,9 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
-	"strconv"
-	"sync"
-	"time"
+
+	gameKruiseV1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/pkg/util"
 )
 
 type Control interface {
@@ -364,6 +366,7 @@ func (manager *GameServerSetManager) SyncStatus() error {
 		MaintainingReplicas:     pointer.Int32Ptr(int32(maintainingGs)),
 		WaitToBeDeletedReplicas: pointer.Int32Ptr(int32(waitToBeDeletedGs)),
 		LabelSelector:           asts.Status.LabelSelector,
+		ObservedGeneration:      gss.GetGeneration(),
 	}
 
 	patchStatus := map[string]interface{}{"status": status}

--- a/pkg/controllers/gameserverset/gameserverset_manager.go
+++ b/pkg/controllers/gameserverset/gameserverset_manager.go
@@ -26,6 +26,7 @@ import (
 	kruiseV1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	kruiseV1beta1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -368,7 +369,9 @@ func (manager *GameServerSetManager) SyncStatus() error {
 		LabelSelector:           asts.Status.LabelSelector,
 		ObservedGeneration:      gss.GetGeneration(),
 	}
-
+	if equality.Semantic.DeepEqual(gss.Status, status) {
+		return nil
+	}
 	patchStatus := map[string]interface{}{"status": status}
 	jsonPatch, err := json.Marshal(patchStatus)
 	if err != nil {


### PR DESCRIPTION
Add ObservedGeneration to GameServerSet.

1. Update api types and crd.
2. Add status update logic.