### PR TITLE
fix: gss status sync failed when template metadata is not null

### DIFF
--- a/pkg/controllers/gameserverset/gameserverset_controller.go
+++ b/pkg/controllers/gameserverset/gameserverset_controller.go
@@ -287,7 +287,7 @@ func (r *GameServerSetReconciler) initAsts(gss *gamekruiseiov1alpha1.GameServerS
 	// set replicas
 	asts.Spec.Replicas = gss.Spec.Replicas
 
-	asts = util.GetNewAstsFromGss(gss, asts)
+	asts = util.GetNewAstsFromGss(gss.DeepCopy(), asts)
 
 	return r.Client.Create(context.Background(), asts)
 }


### PR DESCRIPTION

## problem
When the template metadata is not empty, the label of game.kruise.io/owner-gss will be added to the gss, which will result in an inconsistency with the previous judgment when getting the hash.

## solution
Use DeepCopy when gss is passed in as a parameter