### PR TITLE
assume that slices without elements are equal

### DIFF
--- a/pkg/util/slice.go
+++ b/pkg/util/slice.go
@@ -114,9 +114,6 @@ func StringToInt32Slice(str string, delimiter string) []int32 {
 }
 
 func IsSliceEqual(a, b []int) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/util/slice_test.go
+++ b/pkg/util/slice_test.go
@@ -218,13 +218,38 @@ func TestIsSliceEqual(t *testing.T) {
 			b:      []int{5, 1, 3},
 			result: true,
 		},
+		{
+			a:      []int{1, 3, 5},
+			b:      []int{5, 1, 2},
+			result: false,
+		},
+		{
+			a:      nil,
+			b:      []int{},
+			result: true,
+		},
+		{
+			a:      []int{},
+			b:      nil,
+			result: true,
+		},
+		{
+			a:      nil,
+			b:      nil,
+			result: true,
+		},
+		{
+			a:      []int{},
+			b:      []int{},
+			result: true,
+		},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		actual := IsSliceEqual(test.a, test.b)
 		expect := test.result
 		if expect != actual {
-			t.Errorf("expect %v but got %v", expect, actual)
+			t.Errorf("case %d: expect %v but got %v", i, expect, actual)
 		}
 	}
 }


### PR DESCRIPTION
Slice is nil and slice does not exist elements, both are considered to be the same, which can help to avoid format problems when the user enters.