### PR TITLE
feat: add new opsState named Allocated

### DIFF
--- a/apis/v1alpha1/gameserver_types.go
+++ b/apis/v1alpha1/gameserver_types.go
@@ -61,6 +61,7 @@ const (
 	Maintaining  OpsState = "Maintaining"
 	WaitToDelete OpsState = "WaitToBeDeleted"
 	None         OpsState = "None"
+	Allocated    OpsState = "Allocated"
 )
 
 type ServiceQuality struct {

--- a/docs/en/getting_started/gameservers_scale.md
+++ b/docs/en/getting_started/gameservers_scale.md
@@ -2,7 +2,7 @@
 
 OpenKruiseGame allows you to set the states of game servers. You can manually set the value of opsState or DeletionPriority for a game server. You can also use the service quality feature to automatically set the value of opsState or DeletionPriority for a game server. During scale-in, a proper GameServerSet workload is selected for scale-in based on the states of game servers. The scale-in rules are as follows:
 
-1. Scale in game servers based on the opsState values. Scale in the game servers for which the opsState values are `WaitToBeDeleted`, `None`, and `Maintaining` in sequence.
+1. Scale in game servers based on the opsState values. Scale in the game servers for which the opsState values are `WaitToBeDeleted`, `None`, `Allocated`, and `Maintaining` in sequence.
 
 2. If two or more game servers have the same opsState value, game servers are performed based on the values of DeletionPriority. The game server with the largest DeletionPriority value is deleted first.
 

--- a/docs/中文/快速开始/游戏服水平伸缩.md
+++ b/docs/中文/快速开始/游戏服水平伸缩.md
@@ -4,7 +4,7 @@
 
 OKG提供游戏服状态设置的能力，您可以手动/自动(服务质量功能)地设置游戏服的运维状态或删除优先级。当缩容时，GameServerSet负载会根据游戏服的状态进行缩容选择，缩容规则如下：
 
-1）根据游戏服的opsState缩容。按顺序依次缩容opsState为`WaitToBeDeleted`、`None`、`Maintaining`的游戏服
+1）根据游戏服的opsState缩容。按顺序依次缩容opsState为`WaitToBeDeleted`、`None`、`Allocated`、`Maintaining`的游戏服
 
 2）当opsState相同时，按照DeletionPriority(删除优先级)缩容，优先删除DeletionPriority大的游戏服
 

--- a/pkg/util/gameserver.go
+++ b/pkg/util/gameserver.go
@@ -69,8 +69,10 @@ func opsStateDeletePrority(opsState string) int {
 		return 1
 	case string(gameKruiseV1alpha1.None):
 		return 0
-	case string(gameKruiseV1alpha1.Maintaining):
+	case string(gameKruiseV1alpha1.Allocated):
 		return -1
+	case string(gameKruiseV1alpha1.Maintaining):
+		return -2
 	}
 	return 0
 }

--- a/pkg/util/gameserver_test.go
+++ b/pkg/util/gameserver_test.go
@@ -94,6 +94,47 @@ func TestDeleteSequenceGs(t *testing.T) {
 			},
 			after: []int{2, 0, 3, 1},
 		},
+		{
+			before: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "xxx-0",
+						Labels: map[string]string{
+							gameKruiseV1alpha1.GameServerOpsStateKey:       string(gameKruiseV1alpha1.Allocated),
+							gameKruiseV1alpha1.GameServerDeletePriorityKey: "0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "xxx-1",
+						Labels: map[string]string{
+							gameKruiseV1alpha1.GameServerOpsStateKey:       string(gameKruiseV1alpha1.Maintaining),
+							gameKruiseV1alpha1.GameServerDeletePriorityKey: "0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "xxx-2",
+						Labels: map[string]string{
+							gameKruiseV1alpha1.GameServerOpsStateKey:       string(gameKruiseV1alpha1.WaitToDelete),
+							gameKruiseV1alpha1.GameServerDeletePriorityKey: "0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "xxx-3",
+						Labels: map[string]string{
+							gameKruiseV1alpha1.GameServerOpsStateKey:       string(gameKruiseV1alpha1.None),
+							gameKruiseV1alpha1.GameServerDeletePriorityKey: "0",
+						},
+					},
+				},
+			},
+			after: []int{2, 3, 0, 1},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
https://github.com/openkruise/kruise-game/issues/84

Allocated opsState means the gs is already allocated by kruise-game-open-match-director, players is ready / already in the gs, so that gs with Allocated opsState should not be deleted easily.

After adding Allocated opsState, the deletion priority of opsState has changed. Scale-down the game servers for which the opsState values are WaitToBeDeleted, None, Allocated, and Maintaining in sequence.