### PR TITLE
enhance: add AllocateLoadBalancerNodePorts in clb plugin

### DIFF
--- a/cloudprovider/options/volcenginecloud_options.go
+++ b/cloudprovider/options/volcenginecloud_options.go
@@ -12,9 +12,6 @@ type CLBOptions struct {
 
 func (v VolcengineOptions) Valid() bool {
 	clbOptions := v.CLBOptions
-	if clbOptions.MaxPort-clbOptions.MinPort > 200 {
-		return false
-	}
 
 	if clbOptions.MaxPort > 65535 {
 		return false

--- a/cloudprovider/volcengine/README.md
+++ b/cloudprovider/volcengine/README.md
@@ -24,6 +24,11 @@ min_port = 500
 - Value：`port1/protocol1`,`port2/protocol2`,... The protocol names must be in uppercase letters.
 - Configurable：Y
 
+#### AllocateLoadBalancerNodePorts
+- Meaning：Whether the generated service is assigned nodeport, this can be set to false only in clb passthrough mode
+- Value：false / true
+- Configurable：Y
+
 #### Fixed
 - Meaning：whether the mapping relationship is fixed. If the mapping relationship is fixed, the mapping relationship remains unchanged even if the pod is deleted and recreated.
 - Value：false / true
@@ -63,6 +68,9 @@ spec:
         #If there are multiple ports, the format is as follows: {port1}/{protocol1},{port2}/{protocol2}...
         #If the protocol is not filled in, the default is TCP
         value: 80/TCP
+      - name: AllocateLoadBalancerNodePorts
+        # Whether the generated service is assigned nodeport.
+        value: "true"
       - name: Fixed
         #Fill in here whether a fixed IP is required [optional] ; Default is false
         value: "false"

--- a/cloudprovider/volcengine/README.zh_CN.md
+++ b/cloudprovider/volcengine/README.zh_CN.md
@@ -29,6 +29,11 @@ min_port = 500
 - 填写格式：false / true
 - 是否支持变更：是
 
+#### AllocateLoadBalancerNodePorts
+- 含义：生成的service是否分配nodeport, 仅在clb的直通模式（passthrough）下，才能设置为false
+- 填写格式：true/false
+- 是否支持变更：是
+
 #### AllowNotReadyContainers
 - 含义：在容器原地升级时允许不断流的对应容器名称，可填写多个
 - 填写格式：{containerName_0},{containerName_1},... 例如：sidecar
@@ -64,6 +69,9 @@ spec:
         #If there are multiple ports, the format is as follows: {port1}/{protocol1},{port2}/{protocol2}...
         #If the protocol is not filled in, the default is TCP
         value: 80/TCP
+      - name: AllocateLoadBalancerNodePorts
+        # Whether the generated service is assigned nodeport.
+        value: "true"
       - name: Fixed
         #Fill in here whether a fixed IP is required [optional] ; Default is false
         value: "false"

--- a/cloudprovider/volcengine/clb_test.go
+++ b/cloudprovider/volcengine/clb_test.go
@@ -265,6 +265,7 @@ func TestClbPlugin_consSvc(t *testing.T) {
 						"service.beta.kubernetes.io/volcengine-loadbalancer-scheduler":         "wrr",
 						"service.beta.kubernetes.io/volcengine-loadbalancer-pass-through":      "true",
 					},
+					allocateLoadBalancerNodePorts: true,
 				},
 				pod: &corev1.Pod{
 					TypeMeta: metav1.TypeMeta{
@@ -301,6 +302,7 @@ func TestClbPlugin_consSvc(t *testing.T) {
 								"service.beta.kubernetes.io/volcengine-loadbalancer-scheduler":         "wrr",
 								"service.beta.kubernetes.io/volcengine-loadbalancer-pass-through":      "true",
 							},
+							allocateLoadBalancerNodePorts: true,
 						}),
 						"service.beta.kubernetes.io/volcengine-loadbalancer-health-check-flag": "on",
 						"service.beta.kubernetes.io/volcengine-loadbalancer-healthy-threshold": "3",
@@ -332,6 +334,7 @@ func TestClbPlugin_consSvc(t *testing.T) {
 						},
 					},
 					},
+					AllocateLoadBalancerNodePorts: pointer.BoolPtr(true),
 				},
 			},
 		},


### PR DESCRIPTION
1）Add the AllocateLoadBalancerNodePorts parameter in volcengine clb to control whether the generated service is assigned a nodeport port;

2）Release the range restriction of the lb port