### PR TITLE
fix: AmazonWebServices-NLB controller parameter modification

### DIFF
--- a/cloudprovider/amazonswebservices/README.md
+++ b/cloudprovider/amazonswebservices/README.md
@@ -42,39 +42,34 @@ The key to deploying this project lies in authorizing the k8s ServiceAccount to 
 4. On the cluster details page, ensure that the OIDC provider is enabled. Obtain the OIDC provider URL for the EKS cluster. In the "Configuration" section of the cluster details page, find the "OpenID Connect provider URL".
 
 ##### Step 2：Configure the IAM role trust policy
+1. In the IAM console, create a new identity provider and select "OpenID Connect".
+   - For the Provider URL, enter the OIDC provider URL of your EKS cluster.
+   - For Audience, enter: `sts.amazonaws.com`
 
-Create an IAM role:
-
-- In the IAM console, create a new IAM role and select "Custom trust policy".
-
-- Use the following trust policy to allow EKS to use this role:
-
-  ```json
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Principal": {
-          "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>"
-        },
-        "Action": "sts:AssumeRoleWithWebIdentity",
-        "Condition": {
-          "StringEquals": {
-            "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:sub": "system:serviceaccount:<NAMESPACE>:<SERVICE_ACCOUNT_NAME>",
-            "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:aud": "sts.amazonaws.com"
-          }
-        }
-      }
-    ]
-  }
-  ```
-
-- Replace `<AWS_ACCOUNT_ID>`、`<REGION>`、`<OIDC_ID>`、`<NAMESPACE>` and `<SERVICE_ACCOUNT_NAME>` with your actual values.
-
-
-
-- Add the permission `ElasticLoadBalancingFullAccess`
+2. In the IAM console, create a new IAM role and select "Custom trust policy".
+   - Use the following trust policy to allow EKS to use this role:
+     ```json
+     {
+       "Version": "2012-10-17",
+       "Statement": [
+         {
+           "Effect": "Allow",
+           "Principal": {
+             "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>"
+           },
+           "Action": "sts:AssumeRoleWithWebIdentity",
+           "Condition": {
+             "StringEquals": {
+               "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:sub": "system:serviceaccount:<NAMESPACE>:ack-elbv2-controller",
+               "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:aud": "sts.amazonaws.com"
+             }
+           }
+         }
+       ]
+     }
+     ```
+     - Replace `<AWS_ACCOUNT_ID>`、`<REGION>`、`<OIDC_ID>`、`<NAMESPACE>` and `<SERVICE_ACCOUNT_NAME>` with your actual values.
+     - Add the permission `ElasticLoadBalancingFullAccess`
 
 
 

--- a/cloudprovider/amazonswebservices/README.zh_CN.md
+++ b/cloudprovider/amazonswebservices/README.zh_CN.md
@@ -42,36 +42,33 @@ aws:
 
 ##### 步骤 2：配置 IAM 角色信任策略
 
-创建 IAM 角色：
-
-- 在 IAM 控制台中，创建一个新的 IAM 角色，并选择 “Custom trust policy”。
-
-- 使用以下信任策略，允许 EKS 使用这个角色：
-
-  ```json
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Principal": {
-          "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>"
-        },
-        "Action": "sts:AssumeRoleWithWebIdentity",
-        "Condition": {
-          "StringEquals": {
-            "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:sub": "system:serviceaccount:<NAMESPACE>:<SERVICE_ACCOUNT_NAME>",
-            "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:aud": "sts.amazonaws.com"
-          }
-        }
-      }
-    ]
-  }
-  ```
-
-- 将 `<AWS_ACCOUNT_ID>`、`<REGION>`、`<OIDC_ID>`、`<NAMESPACE>` 和 `<SERVICE_ACCOUNT_NAME>` 替换为您的实际值。
-
-- 添加权限 `ElasticLoadBalancingFullAccess`
+1. 在 IAM 控制台中，创建一个新的身份提供商，并选择 “OpenID Connect”
+   - 提供商URL填写EKS 集群的 OIDC 提供者 URL
+   - 受众填写：`sts.amazonaws.com`
+2. 在 IAM 控制台中，创建一个新的 IAM 角色，并选择 “Custom trust policy”。
+   - 使用以下信任策略，允许 EKS 使用这个角色：
+     ```json
+     {
+       "Version": "2012-10-17",
+       "Statement": [
+         {
+           "Effect": "Allow",
+           "Principal": {
+             "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>"
+           },
+           "Action": "sts:AssumeRoleWithWebIdentity",
+           "Condition": {
+             "StringEquals": {
+               "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:sub": "system:serviceaccount:<NAMESPACE>:ack-elbv2-controller",
+               "oidc.eks.<REGION>.amazonaws.com/id/<OIDC_ID>:aud": "sts.amazonaws.com"
+             }
+           }
+         }
+       ]
+     }
+     ```
+   - 将 `<AWS_ACCOUNT_ID>`、`<REGION>`、`<OIDC_ID>`、`<NAMESPACE>` 和 `<SERVICE_ACCOUNT_NAME>` 替换为您的实际值。
+   - 添加权限 `ElasticLoadBalancingFullAccess`
 
 
 


### PR DESCRIPTION
In AWS EKS, the `TargetGroup` should be explicitly specified as the IP type, and the Kubernetes service should avoid using the `aws-load-balancer` annotation to reduce some of the unknown automation logic of the controller. The network model should be fully managed by OKG.