### PR TITLE
feat(GameServerSet): support range type for ReserveIDs

### DIFF
--- a/apis/v1alpha1/gameserverset_types.go
+++ b/apis/v1alpha1/gameserverset_types.go
@@ -50,14 +50,14 @@ type GameServerSetSpec struct {
 	Replicas *int32 `json:"replicas"`
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	GameServerTemplate   GameServerTemplate `json:"gameServerTemplate,omitempty"`
-	ServiceName          string             `json:"serviceName,omitempty"`
-	ReserveGameServerIds []int              `json:"reserveGameServerIds,omitempty"`
-	ServiceQualities     []ServiceQuality   `json:"serviceQualities,omitempty"`
-	UpdateStrategy       UpdateStrategy     `json:"updateStrategy,omitempty"`
-	ScaleStrategy        ScaleStrategy      `json:"scaleStrategy,omitempty"`
-	Network              *Network           `json:"network,omitempty"`
-	Lifecycle            *appspub.Lifecycle `json:"lifecycle,omitempty"`
+	GameServerTemplate   GameServerTemplate   `json:"gameServerTemplate,omitempty"`
+	ServiceName          string               `json:"serviceName,omitempty"`
+	ReserveGameServerIds []intstr.IntOrString `json:"reserveGameServerIds,omitempty"`
+	ServiceQualities     []ServiceQuality     `json:"serviceQualities,omitempty"`
+	UpdateStrategy       UpdateStrategy       `json:"updateStrategy,omitempty"`
+	ScaleStrategy        ScaleStrategy        `json:"scaleStrategy,omitempty"`
+	Network              *Network             `json:"network,omitempty"`
+	Lifecycle            *appspub.Lifecycle   `json:"lifecycle,omitempty"`
 }
 
 type GameServerTemplate struct {

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -189,7 +189,7 @@ func (in *GameServerSetSpec) DeepCopyInto(out *GameServerSetSpec) {
 	in.GameServerTemplate.DeepCopyInto(&out.GameServerTemplate)
 	if in.ReserveGameServerIds != nil {
 		in, out := &in.ReserveGameServerIds, &out.ReserveGameServerIds
-		*out = make([]int, len(*in))
+		*out = make([]intstr.IntOrString, len(*in))
 		copy(*out, *in)
 	}
 	if in.ServiceQualities != nil {

--- a/config/crd/bases/game.kruise.io_gameserversets.yaml
+++ b/config/crd/bases/game.kruise.io_gameserversets.yaml
@@ -605,7 +605,10 @@ spec:
                 type: integer
               reserveGameServerIds:
                 items:
-                  type: integer
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
                 type: array
               scaleStrategy:
                 properties:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openkruise/kruise-game
 
 go 1.22.0
 
+toolchain go1.22.12
+
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/aws-controllers-k8s/elbv2-controller v0.0.9
@@ -9,8 +11,9 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.32.0
-	github.com/openkruise/kruise-api v1.7.1
+	github.com/openkruise/kruise-api v1.8.0
 	github.com/prometheus/client_golang v1.18.0
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	google.golang.org/grpc v1.58.3
 	google.golang.org/protobuf v1.33.0
 	k8s.io/api v0.30.10
@@ -62,7 +65,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.32.0 h1:JRYU78fJ1LPxlckP6Txi/EYqJvjtMrDC04/MM5XRHPk=
 github.com/onsi/gomega v1.32.0/go.mod h1:a4x4gW6Pz2yK1MAmvluYme5lvYTn61afQ2ETw/8n4Lg=
-github.com/openkruise/kruise-api v1.7.1 h1:pF+tPHWY1SS0X7sXTOIHZ5sNb5h5MBy1D7h6bJI5yW8=
-github.com/openkruise/kruise-api v1.7.1/go.mod h1:ZD94u+GSQGtKrDfFhMVpQhzjr7g7UlXhYfRoNp/EhJs=
+github.com/openkruise/kruise-api v1.8.0 h1:DoUb873uuf2Bhoajim+9tb/X0eFpwIxRydc4Awfeeiw=
+github.com/openkruise/kruise-api v1.8.0/go.mod h1:XRpoTk7VFgh9r5HRUZurwhiC3cpCf5BX8X4beZLcIfA=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/controllers/gameserverset/gameserverset_controller_test.go
+++ b/pkg/controllers/gameserverset/gameserverset_controller_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -115,7 +116,7 @@ func TestInitAsts(t *testing.T) {
 				},
 				Spec: gameKruiseV1alpha1.GameServerSetSpec{
 					Replicas:             ptr.To[int32](4),
-					ReserveGameServerIds: []int{0},
+					ReserveGameServerIds: []intstr.IntOrString{intstr.FromInt(0)},
 					UpdateStrategy: gameKruiseV1alpha1.UpdateStrategy{
 						Type:          apps.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &gameKruiseV1alpha1.RollingUpdateStatefulSetStrategy{},
@@ -144,7 +145,7 @@ func TestInitAsts(t *testing.T) {
 				},
 				Spec: kruiseV1beta1.StatefulSetSpec{
 					Replicas:            ptr.To[int32](4),
-					ReserveOrdinals:     []int{0},
+					ReserveOrdinals:     []intstr.IntOrString{intstr.FromInt(0)},
 					PodManagementPolicy: apps.ParallelPodManagement,
 					ServiceName:         "case1",
 					Selector: &metav1.LabelSelector{

--- a/pkg/util/gameserver.go
+++ b/pkg/util/gameserver.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -95,6 +96,10 @@ func GetIndexListFromPodList(podList []corev1.Pod) []int {
 		indexList = append(indexList, GetIndexFromGsName(podList[i].GetName()))
 	}
 	return indexList
+}
+
+func GetIndexSetFromPodList(podList []corev1.Pod) sets.Set[int] {
+	return sets.New[int](GetIndexListFromPodList(podList)...)
 }
 
 func GetIndexListFromGsList(gsList []gameKruiseV1alpha1.GameServer) []int {

--- a/pkg/util/set.go
+++ b/pkg/util/set.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2022 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
+	"golang.org/x/exp/constraints"
+)
+
+// see github.com/openkruise/kruise/pkg/util/api/asts.go
+
+// ParseRange parses the start and end value from a string like "1-3"
+func ParseRange(s string) (start int, end int, err error) {
+	split := strings.Split(s, "-")
+	if len(split) != 2 {
+		return 0, 0, fmt.Errorf("invalid range %s", s)
+	}
+	start, err = strconv.Atoi(strings.TrimSpace(split[0]))
+	if err != nil {
+		return
+	}
+	end, err = strconv.Atoi(strings.TrimSpace(split[1]))
+	if err != nil {
+		return
+	}
+	if start > end {
+		return 0, 0, fmt.Errorf("invalid range %s", s)
+	}
+	return
+}
+
+// GetReserveOrdinalIntSet returns a set of ints from parsed reserveOrdinal
+func GetReserveOrdinalIntSet(r []intstr.IntOrString) sets.Set[int] {
+	values := sets.New[int]()
+	for _, elem := range r {
+		if elem.Type == intstr.Int {
+			values.Insert(int(elem.IntVal))
+		} else {
+			start, end, err := ParseRange(elem.StrVal)
+			if err != nil {
+				klog.ErrorS(err, "invalid range reserveOrdinal found, an empty slice will be returned", "reserveOrdinal", elem.StrVal)
+				return nil
+			}
+			for i := start; i <= end; i++ {
+				values.Insert(i)
+			}
+		}
+	}
+	return values
+}
+
+// StringToOrdinalIntSet convert a string to a set of ordinals,
+// support ranged ordinals like "1-3,5-7,10"
+// eg, "1, 2-5, 7" -> {1, 2, 3, 4, 5, 7}
+func StringToOrdinalIntSet(str string, delimiter string) sets.Set[int] {
+	ret := sets.New[int]()
+	if str == "" {
+		return ret
+	}
+
+	strList := strings.Split(str, delimiter)
+	if len(strList) == 0 {
+		return ret
+	}
+
+	for _, s := range strList {
+		if strings.Contains(s, "-") {
+			start, end, err := ParseRange(s)
+			if err != nil {
+				klog.ErrorS(err, "invalid range found, skip", "range", s)
+				continue
+			}
+			for i := start; i <= end; i++ {
+				ret.Insert(i)
+			}
+		} else {
+			num, err := strconv.Atoi(strings.TrimSpace(s))
+			if err != nil {
+				klog.ErrorS(err, "invalid number found, skip", "number", s)
+				continue
+			}
+			ret.Insert(num)
+		}
+	}
+
+	return ret
+}
+
+// OrdinalSetToIntStrSlice convert a set of oridinals to a ranged intstr slice
+// e.g. {1, 2, 5, 6, 7, 10} -> ["1", "2", "5-7", 10]
+func OrdinalSetToIntStrSlice[T constraints.Integer](s sets.Set[T]) []intstr.IntOrString {
+	if s.Len() == 0 {
+		return nil
+	}
+
+	// get all ordinals and sort them
+	ordinals := s.UnsortedList()
+	slices.Sort(ordinals)
+
+	var ret []intstr.IntOrString
+	if len(ordinals) == 0 {
+		return ret
+	}
+
+	// Initialize sequence tracking
+	start := ordinals[0]
+	end := start
+
+	// Process all ordinals
+	for i := 1; i < len(ordinals); i++ {
+		curr := ordinals[i]
+		if curr == end+1 {
+			// Continue the current sequence
+			end = curr
+		} else {
+			// Add the completed sequence to results
+			appendSequence(&ret, start, end)
+			// Start a new sequence
+			start = curr
+			end = curr
+		}
+	}
+
+	// Handle the final sequence
+	appendSequence(&ret, start, end)
+
+	return ret
+}
+
+// Helper function to append a sequence to the result slice
+func appendSequence[T constraints.Integer](ret *[]intstr.IntOrString, start, end T) {
+	if end < start {
+		start, end = end, start
+	}
+	switch {
+	case start == end:
+		*ret = append(*ret, intstr.FromInt(int(start)))
+	case end-start == 1:
+		*ret = append(*ret, intstr.FromInt(int(start)), intstr.FromInt(int(end)))
+	default:
+		*ret = append(*ret, intstr.FromString(fmt.Sprintf("%d-%d", start, end)))
+	}
+}
+
+// OrdinalSetToString convert a set of ordinals to a string with default delimiter ",",
+// e.g. {1, 2, 5, 6, 7, 10} -> "1,2,5-7,10"
+func OrdinalSetToString(s sets.Set[int]) string {
+	return intSetToString(s, ",")
+}
+
+func intSetToString(s sets.Set[int], delimiter string) string {
+	if s.Len() == 0 {
+		return ""
+	}
+	// get all ordinals and sort them
+	ss := OrdinalSetToIntStrSlice(s)
+	ret := make([]string, 0, len(ss))
+	for _, elem := range ss {
+		if elem.Type == intstr.Int {
+			ret = append(ret, strconv.Itoa(int(elem.IntVal)))
+		} else {
+			ret = append(ret, elem.StrVal)
+		}
+	}
+	return strings.Join(ret, delimiter)
+}
+
+// GetSetInANotInB returns a set of elements that are in set a but not in set b
+func GetSetInANotInB[T comparable](a, b sets.Set[T]) sets.Set[T] {
+	ret := sets.New[T]()
+	for elem := range a {
+		if !b.Has(elem) {
+			ret.Insert(elem)
+		}
+	}
+	return ret
+}

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2022 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestOrdinalSetToIntStrSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    sets.Set[int]
+		expected []intstr.IntOrString
+	}{
+		{
+			name:     "single element",
+			input:    sets.New(5),
+			expected: []intstr.IntOrString{intstr.FromInt(5)},
+		},
+		{
+			name:     "continuous elements",
+			input:    sets.New(1, 2, 3, 4, 5),
+			expected: []intstr.IntOrString{intstr.FromString("1-5")},
+		},
+		{
+			name:  "multiple continuous elements",
+			input: sets.New(1, 2, 3, 5, 6, 7),
+			expected: []intstr.IntOrString{
+				intstr.FromString("1-3"),
+				intstr.FromString("5-7"),
+			},
+		},
+		{
+			name:  "multiple continuous elements with single element",
+			input: sets.New(1, 2, 3, 5, 7, 8, 9, 11),
+			expected: []intstr.IntOrString{
+				intstr.FromString("1-3"),
+				intstr.FromInt(5),
+				intstr.FromString("7-9"),
+				intstr.FromInt(11),
+			},
+		},
+		{
+			name:  "unsorted continuous elements",
+			input: sets.New(3, 1, 2, 4, 8, 6, 7),
+			expected: []intstr.IntOrString{
+				intstr.FromString("1-4"),
+				intstr.FromString("6-8"),
+			},
+		},
+		{
+			name:  "non-continuous elements",
+			input: sets.New(1, 2, 5, 7, 9),
+			expected: []intstr.IntOrString{
+				intstr.FromInt(1),
+				intstr.FromInt(2),
+				intstr.FromInt(5),
+				intstr.FromInt(7),
+				intstr.FromInt(9),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := OrdinalSetToIntStrSlice(tc.input)
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("OrdinalSetToIntStrSlice(%v) = %v, expected %v", tc.input.UnsortedList(), result, tc.expected)
+			}
+		})
+	}
+}
+
+// test OrdinalSetToIntStrSlice with different types
+func TestOrdinalSetToIntStrSliceWithDifferentTypes(t *testing.T) {
+	int32Set := sets.New[int32](1, 2, 3, 5)
+	expected := []intstr.IntOrString{
+		intstr.FromString("1-3"),
+		intstr.FromInt(5),
+	}
+
+	result := OrdinalSetToIntStrSlice(int32Set)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("use int32 type test failed: got %v, expected %v", result, expected)
+	}
+
+	// 测试uint类型
+	uintSet := sets.New[uint](10, 11, 12, 15)
+	expected = []intstr.IntOrString{
+		intstr.FromString("10-12"),
+		intstr.FromInt(15),
+	}
+
+	result = OrdinalSetToIntStrSlice(uintSet)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("use uint type test failed: got %v, expected %v", result, expected)
+	}
+}
+
+func TestStringToOrdinalIntSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		delimiter string
+		expected  sets.Set[int]
+	}{
+		{
+			name:      "empty string",
+			str:       "",
+			delimiter: ",",
+			expected:  sets.New[int](),
+		},
+		{
+			name:      "single number",
+			str:       "5",
+			delimiter: ",",
+			expected:  sets.New(5),
+		},
+		{
+			name:      "multiple numbers",
+			str:       "1,3,5,7",
+			delimiter: ",",
+			expected:  sets.New(1, 3, 5, 7),
+		},
+		{
+			name:      "single range",
+			str:       "1-5",
+			delimiter: ",",
+			expected:  sets.New(1, 2, 3, 4, 5),
+		},
+		{
+			name:      "multiple ranges",
+			str:       "1-3,7-9",
+			delimiter: ",",
+			expected:  sets.New(1, 2, 3, 7, 8, 9),
+		},
+		{
+			name:      "mixed numbers and ranges",
+			str:       "1-3,5,7-9,11",
+			delimiter: ",",
+			expected:  sets.New(1, 2, 3, 5, 7, 8, 9, 11),
+		},
+		{
+			name:      "with spaces",
+			str:       "1-3, 5, 7-9, 11",
+			delimiter: ",",
+			expected:  sets.New(1, 2, 3, 5, 7, 8, 9, 11),
+		},
+		{
+			name:      "different delimiter",
+			str:       "1-3;5;7-9;11",
+			delimiter: ";",
+			expected:  sets.New(1, 2, 3, 5, 7, 8, 9, 11),
+		},
+		{
+			name:      "invalid number",
+			str:       "1,abc,3",
+			delimiter: ",",
+			expected:  sets.New(1, 3),
+		},
+		{
+			name:      "invalid range",
+			str:       "1-3,5-abc,7-9",
+			delimiter: ",",
+			expected:  sets.New(1, 2, 3, 7, 8, 9),
+		},
+		{
+			name:      "inverted range",
+			str:       "1-3,5-2,7-9",
+			delimiter: ",",
+			expected:  sets.New(1, 2, 3, 7, 8, 9),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := StringToOrdinalIntSet(tc.str, tc.delimiter)
+
+			if !result.Equal(tc.expected) {
+				t.Errorf("StringToOrdinalIntSet(%q, %q) = %v, expected %v",
+					tc.str, tc.delimiter, result.UnsortedList(), tc.expected.UnsortedList())
+			}
+		})
+	}
+}
+
+func TestIntSetToString(t *testing.T) {
+	tests := []struct {
+		name      string
+		set       sets.Set[int]
+		delimiter string
+		expected  string
+	}{
+		{
+			name:      "empty set",
+			set:       sets.New[int](),
+			delimiter: ",",
+			expected:  "",
+		},
+		{
+			name:      "single element",
+			set:       sets.New(5),
+			delimiter: ",",
+			expected:  "5",
+		},
+		{
+			name:      "multiple elements",
+			set:       sets.New(1, 3, 5, 7),
+			delimiter: ",",
+			expected:  "1,3,5,7",
+		},
+		{
+			name:      "continuous elements",
+			set:       sets.New(1, 2, 3, 4, 5),
+			delimiter: ",",
+			expected:  "1-5",
+		},
+		{
+			name:      "mixed continuous and single elements",
+			set:       sets.New(1, 2, 3, 5, 7, 8, 9, 11),
+			delimiter: ",",
+			expected:  "1-3,5,7-9,11",
+		},
+		{
+			name:      "unsorted elements",
+			set:       sets.New(5, 3, 1, 2, 4),
+			delimiter: ",",
+			expected:  "1-5",
+		},
+		{
+			name:      "different delimiter",
+			set:       sets.New(1, 2, 3, 5, 7),
+			delimiter: ";",
+			expected:  "1-3;5;7",
+		},
+		{
+			name:      "non-continuous elements",
+			set:       sets.New(1, 2, 5),
+			delimiter: ",",
+			expected:  "1,2,5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := intSetToString(tc.set, tc.delimiter)
+			if result != tc.expected {
+				t.Errorf("intSetToString(%v, %q) = %q, expected %q",
+					tc.set.UnsortedList(), tc.delimiter, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/util/slice.go
+++ b/pkg/util/slice.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func IsNumInList(num int, list []int) bool {
@@ -87,6 +89,29 @@ func StringToIntSlice(str string, delimiter string) []int {
 			continue
 		}
 		retSlice = append(retSlice, val)
+	}
+	return retSlice
+}
+
+func StringToIntStrSlice(str string, delimiter string) []intstr.IntOrString {
+	if str == "" || delimiter == "" {
+		return nil
+	}
+	strList := strings.Split(str, delimiter)
+	if len(strList) == 0 {
+		return nil
+	}
+	var retSlice []intstr.IntOrString
+	for _, item := range strList {
+		if item == "" {
+			continue
+		}
+		val, err := strconv.Atoi(item)
+		if err != nil {
+			retSlice = append(retSlice, intstr.FromString(strings.TrimSpace(item)))
+		} else {
+			retSlice = append(retSlice, intstr.FromInt(val))
+		}
 	}
 	return retSlice
 }

--- a/pkg/webhook/validating_gss.go
+++ b/pkg/webhook/validating_gss.go
@@ -25,6 +25,8 @@ import (
 	"github.com/openkruise/kruise-game/cloudprovider/manager"
 	"github.com/openkruise/kruise-game/pkg/util"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -65,12 +67,50 @@ func (gvh *GssValidaatingHandler) Handle(ctx context.Context, req admission.Requ
 
 func validatingGss(gss *gamekruiseiov1alpha1.GameServerSet, client client.Client) (bool, string) {
 	// validate reserveGameServerIds
-	rgsIds := gss.Spec.ReserveGameServerIds
-	if util.IsRepeat(rgsIds) {
-		return false, fmt.Sprintf("reserveGameServerIds should not be repeat. Now it is %v", rgsIds)
+	vset := sets.Set[int]{}
+
+	validate := func(ids intstr.IntOrString) (bool, string) {
+		switch ids.Type {
+		case intstr.Int:
+			id := ids.IntVal
+			if id < 0 {
+				return false, fmt.Sprintf("reserveGameServerIds should be greater or equal to 0. Now it is %d", id)
+			}
+			if vset.Has(int(id)) {
+				return false, fmt.Sprintf("reserveGameServerIds should not be repeat. Now it is %d", id)
+			}
+			vset.Insert(int(id))
+		case intstr.String:
+			start, end, err := util.ParseRange(ids.StrVal)
+			if err != nil {
+				return false, fmt.Sprintf("invalid range reserveGameServerIds found, an empty slice will be returned: %s", ids.StrVal)
+			}
+			if start < 0 {
+				return false, fmt.Sprintf("reserveGameServerIds should be greater or equal to 0. Now it is %d", start)
+			}
+			if end < 0 {
+				return false, fmt.Sprintf("reserveGameServerIds should be greater or equal to 0. Now it is %d", end)
+			}
+			if start > end {
+				return false, fmt.Sprintf("invalid range reserveGameServerIds found, an empty slice will be returned: %s", ids.StrVal)
+			}
+			if vset.Has(int(start)) || vset.Has(int(end)) {
+				return false, fmt.Sprintf("reserveGameServerIds should not be repeat. Now it is %d-%d", start, end)
+			}
+			for i := start; i <= end; i++ {
+				if vset.Has(int(i)) {
+					return false, fmt.Sprintf("reserveGameServerIds should not be repeat. Now it is %d-%d", start, end)
+				}
+				vset.Insert(int(i))
+			}
+		}
+		return true, ""
 	}
-	if util.IsHasNegativeNum(rgsIds) {
-		return false, fmt.Sprintf("reserveGameServerIds should be greater or equal to 0. Now it is %v", rgsIds)
+
+	for _, id := range gss.Spec.ReserveGameServerIds {
+		if ok, reason := validate(id); !ok {
+			return false, reason
+		}
 	}
 
 	return true, "general validating success"

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -124,7 +124,7 @@ func (f *Framework) DeployGssWithServiceQualities() (*gamekruiseiov1alpha1.GameS
 	return f.client.CreateGameServerSet(gss)
 }
 
-func (f *Framework) GameServerScale(gss *gamekruiseiov1alpha1.GameServerSet, desireNum int, reserveGsId *int) (*gamekruiseiov1alpha1.GameServerSet, error) {
+func (f *Framework) GameServerScale(gss *gamekruiseiov1alpha1.GameServerSet, desireNum int, reserveGsId *intstr.IntOrString) (*gamekruiseiov1alpha1.GameServerSet, error) {
 	// TODO: change patch type
 	newReserves := gss.Spec.ReserveGameServerIds
 	if reserveGsId != nil {


### PR DESCRIPTION
resolve #203 

Changes `ReserveGameServerIds` to the `[]intstr.IntOrString` type, adapting to the upstream Kruise asts type change to support the range type of ReserveID.

There are some key dependency changes to be aware of, and I'm also trying to remove the unnecessary changes

Key dependency changes：

- kruise-api v1.7.1-> v1.8.0

This PR is still working in progress, and any comments and suggestions are always welcome. Thanks~

TODO:
- [ ] update docs https://github.com/openkruise/openkruise.io/pull/241