### PR TITLE
fix:add pod create time in svc

### DIFF
--- a/cloudprovider/volcengine/clb.go
+++ b/cloudprovider/volcengine/clb.go
@@ -173,6 +173,10 @@ func (c *ClbPlugin) OnPodUpdated(client client.Client, pod *corev1.Pod, ctx cont
 		}
 		return pod, cperrors.NewPluginError(cperrors.ApiCallError, err.Error())
 	}
+	if svc.OwnerReferences[0].Kind == "Pod" && svc.OwnerReferences[0].UID != pod.UID {
+		log.Infof("[%s] waitting old svc %s/%s deleted. old owner pod uid is %s, but now is %s", ClbNetwork, svc.Namespace, svc.Name, svc.OwnerReferences[0].UID, pod.UID)
+		return pod, nil
+	}
 
 	// update svc
 	if util.GetHash(config) != svc.GetAnnotations()[ClbConfigHashKey] {


### PR DESCRIPTION
解决如下场景问题：

用户使用了volcengine的clb作为网络选型；新建gss，网络模式未选择fixed，此时会为每个副本依次创建出pod和svc；并且svc上会有pod的ownreference；
此时如果删除某个副本，会将其pod删除，正常情况下svc会连带删除，随后再创出一个pod以及svc；
但是如果旧的svc连带删除比较慢，新的pod已经创出来，旧的svc还没有被删除；此时由于新旧pod的名称一致，需要的svc也名称一致。新的pod就会使用旧的svc；出现问题
解决方案：
在非Fixed模式，给service的注解中打上对应pod的时间戳；则即使旧的svc未删除，新的pod已经创建出来时。也会因为旧的svc带的时旧的时间戳，不会错误的将新的pod和旧的svc绑定上；