### PR TITLE
优化游戏服务器并发调和设置，优化Trigger的容错率和日志

### DIFF
--- a/pkg/controllers/gameserver/gameserver_controller.go
+++ b/pkg/controllers/gameserver/gameserver_controller.go
@@ -51,7 +51,7 @@ import (
 var (
 	controllerKind = gamekruiseiov1alpha1.SchemeGroupVersion.WithKind("GameServer")
 	// leave it to batch size
-	concurrentReconciles = 10
+	concurrentReconciles = util.GetGameServerConcurrentReconciles()
 )
 
 func Add(mgr manager.Manager) error {

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,10 +1,11 @@
 package util
 
 import (
-	"k8s.io/klog/v2"
 	"os"
 	"strconv"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 func GetNetworkTotalWaitTime() time.Duration {
@@ -29,4 +30,16 @@ func GetNetworkIntervalTime() time.Duration {
 		}
 	}
 	return networkIntervalTime
+}
+
+// GetGameServerConcurrentReconciles from env
+func GetGameServerConcurrentReconciles() int {
+	val := os.Getenv("GAMESERVER_CONCURRENT_RECONCILES")
+	if val == "" {
+		return 10
+	}
+	if v, err := strconv.Atoi(val); err == nil && v > 0 {
+		return v
+	}
+	return 10
 }

--- a/pkg/util/env_test.go
+++ b/pkg/util/env_test.go
@@ -43,3 +43,37 @@ func TestGetNetworkIntervalTime(t *testing.T) {
 		}
 	}
 }
+func TestGetGameServerConcurrentReconciles(t *testing.T) {
+	tests := []struct {
+		gameServerConcurrentReconciles string
+		result                         int
+	}{
+		{
+			gameServerConcurrentReconciles: "",
+			result:                         10, // Default value
+		},
+		{
+			gameServerConcurrentReconciles: "20",
+			result:                         20,
+		},
+		{
+			gameServerConcurrentReconciles: "invalid",
+			result:                         10, // Default value for invalid input
+		},
+		{
+			gameServerConcurrentReconciles: "0",
+			result:                         10, // Default value for non-positive input
+		},
+		{
+			gameServerConcurrentReconciles: "-5",
+			result:                         10, // Default value for negative input
+		},
+	}
+	defer os.Unsetenv("GAMESERVER_CONCURRENT_RECONCILES")
+	for _, test := range tests {
+		os.Setenv("GAMESERVER_CONCURRENT_RECONCILES", test.gameServerConcurrentReconciles)
+		if GetGameServerConcurrentReconciles() != test.result {
+			t.Errorf("expect %v but got %v", test.result, GetGameServerConcurrentReconciles())
+		}
+	}
+}


### PR DESCRIPTION
1. 增加从环境变量中设置GS Controller 并发数的设置，优化大集群调和能力
2. 优化trigger时机，改用time.RFC3339 增强时间一致性，通过报错就重写的方式兼容以前的timeformat，增加日志打印和Event，降低诊断成本