### PR TITLE
feat: add enable-cert-generation option

### DIFF
--- a/.github/workflows/e2e-1.26.yaml
+++ b/.github/workflows/e2e-1.26.yaml
@@ -14,6 +14,7 @@ env:
   KIND_VERSION: 'v0.18.0'
   KIND_IMAGE: 'kindest/node:v1.26.4'
   KIND_CLUSTER_NAME: 'ci-testing'
+  CERT_MANAGER_VERSION: 'v1.18.2'
 
 jobs:
 
@@ -39,6 +40,10 @@ jobs:
           export IMAGE="openkruise/kruise-game-manager:e2e-${GITHUB_RUN_ID}"
           docker build --pull --no-cache . -t $IMAGE
           kind load docker-image --name=${KIND_CLUSTER_NAME} $IMAGE || { echo >&2 "kind not installed or error loading image: $IMAGE"; exit 1; }
+      - name: Install Cert-Manager
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERT_MANAGER_VERSION }}/cert-manager.yaml
+          kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
       - name: Install Kruise
         run: |
           set -ex

--- a/.github/workflows/e2e-1.30.yaml
+++ b/.github/workflows/e2e-1.30.yaml
@@ -14,6 +14,7 @@ env:
   KIND_VERSION: 'v0.22.0'
   KIND_IMAGE: 'kindest/node:v1.30.8'
   KIND_CLUSTER_NAME: 'ci-testing'
+  CERT_MANAGER_VERSION: 'v1.18.2'
 
 jobs:
 
@@ -39,6 +40,10 @@ jobs:
           export IMAGE="openkruise/kruise-game-manager:e2e-${GITHUB_RUN_ID}"
           docker build --pull --no-cache . -t $IMAGE
           kind load docker-image --name=${KIND_CLUSTER_NAME} $IMAGE || { echo >&2 "kind not installed or error loading image: $IMAGE"; exit 1; }
+      - name: Install Cert-Manager
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERT_MANAGER_VERSION }}/cert-manager.yaml
+          kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
       - name: Install Kruise
         run: |
           set -ex

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,31 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert
+  namespace: system
+spec:
+  commonName: kruise-game-controller-manager
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE)
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  secretName: kruise-game-certs
+  usages:
+    - server auth
+    - client auth
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    rotationPolicy: Never
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,6 +1,5 @@
 resources:
-- manifests.yaml
-- service.yaml
+- certificate.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ bases:
 # crd/kustomization.yaml
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 # - ../prometheus
 
@@ -38,39 +38,39 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -9,15 +9,16 @@ spec:
       containers:
       - name: manager
         ports:
-        - containerPort: 9443
+        - containerPort: 9876
           name: webhook-server
           protocol: TCP
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
+        - mountPath: /tmp/webhook-certs/
           name: cert
           readOnly: true
       volumes:
       - name: cert
         secret:
           defaultMode: 420
-          secretName:  webhook-server-cert
+          secretName:  kruise-game-certs
+          optional: true

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,8 +1,15 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: mutating-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,6 +41,7 @@ spec:
         - --provider-config=/etc/kruise-game/config.toml
         - --api-server-qps=5
         - --api-server-qps-burst=10
+        - --enable-cert-generation=false
         image: controller:latest
         name: manager
         env:

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,24 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: kruise-game-system
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: mgameserverset.kb.io
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    resources:
+    - pods
+  objectSelector:
+    matchExpressions:
+    - key: game.kruise.io/owner-gss
+      operator: Exists
+  sideEffects: None
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: kruise-game-system
+      path: /validate-v1alpha1-gss
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vgameserverset.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - game.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gameserversets
+  sideEffects: None
+  timeoutSeconds: 10

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 9876
+      targetPort: webhook-server
   selector:
     control-plane: controller-manager

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -2,29 +2,28 @@ package webhook
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"reflect"
-	"testing"
 )
 
 func TestCheckValidatingConfiguration(t *testing.T) {
 	tests := []struct {
 		vwcNow   *v1.ValidatingWebhookConfiguration
-		dnsName  string
 		caBundle []byte
 		vwcNew   *v1.ValidatingWebhookConfiguration
 	}{
 		{
 			vwcNow:   nil,
-			dnsName:  "dnsName",
 			caBundle: []byte(`xxx`),
 			vwcNew: &v1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validatingWebhookConfigurationName,
 				},
-				Webhooks: getValidatingWebhookConf("dnsName", []byte(`xxx`)),
+				Webhooks: getValidatingWebhookConf([]byte(`xxx`)),
 			},
 		},
 		{
@@ -32,15 +31,14 @@ func TestCheckValidatingConfiguration(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validatingWebhookConfigurationName,
 				},
-				Webhooks: getValidatingWebhookConf("dnsName", []byte(`old`)),
+				Webhooks: getValidatingWebhookConf([]byte(`old`)),
 			},
-			dnsName:  "dnsName",
 			caBundle: []byte(`new`),
 			vwcNew: &v1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validatingWebhookConfigurationName,
 				},
-				Webhooks: getValidatingWebhookConf("dnsName", []byte(`new`)),
+				Webhooks: getValidatingWebhookConf([]byte(`new`)),
 			},
 		},
 		{
@@ -49,13 +47,12 @@ func TestCheckValidatingConfiguration(t *testing.T) {
 					Name: validatingWebhookConfigurationName,
 				},
 			},
-			dnsName:  "dnsName",
 			caBundle: []byte(`new`),
 			vwcNew: &v1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validatingWebhookConfigurationName,
 				},
-				Webhooks: getValidatingWebhookConf("dnsName", []byte(`new`)),
+				Webhooks: getValidatingWebhookConf([]byte(`new`)),
 			},
 		},
 	}
@@ -69,7 +66,7 @@ func TestCheckValidatingConfiguration(t *testing.T) {
 			}
 		}
 
-		if err := checkValidatingConfiguration(test.dnsName, clientSet, test.caBundle); err != nil {
+		if err := checkValidatingConfiguration(clientSet, test.caBundle); err != nil {
 			t.Error(err)
 		}
 
@@ -87,19 +84,17 @@ func TestCheckValidatingConfiguration(t *testing.T) {
 func TestCheckMutatingConfiguration(t *testing.T) {
 	tests := []struct {
 		mwcNow   *v1.MutatingWebhookConfiguration
-		dnsName  string
 		caBundle []byte
 		mwcNew   *v1.MutatingWebhookConfiguration
 	}{
 		{
 			mwcNow:   nil,
-			dnsName:  "dnsName",
 			caBundle: []byte(`xxx`),
 			mwcNew: &v1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: mutatingWebhookConfigurationName,
 				},
-				Webhooks: getMutatingWebhookConf("dnsName", []byte(`xxx`)),
+				Webhooks: getMutatingWebhookConf([]byte(`xxx`)),
 			},
 		},
 		{
@@ -107,15 +102,14 @@ func TestCheckMutatingConfiguration(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: mutatingWebhookConfigurationName,
 				},
-				Webhooks: getMutatingWebhookConf("dnsName", []byte(`old`)),
+				Webhooks: getMutatingWebhookConf([]byte(`old`)),
 			},
-			dnsName:  "dnsName",
 			caBundle: []byte(`new`),
 			mwcNew: &v1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: mutatingWebhookConfigurationName,
 				},
-				Webhooks: getMutatingWebhookConf("dnsName", []byte(`new`)),
+				Webhooks: getMutatingWebhookConf([]byte(`new`)),
 			},
 		},
 		{
@@ -124,13 +118,12 @@ func TestCheckMutatingConfiguration(t *testing.T) {
 					Name: mutatingWebhookConfigurationName,
 				},
 			},
-			dnsName:  "dnsName",
 			caBundle: []byte(`new`),
 			mwcNew: &v1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: mutatingWebhookConfigurationName,
 				},
-				Webhooks: getMutatingWebhookConf("dnsName", []byte(`new`)),
+				Webhooks: getMutatingWebhookConf([]byte(`new`)),
 			},
 		},
 	}
@@ -144,7 +137,7 @@ func TestCheckMutatingConfiguration(t *testing.T) {
 			}
 		}
 
-		if err := checkMutatingConfiguration(test.dnsName, clientSet, test.caBundle); err != nil {
+		if err := checkMutatingConfiguration(clientSet, test.caBundle); err != nil {
 			t.Error(err)
 		}
 


### PR DESCRIPTION
part of https://github.com/openkruise/kruise-game/issues/220

Support for cert-manager with CA injection

Change the self-generated certificate to an option, defaulting to true. To adapt the chart changes, the webhook name is hard-coded

link PR: https://github.com/openkruise/charts/pull/146