### PR TITLE
Harden and Optimize CI Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,13 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 env:
   # Common versions
   GO_VERSION: '1.22'


### PR DESCRIPTION
This PR improves CI security and efficiency with two operational changes:

- **Harden Security:** Sets default GITHUB_TOKEN permissions to contents: read, following the principle of least privilege.
- **Optimize Concurrency:** Adds a concurrency group to cancel redundant CI runs on pull requests, which saves runner resources.