### PR TITLE
GameServerSet: prevent stale-cache overwrites and minimize patch churn for reserve IDs

### DIFF
--- a/.github/workflows/e2e-1.26.yaml
+++ b/.github/workflows/e2e-1.26.yaml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: Prepare audit policy
+        run: |
+          mkdir -p /tmp/kind-audit
+          cp test/audit/policy.yaml /tmp/kind-audit/policy.yaml
       - name: Setup Kind Cluster
         uses: helm/kind-action@v1.3.0
         with:
@@ -35,6 +39,11 @@ jobs:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           config: ./test/kind-conf.yaml
           version: ${{ env.KIND_VERSION }}
+      - name: Ensure audit log file exists and is world-readable
+        run: |
+          sudo mkdir -p /tmp/kind-audit || true
+          sudo touch /tmp/kind-audit/audit.log || true
+          sudo chmod 0644 /tmp/kind-audit/audit.log || true
       - name: Build image
         run: |
           export IMAGE="openkruise/kruise-game-manager:e2e-${GITHUB_RUN_ID}"
@@ -97,21 +106,59 @@ jobs:
             echo "Timeout to wait for kruise-game ready"
             exit 1
           fi
+      - name: Verify Kind Cluster
+        run: |
+          set -euo pipefail
+          echo "=== Verifying Kind cluster ==="
+          kind get clusters
+          kubectl config use-context kind-${KIND_CLUSTER_NAME}
+          kubectl cluster-info --request-timeout=15s
+          kubectl get nodes
       - name: Run E2E Tests
         run: |
+          echo "=== Switching to Kind context ==="
           export KUBECONFIG=/home/runner/.kube/config
+          kubectl config use-context kind-${KIND_CLUSTER_NAME}
+
+          echo "=== Verifying current context ==="
+          kubectl config current-context
+
+          echo "=== Checking cluster status ==="
+          kubectl cluster-info
+          kubectl get nodes
+
+          echo "=== Building ginkgo ==="
           make ginkgo
-          set +e
-          ./bin/ginkgo -timeout 60m -v test/e2e
-          retVal=$?
-          # kubectl get pod -n kruise-game-system --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-game-system
+
+          echo "=== Running tests with verbose output ==="
+          EXIT_CODE=0
+          ./bin/ginkgo --timeout 60m -v --trace --progress test/e2e || EXIT_CODE=$?
+
+          echo "=== Collecting diagnostics ==="
+          kubectl get gss -A || true
+          kubectl get pods -n e2e-test || true
+          kubectl get events -n e2e-test || true
+
           restartCount=$(kubectl get pod -n kruise-game-system --no-headers | awk '{print $4}')
-          if [ "${restartCount}" -eq "0" ];then
-              echo "Kruise-game has not restarted"
-          else
+          if [ "${restartCount}" -ne "0" ]; then
               kubectl get pod -n kruise-game-system --no-headers
               echo "Kruise-game has restarted, abort!!!"
-              kubectl get pod -n kruise-game-system --no-headers| awk '{print $1}' | xargs kubectl logs -p -n kruise-game-system
+              kubectl get pod -n kruise-game-system --no-headers | awk '{print $1}' | xargs kubectl logs -p -n kruise-game-system
               exit 1
+          else
+              echo "Kruise-game has not restarted"
           fi
-          exit $retVal
+
+          exit ${EXIT_CODE:-0}
+      - name: Make audit logs readable
+        if: always()
+        run: |
+          sudo chmod -R a+r /tmp/kind-audit || chmod -R a+r /tmp/kind-audit || true
+          ls -l /tmp/kind-audit || true
+      - name: Upload audit logs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-audit-logs-1.26
+          path: /tmp/kind-audit
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-1.30.yaml
+++ b/.github/workflows/e2e-1.30.yaml
@@ -28,6 +28,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+        # Prepare audit policy before cluster creation so extraMounts can find it
+      - name: Prepare audit policy
+        run: |
+          mkdir -p /tmp/kind-audit
+          cp test/audit/policy.yaml /tmp/kind-audit/policy.yaml
       - name: Setup Kind Cluster
         uses: helm/kind-action@v1.12.0
         with:
@@ -35,6 +40,11 @@ jobs:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           config: ./test/kind-conf.yaml
           version: ${{ env.KIND_VERSION }}
+      - name: Ensure audit log file exists and is world-readable
+        run: |
+          sudo mkdir -p /tmp/kind-audit
+          sudo touch /tmp/kind-audit/audit.log
+          sudo chmod 0644 /tmp/kind-audit/audit.log
       - name: Build image
         run: |
           export IMAGE="openkruise/kruise-game-manager:e2e-${GITHUB_RUN_ID}"
@@ -49,7 +59,7 @@ jobs:
           set -ex
           kubectl cluster-info
           make helm
-          helm repo add openkruise https://openkruise.github.io/charts/
+          helm repo add openkruise https://openkruise.github.io/charts/ || true
           helm repo update
           helm install kruise openkruise/kruise --version 1.8.0
           for ((i=1;i<10;i++));
@@ -96,11 +106,38 @@ jobs:
             exit 1
           fi
           echo "Kruise Game installed in HA mode successfully"
+      - name: Verify Kind Cluster
+        run: |
+          set -euo pipefail
+          echo "=== Verifying Kind cluster ==="
+          kind get clusters
+          kubectl config use-context kind-${KIND_CLUSTER_NAME}
+          kubectl cluster-info --request-timeout=15s
+          kubectl get nodes
       - name: Run E2E Tests before failover
         run: |
-          export KUBECONFIG=/home/runner/.kube/config
+          echo "=== Switching to Kind context ==="
+          kubectl config use-context kind-${KIND_CLUSTER_NAME}
+          
+          echo "=== Verifying current context ==="
+          kubectl config current-context
+          
+          echo "=== Checking cluster status ==="
+          kubectl cluster-info
+          kubectl get nodes
+          
+          echo "=== Building ginkgo ==="
           make ginkgo
-          ./bin/ginkgo --timeout 10m -v test/e2e
+          
+          echo "=== Running tests with verbose output ==="
+          ./bin/ginkgo --timeout 10m -v --trace --progress test/e2e || EXIT_CODE=$?
+          
+          echo "=== Collecting diagnostics ==="
+          kubectl get gss -A
+          kubectl get pods -n e2e-test
+          kubectl get events -n e2e-test
+          
+          exit ${EXIT_CODE:-0}
       - name: Test HA Failover
         run: |
           set -e
@@ -162,3 +199,15 @@ jobs:
               exit 1
           fi
           exit $retVal
+      - name: Make audit logs readable
+        if: always()
+        run: |
+          sudo chmod -R a+r /tmp/kind-audit || true
+          ls -l /tmp/kind-audit || true
+      - name: Upload audit logs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-audit-logs-1.30
+          path: /tmp/kind-audit
+          if-no-files-found: ignore

--- a/pkg/controllers/gameserverset/gameserverset_controller_test.go
+++ b/pkg/controllers/gameserverset/gameserverset_controller_test.go
@@ -216,7 +216,6 @@ func TestInitAsts(t *testing.T) {
 	}
 }
 
-
 func TestGameServerSetController_ASTS_Management(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/test/audit/policy.yaml
+++ b/test/audit/policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  # For kruise-game controller on pods in tests: capture bodies to debug patch failures
+  - level: RequestResponse
+    users: ["system:serviceaccount:kruise-game-system:kruise-game-controller-manager"]
+    verbs: ["update", "patch"]
+    resources:
+      - group: ""
+        resources: ["pods", "pods/status"]
+    omitStages: ["RequestReceived"]
+
+  # High-signal: record full request/response bodies for changes to our CRDs and ASTS
+  - level: RequestResponse
+    verbs: ["create", "update", "patch", "delete", "deletecollection"]
+    resources:
+      - group: "game.kruise.io"
+        resources: ["gameserversets", "gameservers", "gameserversets/scale", "gameservers/scale"]
+      - group: "apps.kruise.io"
+        resources: ["statefulsets", "statefulsets/scale"]
+    omitStages: ["RequestReceived"]
+
+  # Metadata-only for pods and leases (labels/status changes, leader election)
+  - level: Metadata
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: ""
+        resources: ["pods", "pods/status"]
+      - group: "coordination.k8s.io"
+        resources: ["leases"]
+    omitStages: ["RequestReceived"]

--- a/test/e2e/framework/audit.go
+++ b/test/e2e/framework/audit.go
@@ -1,0 +1,334 @@
+package framework
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// FilterAuditLog reads the audit log file, selects entries after sinceTS
+// within the given namespace, and returns up to maxLines formatted lines.
+func FilterAuditLog(path string, sinceTS time.Time, namespace string, maxLines int) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// Allow larger lines for RequestResponse bodies
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 4*1024*1024)
+
+	type objRef struct {
+		Namespace   string `json:"namespace"`
+		Resource    string `json:"resource"`
+		APIGroup    string `json:"apiGroup"`
+		Name        string `json:"name"`
+		Subresource string `json:"subresource"`
+	}
+	type userInfo struct {
+		Username string `json:"username"`
+	}
+	type respStatus struct {
+		Code int `json:"code"`
+	}
+	type event struct {
+		Verb                 string          `json:"verb"`
+		Stage                string          `json:"stage"`
+		RequestURI           string          `json:"requestURI"`
+		StageTimestamp       string          `json:"stageTimestamp"`
+		ObjectRef            objRef          `json:"objectRef"`
+		User                 userInfo        `json:"user"`
+		UserAgent            string          `json:"userAgent"`
+		ResponseStatus       respStatus      `json:"responseStatus"`
+		RequestReceivedStamp string          `json:"requestReceivedTimestamp"`
+		RequestObject        json.RawMessage `json:"requestObject,omitempty"`
+		ResponseObject       json.RawMessage `json:"responseObject,omitempty"`
+	}
+
+	// ring buffer of last matches
+	lines := make([]string, 0, maxLines)
+	push := func(s string) {
+		if len(lines) == maxLines {
+			copy(lines, lines[1:])
+			lines[len(lines)-1] = s
+		} else {
+			lines = append(lines, s)
+		}
+	}
+
+	// keep last seen flattened state per object to compute generic diffs
+	lastObj := make(map[string]map[string]string)
+	keyOf := func(ev event) string {
+		grp := ev.ObjectRef.APIGroup
+		if grp == "" {
+			grp = "core"
+		}
+		sub := ev.ObjectRef.Subresource
+		if sub != "" {
+			return fmt.Sprintf("%s/%s/%s/%s", grp, ev.ObjectRef.Resource+"/"+sub, ev.ObjectRef.Namespace, ev.ObjectRef.Name)
+		}
+		return fmt.Sprintf("%s/%s/%s/%s", grp, ev.ObjectRef.Resource, ev.ObjectRef.Namespace, ev.ObjectRef.Name)
+	}
+
+	for scanner.Scan() {
+		b := scanner.Bytes()
+		var ev event
+		if err := json.Unmarshal(b, &ev); err != nil {
+			continue
+		}
+		if ev.Stage != "ResponseComplete" {
+			continue
+		}
+		if ev.ObjectRef.Namespace != namespace {
+			continue
+		}
+		// time filter
+		if sinceTS.After(time.Time{}) {
+			tsStr := ev.StageTimestamp
+			if tsStr == "" {
+				tsStr = ev.RequestReceivedStamp
+			}
+			if tsStr != "" {
+				if ts, err := time.Parse(time.RFC3339Nano, tsStr); err == nil {
+					if ts.Before(sinceTS) {
+						continue
+					}
+				}
+			}
+		}
+		// Only mutating verbs
+		switch ev.Verb {
+		case "update", "patch", "delete", "deletecollection":
+		default:
+			continue
+		}
+
+		grp := ev.ObjectRef.APIGroup
+		if grp == "" {
+			grp = "core"
+		}
+		res := ev.ObjectRef.Resource
+		if ev.ObjectRef.Subresource != "" {
+			res = res + "/" + ev.ObjectRef.Subresource
+		}
+
+		// Filter out particularly noisy/low-value resources (events, leases, etc.)
+		if res == "events" || strings.HasSuffix(res, "/events") || strings.HasSuffix(grp, "events.k8s.io") || res == "leases" {
+			continue
+		}
+		// Filter known high-frequency user agents (e.g., kruise pod-readiness-controller)
+		if strings.Contains(strings.ToLower(ev.UserAgent), "pod-readiness") {
+			continue
+		}
+
+		// Compute field changes (generic): prefer diff between ResponseObject and last snapshot;
+		// if there is no prior snapshot, fall back to fields from the request body.
+		var changeSuffix string
+		curFlat := flattenJSON(ev.ResponseObject, 4, 200)
+		objKey := keyOf(ev)
+		if len(curFlat) > 0 {
+			if prev, ok := lastObj[objKey]; ok {
+				diff := diffFlat(prev, curFlat)
+				changeSuffix = formatChanges(diff, 12)
+			} else {
+				// First occurrence: show intent from the request body (if available)
+				reqFlat := flattenJSON(ev.RequestObject, 3, 120)
+				changeSuffix = formatChanges(reqFlat, 12)
+			}
+			lastObj[objKey] = curFlat
+		} else {
+			// No response object (e.g., some delete operations): fall back to request fields
+			reqFlat := flattenJSON(ev.RequestObject, 3, 120)
+			changeSuffix = formatChanges(reqFlat, 12)
+			if changeSuffix == "" && (ev.Verb == "delete" || ev.Verb == "deletecollection") {
+				changeSuffix = " chg=deleted"
+			}
+		}
+
+		// who/what/where
+		push(fmt.Sprintf("%s usr=%s verb=%s %s/%s ns=%s name=%s code=%d ua=%s uri=%s%s",
+			ev.StageTimestamp,
+			ev.User.Username,
+			ev.Verb,
+			grp, res,
+			ev.ObjectRef.Namespace,
+			ev.ObjectRef.Name,
+			ev.ResponseStatus.Code,
+			trimUA(ev.UserAgent),
+			ev.RequestURI,
+			changeSuffix,
+		))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n")
+}
+
+func trimUA(ua string) string {
+	if len(ua) > 120 {
+		return ua[:120] + "..."
+	}
+	return ua
+}
+
+// flattenJSON flattens a JSON object into path->value strings, filtering noisy keys.
+// depth limits recursion depth; limit caps number of entries to avoid blow-up.
+func flattenJSON(raw json.RawMessage, depth int, limit int) map[string]string {
+	if len(raw) == 0 || limit <= 0 {
+		return nil
+	}
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	out := make(map[string]string)
+	var n int
+	var rec func(prefix string, x interface{}, d int)
+	rec = func(prefix string, x interface{}, d int) {
+		if n >= limit || d < 0 {
+			return
+		}
+		switch vv := x.(type) {
+		case map[string]interface{}:
+			// stable order for determinism
+			keys := make([]string, 0, len(vv))
+			for k := range vv {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				val := vv[k]
+				path := k
+				if prefix != "" {
+					path = prefix + "." + k
+				}
+				if noisyKey(path) {
+					continue
+				}
+				rec(path, val, d-1)
+				if n >= limit {
+					return
+				}
+			}
+		case []interface{}:
+			// Summarize array values by first few entries and length
+			l := len(vv)
+			max := l
+			if max > 3 {
+				max = 3
+			}
+			for i := 0; i < max && n < limit; i++ {
+				path := prefix + "[" + strconv.Itoa(i) + "]"
+				rec(path, vv[i], d-1)
+			}
+			out[prefix+".#"] = strconv.Itoa(l)
+			n++
+		case string:
+			out[prefix] = vv
+			n++
+		case bool:
+			out[prefix] = strconv.FormatBool(vv)
+			n++
+		case float64:
+			// JSON numbers decode to float64; render without trailing .0 when integer
+			if vv == float64(int64(vv)) {
+				out[prefix] = strconv.FormatInt(int64(vv), 10)
+			} else {
+				out[prefix] = strconv.FormatFloat(vv, 'f', -1, 64)
+			}
+			n++
+		case nil:
+			out[prefix] = "<nil>"
+			n++
+		default:
+			// fallback to JSON string for nested objects we didn't dive into
+			b, _ := json.Marshal(vv)
+			s := string(b)
+			if len(s) > 80 {
+				s = s[:80] + "..."
+			}
+			out[prefix] = s
+			n++
+		}
+	}
+	rec("", v, depth)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// diffFlat returns paths->newValue where current differs from prev (added or changed).
+func diffFlat(prev, cur map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range cur {
+		if pv, ok := prev[k]; !ok || pv != v {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// noisyKey filters out high-churn fields that add little debug value.
+func noisyKey(path string) bool {
+	if path == "" {
+		return false
+	}
+	p := path
+	if strings.HasPrefix(p, "metadata.") {
+		if strings.HasPrefix(p, "metadata.managedFields") ||
+			strings.HasPrefix(p, "metadata.resourceVersion") ||
+			strings.HasPrefix(p, "metadata.uid") ||
+			strings.HasPrefix(p, "metadata.creationTimestamp") {
+			return true
+		}
+	}
+	// timestamps and probe churn
+	if strings.Contains(p, "lastTransitionTime") || strings.Contains(p, "lastProbeTime") {
+		return true
+	}
+	// containerStatuses can be verbose; summarize by count
+	if strings.HasPrefix(p, "status.containerStatuses") {
+		return true
+	}
+	return false
+}
+
+// formatChanges renders key=value pairs compactly, limiting count.
+func formatChanges(m map[string]string, max int) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	show := keys
+	more := 0
+	if len(keys) > max {
+		show = keys[:max]
+		more = len(keys) - max
+	}
+	parts := make([]string, 0, len(show))
+	for _, k := range show {
+		v := m[k]
+		if len(v) > 100 {
+			v = v[:100] + "..."
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	}
+	suffix := " chg=" + strings.Join(parts, ",")
+	if more > 0 {
+		suffix += fmt.Sprintf(" (+%d)", more)
+	}
+	return suffix
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -24,7 +25,8 @@ import (
 )
 
 type Framework struct {
-	client *client.Client
+	client    *client.Client
+	testStart time.Time
 }
 
 func NewFrameWork(config *restclient.Config) *Framework {
@@ -32,6 +34,28 @@ func NewFrameWork(config *restclient.Config) *Framework {
 	kubeClient := clientset.NewForConfigOrDie(config)
 	return &Framework{
 		client: client.NewKubeClient(kruisegameClient, kubeClient),
+	}
+}
+
+// MarkTestStart records the approximate start time of the current test.
+func (f *Framework) MarkTestStart() { f.testStart = time.Now() }
+
+// DumpAuditIfFailed prints a trimmed audit log snippet for the test namespace when the test fails.
+func (f *Framework) DumpAuditIfFailed() {
+	const auditFile = "/tmp/kind-audit/audit.log"
+	if _, err := os.Stat(auditFile); err != nil {
+		return
+	}
+	// Primary: events since test start
+	limit := 400
+	snippet := FilterAuditLog(auditFile, f.testStart, client.Namespace, limit)
+	// Fallback: if nothing matched (e.g., clock skew, strict filters), show a shorter tail
+	if snippet == "" {
+		limit = 200
+		snippet = FilterAuditLog(auditFile, time.Time{}, client.Namespace, limit)
+	}
+	if snippet != "" {
+		fmt.Printf("\n===== AUDIT (last %d matching entries since %s) =====\n%s\n===== END AUDIT =====\n", limit, f.testStart.Format(time.RFC3339), snippet)
 	}
 }
 
@@ -184,7 +208,6 @@ func (f *Framework) PatchGameServerSpec(gsName string, specFields map[string]int
 	}
 	return f.client.PatchGameServer(gsName, data)
 }
-
 func (f *Framework) ImageUpdate(gss *gamekruiseiov1alpha1.GameServerSet, name, image string) (*gamekruiseiov1alpha1.GameServerSet, error) {
 	var newContainers []corev1.Container
 	for _, c := range gss.Spec.GameServerTemplate.Spec.Containers {
@@ -282,9 +305,105 @@ func (f *Framework) WaitForUpdated(gss *gamekruiseiov1alpha1.GameServerSet, name
 		})
 }
 
-func (f *Framework) ExpectGssCorrect(gss *gamekruiseiov1alpha1.GameServerSet, expectIndex []int) error {
+// WaitForGssCounts waits until both Pod and GameServer counts equal desired.
+func (f *Framework) WaitForGssCounts(gss *gamekruiseiov1alpha1.GameServerSet, desired int) error {
+	gssName := gss.GetName()
+	labelSelector := labels.SelectorFromSet(map[string]string{
+		gamekruiseiov1alpha1.GameServerOwnerGssKey: gssName,
+	}).String()
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true,
+		func(ctx context.Context) (done bool, err error) {
+			podList, err := f.client.GetPodList(labelSelector)
+			if err != nil {
+				return false, nil
+			}
+			if len(podList.Items) != desired {
+				return false, nil
+			}
+			gsList, err := f.client.GetGameServerList(labelSelector)
+			if err != nil {
+				return false, nil
+			}
+			if len(gsList.Items) != desired {
+				return false, nil
+			}
+			return true, nil
+		})
+}
 
-	if err := f.WaitForGsCreated(gss); err != nil {
+// WaitForGssObservedGeneration waits until status.observedGeneration catches up with metadata.generation.
+func (f *Framework) WaitForGssObservedGeneration() error {
+	return f.WaitForGss(func(g *gamekruiseiov1alpha1.GameServerSet) (bool, error) {
+		return g.Status.ObservedGeneration == g.Generation, nil
+	})
+}
+
+// WaitForReplicasConverge waits until gss.Spec.Replicas equals desired and
+// on timeout returns a detailed snapshot of last observed state to aid debugging.
+func (f *Framework) WaitForReplicasConverge(gss *gamekruiseiov1alpha1.GameServerSet, desired int) error {
+	gssName := gss.GetName()
+	labelSelector := labels.SelectorFromSet(map[string]string{
+		gamekruiseiov1alpha1.GameServerOwnerGssKey: gssName,
+	}).String()
+	var lastSpecReplicas int
+	var lastStatusReplicas int
+	var lastCurrentReplicas int
+	var lastPodCount, lastGsCount int
+	var lastPodOrdinals []int
+	err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true,
+		func(ctx context.Context) (done bool, err error) {
+			// Fetch latest GSS
+			g, err := f.client.GetGameServerSet()
+			if err != nil {
+				return false, nil
+			}
+			if g.Spec.Replicas != nil {
+				lastSpecReplicas = int(*g.Spec.Replicas)
+			}
+			lastStatusReplicas = int(g.Status.Replicas)
+			lastCurrentReplicas = int(g.Status.CurrentReplicas)
+			// Fetch Pods and GameServers for context
+			if podList, err := f.client.GetPodList(labelSelector); err == nil {
+				lastPodCount = len(podList.Items)
+				lastPodOrdinals = util.GetIndexListFromPodList(podList.Items)
+			}
+			if gsList, err := f.client.GetGameServerList(labelSelector); err == nil {
+				lastGsCount = len(gsList.Items)
+			}
+			return lastSpecReplicas == desired, nil
+		})
+	if err != nil {
+		return fmt.Errorf(
+			"WaitForReplicasConverge timeout: want=%d spec=%d status.replicas=%d status.current=%d pods=%d gs=%d ordinals=%v",
+			desired, lastSpecReplicas, lastStatusReplicas, lastCurrentReplicas, lastPodCount, lastGsCount, lastPodOrdinals,
+		)
+	}
+	return nil
+}
+
+// GetGameServerSet fetches the current GameServerSet from cluster.
+func (f *Framework) GetGameServerSet() (*gamekruiseiov1alpha1.GameServerSet, error) {
+	return f.client.GetGameServerSet()
+}
+
+// WaitForGssReplicas waits until .spec.replicas equals the desired value.
+// WaitForGss fetches GSS periodically and evaluates a predicate until it returns true.
+func (f *Framework) WaitForGss(predicate func(*gamekruiseiov1alpha1.GameServerSet) (bool, error)) error {
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true,
+		func(ctx context.Context) (done bool, err error) {
+			gss, err := f.client.GetGameServerSet()
+			if err != nil {
+				return false, err
+			}
+			return predicate(gss)
+		})
+}
+
+func (f *Framework) ExpectGssCorrect(gss *gamekruiseiov1alpha1.GameServerSet, expectIndex []int) error {
+	// First wait until the number of objects matches the expected replica count
+	// (avoids relying on spec.replicas which may be delayed).
+	desired := len(expectIndex)
+	if err := f.WaitForGssCounts(gss, desired); err != nil {
 		return err
 	}
 
@@ -293,17 +412,38 @@ func (f *Framework) ExpectGssCorrect(gss *gamekruiseiov1alpha1.GameServerSet, ex
 		gamekruiseiov1alpha1.GameServerOwnerGssKey: gssName,
 	}).String()
 
-	podList, err := f.client.GetPodList(labelSelector)
+	// capture last observed snapshot for better error messages
+	var lastPodIndexes []int
+	var lastPodCount, lastGsCount int
+
+	// Then poll only for whether the ordinals match (while ensuring the counts remain consistent).
+	err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true,
+		func(ctx context.Context) (done bool, err error) {
+			podList, err := f.client.GetPodList(labelSelector)
+			if err != nil {
+				return false, nil
+			}
+			lastPodCount = len(podList.Items)
+			lastPodIndexes = util.GetIndexListFromPodList(podList.Items)
+
+			gsList, err := f.client.GetGameServerList(labelSelector)
+			if err != nil {
+				return false, nil
+			}
+			lastGsCount = len(gsList.Items)
+
+			// ensure the counts still match the expected value
+			if lastPodCount != desired || lastGsCount != desired {
+				return false, nil
+			}
+			if util.IsSliceEqual(expectIndex, lastPodIndexes) {
+				return true, nil
+			}
+			return false, nil
+		})
 	if err != nil {
-		return err
+		return fmt.Errorf("ExpectGssCorrect timeout: desired=%d expectedOrdinals=%v lastPodOrdinals=%v lastPodCount=%d lastGsCount=%d", desired, expectIndex, lastPodIndexes, lastPodCount, lastGsCount)
 	}
-
-	podIndexList := util.GetIndexListFromPodList(podList.Items)
-
-	if !util.IsSliceEqual(expectIndex, podIndexList) {
-		return fmt.Errorf("current pods and expected pods do not correspond, actual podIndexList: %v", podIndexList)
-	}
-
 	return nil
 }
 
@@ -320,6 +460,61 @@ func (f *Framework) WaitForGsOpsStateUpdate(gsName string, opsState string) erro
 			}
 			return false, nil
 		})
+}
+
+// WaitForGsSpecOpsState waits until GameServer.spec.opsState reaches the desired value.
+func (f *Framework) WaitForGsSpecOpsState(gsName string, opsState string) error {
+	return wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true,
+		func(ctx context.Context) (done bool, err error) {
+			gs, err := f.client.GetGameServer(gsName)
+			if err != nil {
+				return false, err
+			}
+			if string(gs.Spec.OpsState) == opsState {
+				return true, nil
+			}
+			return false, nil
+		})
+}
+
+// WaitForPodOpsStateOrDeleted waits until the pod label opsState equals the target or the pod is deleted.
+func (f *Framework) WaitForPodOpsStateOrDeleted(gsName string, opsState string) error {
+	var lastPodOpsState, lastPodPhase, lastPodUID, lastGsSpecOps string
+	var lastPodErr, lastGsErr error
+	var lastDeletionTimestamp string
+	err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true,
+		func(ctx context.Context) (done bool, err error) {
+			if pod, err0 := f.client.GetPod(gsName); err0 == nil {
+				lastPodOpsState = pod.GetLabels()[gamekruiseiov1alpha1.GameServerOpsStateKey]
+				lastPodPhase = string(pod.Status.Phase)
+				lastPodUID = string(pod.UID)
+				if pod.DeletionTimestamp != nil {
+					lastDeletionTimestamp = pod.DeletionTimestamp.Time.Format(time.RFC3339)
+				} else {
+					lastDeletionTimestamp = "<nil>"
+				}
+				if lastPodOpsState == opsState {
+					return true, nil
+				}
+			} else {
+				if apierrors.IsNotFound(err0) {
+					return true, nil
+				}
+				lastPodErr = err0
+			}
+
+			if gs, err1 := f.client.GetGameServer(gsName); err1 == nil {
+				lastGsSpecOps = string(gs.Spec.OpsState)
+			} else {
+				lastGsErr = err1
+			}
+			return false, nil
+		})
+	if err != nil {
+		return fmt.Errorf("WaitForPodOpsStateOrDeleted timeout: wantOps=%s lastPodOps=%s lastPodPhase=%s lastPodUID=%s lastPodDeletionTs=%s lastGsSpecOps=%s podErr=%v gsErr=%v",
+			opsState, lastPodOpsState, lastPodPhase, lastPodUID, lastDeletionTimestamp, lastGsSpecOps, lastPodErr, lastGsErr)
+	}
+	return nil
 }
 
 func (f *Framework) WaitForGsDeletionPriorityUpdated(gsName string, deletionPriority string) error {

--- a/test/e2e/testcase/testcase.go
+++ b/test/e2e/testcase/testcase.go
@@ -7,15 +7,25 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	gameKruiseV1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/pkg/util"
 	"github.com/openkruise/kruise-game/test/e2e/client"
 	"github.com/openkruise/kruise-game/test/e2e/framework"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func RunTestCases(f *framework.Framework) {
 	ginkgo.Describe("kruise game controllers", func() {
 
+		ginkgo.BeforeEach(func() {
+			// Mark a per-test start timestamp for audit filtering
+			f.MarkTestStart()
+		})
+
 		ginkgo.AfterEach(func() {
+			if ginkgo.CurrentGinkgoTestDescription().Failed {
+				f.DumpAuditIfFailed()
+			}
 			err := f.AfterEach()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
@@ -30,7 +40,7 @@ func RunTestCases(f *framework.Framework) {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// scale up
-			gss, err = f.GameServerScale(gss, 5, nil)
+			_, err = f.GameServerScale(gss, 5, nil)
 			gomega.Expect(err).To(gomega.BeNil())
 
 			err = f.ExpectGssCorrect(gss, []int{0, 1, 2, 3, 4})
@@ -183,6 +193,139 @@ func RunTestCases(f *framework.Framework) {
 
 			err = f.ExpectGsCorrect(gss.GetName()+"-1", "None", "0", "0")
 			gomega.Expect(err).To(gomega.BeNil())
+		})
+
+		// Reserve-only equivalent replacement (requires Delete ReclaimPolicy for precise replacement)
+		ginkgo.It("reserve-only equal replacement", func() {
+			// 1. Deploy GSS (ReclaimPolicy=Delete) and scale to 5 replicas
+			gss, err := f.DeployGameServerSetWithReclaimPolicy(gameKruiseV1alpha1.DeleteGameServerReclaimPolicy)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			_, err = f.GameServerScale(gss, 5, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// 2. Only set reserve = "3-4"
+			_, err = f.PatchGssSpec(map[string]interface{}{
+				"reserveGameServerIds": []intstr.IntOrString{intstr.FromString("3-4")},
+			})
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+
+			// 3. Assert final set is {0,1,2,5,6}, replicas still 5
+			err = f.ExpectGssCorrect(gss, []int{0, 1, 2, 5, 6})
+			gomega.Expect(err).To(gomega.BeNil())
+		})
+
+		// Reserve+replicas change simultaneously (prioritize deleting reserve, requires Delete ReclaimPolicy)
+		ginkgo.It("reserve+replicas change prioritizes reserve deletions", func() {
+			// 1. Deploy to 5 replicas and set reserve=3-4 (preparation) with Delete ReclaimPolicy
+			gss, err := f.DeployGameServerSetWithReclaimPolicy(gameKruiseV1alpha1.DeleteGameServerReclaimPolicy)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			_, err = f.GameServerScale(gss, 5, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			_, err = f.PatchGssSpec(map[string]interface{}{
+				"reserveGameServerIds": []intstr.IntOrString{intstr.FromString("3-4")},
+			})
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+
+			// 2. Scale down to 3 and extend reserve to 3-6 simultaneously
+			gss, err = f.PatchGssSpec(map[string]interface{}{
+				"replicas":             3,
+				"reserveGameServerIds": []intstr.IntOrString{intstr.FromString("3-6")},
+			})
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+
+			// 3. Assert final set is {0,1,2}
+			err = f.ExpectGssCorrect(gss, []int{0, 1, 2})
+			gomega.Expect(err).To(gomega.BeNil())
+		})
+
+		// ReserveIds strategy backfill and reuse
+		ginkgo.It("reserveIds backfill and reuse on expansion", func() {
+			// 1. Deploy replicas=5 and set strategy to ReserveIds
+			gss, err := f.DeployGameServerSet()
+			gomega.Expect(err).To(gomega.BeNil())
+
+			_, err = f.GameServerScale(gss, 5, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			gss, err = f.PatchGssSpec(map[string]interface{}{
+				"scaleStrategy": map[string]interface{}{
+					"scaleDownStrategyType": "ReserveIds",
+				},
+			})
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+
+			// 2. Scale down to 3 and assert set {0,1,2}
+			gss, err = f.GameServerScale(gss, 3, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+			err = f.ExpectGssCorrect(gss, []int{0, 1, 2})
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// 3. Wait for controller to backfill reserve into GSS (both spec and annotation contain 3 and 4)
+			err = f.WaitForGss(func(g *gameKruiseV1alpha1.GameServerSet) (bool, error) {
+				rset := util.GetReserveOrdinalIntSet(g.Spec.ReserveGameServerIds)
+				if rset == nil || !(rset.Has(3) && rset.Has(4)) {
+					return false, nil
+				}
+				ann := g.GetAnnotations()[gameKruiseV1alpha1.GameServerSetReserveIdsKey]
+				aset := util.StringToOrdinalIntSet(ann, ",")
+				return aset.Has(3) && aset.Has(4), nil
+			})
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// 4. Remove 4 from reserve, scale to 4, assert new ordinal 4
+			gss, err = f.PatchGssSpec(map[string]interface{}{
+				"replicas":             4,
+				"reserveGameServerIds": []intstr.IntOrString{intstr.FromInt(3)},
+			})
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+			err = f.ExpectGssCorrect(gss, []int{0, 1, 2, 4})
+			gomega.Expect(err).To(gomega.BeNil())
+		})
+
+		// Kill triggers automatic scale-down
+		ginkgo.It("kill opsState triggers auto scale down and does not backfill reserve", func() {
+			// 1. Deploy replicas=3 to get 0..2
+			gss, err := f.DeployGameServerSet()
+			gomega.Expect(err).To(gomega.BeNil())
+			err = f.ExpectGssCorrect(gss, []int{0, 1, 2})
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// 2. Mark gss-1 as Kill (ensure spec is set) and wait for pod label to sync
+			_, err = f.MarkGameServerOpsState(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
+			gomega.Expect(err).To(gomega.BeNil())
+			err = f.WaitForGsSpecOpsState(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
+			gomega.Expect(err).To(gomega.BeNil())
+			err = f.WaitForGsOpsStateUpdate(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
+			gomega.Expect(err).To(gomega.BeNil())
+			err = f.WaitForPodOpsStateOrDeleted(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// 3. Wait for replicas to automatically become 2, and assert 1 is excluded
+			gomega.Expect(f.WaitForReplicasConverge(gss, 2)).To(gomega.BeNil())
+			cur, err := f.GetGameServerSet()
+			gomega.Expect(err).To(gomega.BeNil())
+			err = f.ExpectGssCorrect(cur, []int{0, 2})
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// 4. Scale back to 3, allow reusing 1 (implementation reuses 1)
+			cur, err = f.GameServerScale(cur, 3, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+			err = f.ExpectGssCorrect(cur, []int{0, 1, 2})
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// And do not backfill reserve (should not include 1)
+			cur, err = f.GetGameServerSet()
+			gomega.Expect(err).To(gomega.BeNil())
+			rset2 := util.GetReserveOrdinalIntSet(cur.Spec.ReserveGameServerIds)
+			gomega.Expect(rset2.Has(1)).To(gomega.BeFalse(), "id 1 should not be backfilled in reserve")
 		})
 	})
 }

--- a/test/e2e/testcase/testcase.go
+++ b/test/e2e/testcase/testcase.go
@@ -298,12 +298,10 @@ func RunTestCases(f *framework.Framework) {
 			err = f.ExpectGssCorrect(gss, []int{0, 1, 2})
 			gomega.Expect(err).To(gomega.BeNil())
 
-			// 2. Mark gss-1 as Kill (ensure spec is set) and wait for pod label to sync
+			// 2. Mark gss-1 as Kill and wait for spec update plus pod handling
 			_, err = f.MarkGameServerOpsState(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
 			gomega.Expect(err).To(gomega.BeNil())
 			err = f.WaitForGsSpecOpsState(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
-			gomega.Expect(err).To(gomega.BeNil())
-			err = f.WaitForGsOpsStateUpdate(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
 			gomega.Expect(err).To(gomega.BeNil())
 			err = f.WaitForPodOpsStateOrDeleted(client.GameServerSet+"-1", string(gameKruiseV1alpha1.Kill))
 			gomega.Expect(err).To(gomega.BeNil())

--- a/test/kind-conf.yaml
+++ b/test/kind-conf.yaml
@@ -2,6 +2,40 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    # Mount audit policy and audit log directory into the control-plane node
+    extraMounts:
+      # Host path where CI/local will place the policy file
+      - hostPath: /tmp/kind-audit/policy.yaml
+        containerPath: /etc/kubernetes/audit/policy.yaml
+        readOnly: true
+      # Host directory to collect audit logs written by kube-apiserver
+      - hostPath: /tmp/kind-audit
+        containerPath: /var/log/kubernetes/audit
+        readOnly: false
   - role: worker
   - role: worker
   - role: worker
+
+# Configure kube-apiserver with audit flags and volumes
+kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        audit-policy-file: /etc/kubernetes/audit/policy.yaml
+        audit-log-path: /var/log/kubernetes/audit/audit.log
+        audit-log-format: json
+        audit-log-maxage: "1"
+        audit-log-maxbackup: "1"
+        audit-log-maxsize: "100"
+      extraVolumes:
+        - name: audit-policy
+          hostPath: /etc/kubernetes/audit/policy.yaml
+          mountPath: /etc/kubernetes/audit/policy.yaml
+          pathType: File
+          readOnly: true
+        - name: audit-log
+          hostPath: /var/log/kubernetes/audit
+          mountPath: /var/log/kubernetes/audit
+          pathType: DirectoryOrCreate
+          readOnly: false


### PR DESCRIPTION
## Summary
- Fixes stale-cache overwriting of `spec.reserveGameServerIds` by only patching the spec when ScaleDownStrategyType is `ReserveIds`.
- Minimizes merge patches for both spec and annotation by skipping fields that haven’t changed.
- Preserves user-managed spec under General strategy and reduces unnecessary reconciliations/patches.
- Depends on https://github.com/openkruise/kruise-game/pull/285

## Problem
- Previously, `GameServerScale` always constructed a patch that included `spec.reserveGameServerIds` based on the controller’s cached object. If the cache was stale, this could clobber fresher user/external updates in API Server.
- Even when values did not change, the controller still emitted patches, increasing churn and risk of last-writer-wins behaviors during cache staleness windows.

## Changes
- Scope spec patching to `ReserveIds` strategy:
  - Only include `spec.reserveGameServerIds` in the patch for `ReserveIds` (controller-managed) strategy.
  - Keep General strategy spec user-managed; controller no longer writes `spec.reserveGameServerIds` in General.
- Minimal patching for spec and annotation in `GameServerScale`:
  - Compute the intended annotation `game.kruise.io/reserve-ids` and only include it in patch if it differs from the current object’s annotation.
  - For `ReserveIds` strategy, only include the spec field if the computed set actually changes.
  - If neither spec nor annotation needs an update, skip sending a patch altogether.
- No change to ASTS updates; controller still updates `asts.Spec.ReserveOrdinals`, replicas, and scale strategy as before.

## Behavior by strategy
- General:
  - Controller does not modify `spec.reserveGameServerIds`; it only keeps the annotation aligned with the spec (and only patches when different).
- ReserveIds:
  - Controller computes the latest reserve set and writes it to `spec.reserveGameServerIds` (only when different).
  - Annotation is kept in sync with the computed set.

## Why minimal patch
- Reduces “no-op” patches and the chance of overwriting newer values when informer cache lags.
- Ensures patches are only emitted when values truly change, improving idempotency and reducing API churn.

## Files
- Updated: `pkg/controllers/gameserverset/gameserverset_manager.go`

## Compatibility and risk
- No API/schema changes.
- Aligns implementation with documented semantics of General vs ReserveIds strategies.
- Addresses primary risk of stale-cache overwrites. For absolute prevention of stale writes in all edge cases, a stronger approach (conditional updates with `resourceVersion` or refetch-latest before patch) can be considered in a future change. Minimal patching is chosen here as a lightweight, low-risk improvement that covers most cases.

## Notes
- This PR includes the stale-overwrite fix and the minimal-patch enhancement together to both correct behavior and reduce churn.
