### PR TITLE
e2e: Wait for a specific GSS generation to eliminate a potential race

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -331,10 +331,16 @@ func (f *Framework) WaitForGssCounts(gss *gamekruiseiov1alpha1.GameServerSet, de
 		})
 }
 
-// WaitForGssObservedGeneration waits until status.observedGeneration catches up with metadata.generation.
-func (f *Framework) WaitForGssObservedGeneration() error {
+// WaitForGssObservedGeneration waits until status.observedGeneration reaches at least the targetGeneration.
+func (f *Framework) WaitForGssObservedGeneration(targetGeneration int64) error {
 	return f.WaitForGss(func(g *gamekruiseiov1alpha1.GameServerSet) (bool, error) {
-		return g.Status.ObservedGeneration == g.Generation, nil
+		if g.Generation < targetGeneration {
+			return false, nil
+		}
+		if g.Status.ObservedGeneration < targetGeneration {
+			return false, nil
+		}
+		return true, nil
 	})
 }
 

--- a/test/e2e/testcase/testcase.go
+++ b/test/e2e/testcase/testcase.go
@@ -205,11 +205,11 @@ func RunTestCases(f *framework.Framework) {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// 2. Only set reserve = "3-4"
-			_, err = f.PatchGssSpec(map[string]interface{}{
+			gss, err = f.PatchGssSpec(map[string]interface{}{
 				"reserveGameServerIds": []intstr.IntOrString{intstr.FromString("3-4")},
 			})
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration(gss.Generation)).To(gomega.BeNil())
 
 			// 3. Assert final set is {0,1,2,5,6}, replicas still 5
 			err = f.ExpectGssCorrect(gss, []int{0, 1, 2, 5, 6})
@@ -225,11 +225,11 @@ func RunTestCases(f *framework.Framework) {
 			_, err = f.GameServerScale(gss, 5, nil)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			_, err = f.PatchGssSpec(map[string]interface{}{
+			gss, err = f.PatchGssSpec(map[string]interface{}{
 				"reserveGameServerIds": []intstr.IntOrString{intstr.FromString("3-4")},
 			})
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration(gss.Generation)).To(gomega.BeNil())
 
 			// 2. Scale down to 3 and extend reserve to 3-6 simultaneously
 			gss, err = f.PatchGssSpec(map[string]interface{}{
@@ -237,7 +237,7 @@ func RunTestCases(f *framework.Framework) {
 				"reserveGameServerIds": []intstr.IntOrString{intstr.FromString("3-6")},
 			})
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration(gss.Generation)).To(gomega.BeNil())
 
 			// 3. Assert final set is {0,1,2}
 			err = f.ExpectGssCorrect(gss, []int{0, 1, 2})
@@ -259,7 +259,7 @@ func RunTestCases(f *framework.Framework) {
 				},
 			})
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration(gss.Generation)).To(gomega.BeNil())
 
 			// 2. Scale down to 3 and assert set {0,1,2}
 			gss, err = f.GameServerScale(gss, 3, nil)
@@ -285,7 +285,7 @@ func RunTestCases(f *framework.Framework) {
 				"reserveGameServerIds": []intstr.IntOrString{intstr.FromInt(3)},
 			})
 			gomega.Expect(err).To(gomega.BeNil())
-			gomega.Expect(f.WaitForGssObservedGeneration()).To(gomega.BeNil())
+			gomega.Expect(f.WaitForGssObservedGeneration(gss.Generation)).To(gomega.BeNil())
 			err = f.ExpectGssCorrect(gss, []int{0, 1, 2, 4})
 			gomega.Expect(err).To(gomega.BeNil())
 		})


### PR DESCRIPTION
## Summary
- Harden e2e wait logic to target the exact post-PATCH generation returned by the API server.
- Avoids the race where tests proceed after observing an older object where observedGeneration == generation, but the latest spec change hasn’t been observed by the controller yet.

## Background
- Old behavior: WaitForGssObservedGeneration() polled until status.observedGeneration == metadata.generation.
- Problem: If the first GET after PATCH reads an older object (or the PATCH is a no-op and does not bump generation), the condition already holds and the wait returns immediately. Tests may then assert on state that hasn’t reflected the latest change yet.

## Rationale
- PATCH returns the server’s latest representation (no informer cache involved). Using its Generation ensures we wait for exactly the change we just submitted.
- The waiter polls via direct GETs (also not cache-based), guaranteeing we compare against live API server state.

## Impact
- Scope: e2e framework and tests only; production controller code is unaffected.
- Signature change is internal to tests; all updated in this PR.