### PR TITLE
feat: add SecurityProtectionTypes support for Auto-NLBs-V2

### DIFF
--- a/cloudprovider/alibabacloud/auto_nlbs_v2.go
+++ b/cloudprovider/alibabacloud/auto_nlbs_v2.go
@@ -1230,12 +1230,13 @@ func (a *AutoNLBsV2Plugin) ensureEIPCR(ctx context.Context, c client.Client, nam
 			},
 		},
 		Spec: eipv1.EIPSpec{
-			Name:               eipName,
-			Bandwidth:          "5",                // 默认带宽 5Mbps，可以后续通过配置调整
-			InternetChargeType: internetChargeType, // 根据 ISP 类型选择计费方式
-			ISP:                eipIspType,         // 设置 ISP 线路类型（支持单线 EIP）
-			ReleaseStrategy:    "OnDelete",         // CR 删除时释放 EIP
-			Description:        fmt.Sprintf("EIP for GameServerSet %s, NLB index %d, zone %d", gssName, nlbIndex, zoneIndex),
+			Name:                    eipName,
+			Bandwidth:               "5",                // 默认带宽 5Mbps，可以后续通过配置调整
+			InternetChargeType:      internetChargeType, // 根据 ISP 类型选择计费方式
+			ISP:                     eipIspType,         // 设置 ISP 线路类型（支持单线 EIP）
+			ReleaseStrategy:         "OnDelete",         // CR 删除时释放 EIP
+			Description:             fmt.Sprintf("EIP for GameServerSet %s, NLB index %d, zone %d", gssName, nlbIndex, zoneIndex),
+			SecurityProtectionTypes: config.securityProtectionTypes, // 安全防护类型（高防护 EIP）
 		},
 	}
 

--- a/docs/中文/用户手册/网络模型.md
+++ b/docs/中文/用户手册/网络模型.md
@@ -843,6 +843,23 @@ EipIspTypes
 - 示例：`BGP,BGP_PRO` 或 `ChinaTelecom,ChinaMobile,ChinaUnicom`
 - 是否支持变更：否
 
+SecurityProtectionTypes
+
+- 含义：EIP 安全防护类型，支持 DDoS 高防护
+- 填写格式：`type1,type2,...`（多个类型用逗号分隔）
+- 可选值：
+  - `AntiDDoS_Enhanced`：DDoS 防护（增强版）- 提供 Tbps 级专业 DDoS 防护能力
+- 示例：`AntiDDoS_Enhanced`
+- 是否支持变更：否
+- 默认值：空（不启用防护）
+- 使用限制：
+  - 仅支持按量付费模式（`PostPaid`）
+  - 仅支持 BGP（多线）线路类型
+  - 不兼容单线 ISP 类型（ChinaTelecom/ChinaMobile/ChinaUnicom）
+  - 支持地域：华北2（北京）、华东1（杭州）、华东2（上海）、中国香港等
+  - 会产生额外的安全防护费用
+- 说明：目前仅支持 `AntiDDoS_Enhanced` 类型。如果配置了不兼容的 ISP 类型，EIP CR 创建将失败，错误信息由阿里云 API 返回
+
 MinPort
 
 - 含义：NLB 外部端口分配的最小值
@@ -1146,6 +1163,50 @@ spec:
         name: gameserver
 ```
 
+**示例 5：启用 DDoS 高防护（增强版）**
+
+```yaml
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  name: gs-ddos-protected
+  namespace: default
+spec:
+  replicas: 5
+  updateStrategy:
+    rollingUpdate:
+      podUpdatePolicy: InPlaceIfPossible
+  network:
+    networkType: AlibabaCloud-AutoNLBs-V2
+    networkConf:
+    - name: ZoneMaps
+      value: "vpc-xxx@cn-hangzhou-h:vsw-aaa,cn-hangzhou-i:vsw-bbb"
+    - name: PortProtocols
+      value: "8080/TCP,9000/UDP"
+    - name: EipIspTypes
+      value: "BGP"  # DDoS 高防护必须使用 BGP 线路
+    - name: SecurityProtectionTypes
+      value: "AntiDDoS_Enhanced"  # 启用 DDoS 防护（增强版）
+    - name: MinPort
+      value: "10000"
+    - name: MaxPort
+      value: "10999"
+    - name: LBHealthCheckFlag
+      value: "on"
+  gameServerTemplate:
+    spec:
+      containers:
+      - image: registry.cn-hangzhou.aliyuncs.com/gs-demo/gameserver:network
+        name: gameserver
+```
+
+> **DDoS 高防护重要说明：**
+> - 必须使用 BGP 线路类型（`EipIspTypes: BGP`），不兼容单线 ISP（ChinaTelecom/ChinaMobile/ChinaUnicom）
+> - 仅支持按量付费模式，不能使用包年包月
+> - 会产生额外的安全防护费用
+> - 查看 EIP CR 状态确认是否成功激活：`kubectl get eip -n default`
+> - 如果配置不兼容，EIP CR 创建将失败，错误信息由阿里云 API 返回
+
 #### 生成的 GameServer 网络状态
 
 > **注意**：Auto NLB V2 模式下，`externalAddresses` 中会填充：
@@ -1285,7 +1346,7 @@ kubectl get svc -l game.kruise.io/owner-gss=gs-auto-nlb-v2
    - **级联删除模式（`RetainNLBOnDelete=false`）**：删除 GSS 时会自动删除对应的 NLB 和 EIP 资源，无需手动清理
 
 2. **网络配置不可变**
-   - `ZoneMaps`、`PortProtocols`、`EipIspTypes` 等参数创建后不可修改
+   - `ZoneMaps`、`PortProtocols`、`EipIspTypes`、`SecurityProtectionTypes` 等参数创建后不可修改
    - 需要变更时，建议创建新的 GameServerSet 并迁移
 
 3. **单线 ISP 计费**


### PR DESCRIPTION
- Support DDoS protection (AntiDDoS_Enhanced)
- Add SecurityProtectionTypes configuration parameter
- Update documentation with examples and restrictions
- Add comprehensive test cases
- Compatible with existing configurations (backward compatible)

Changes:
- cloudprovider: Add SecurityProtectionTypes config parsing
- cloudprovider: Apply SecurityProtectionTypes to EIP CR creation
- docs: Add SecurityProtectionTypes parameter documentation (EN/CN)
- docs: Add DDoS protection usage example
- test: Add 4 test cases for SecurityProtectionTypes

Test coverage: 41.0% (alibabacloud package)