### PR TITLE
fix: capture Run() error in metrics controller goroutine

### DIFF
--- a/main.go
+++ b/main.go
@@ -278,8 +278,8 @@ func main() {
 	}
 	kruisegameInformerFactory.Start(signal.Done())
 	go func() {
-		if metricsController.Run(signal) != nil {
-			setupLog.Error(err, "unable to setup metrics controller")
+		if runErr := metricsController.Run(signal); runErr != nil {
+			setupLog.Error(runErr, "unable to setup metrics controller")
 			os.Exit(1)
 		}
 	}()


### PR DESCRIPTION
## What this PR does

Fixes a closure bug where the metrics controller goroutine logged the wrong error on failure.

## Problem

In `main.go` (lines 280-285), the goroutine that runs the metrics controller never captures the return value of `metricsController.Run()`. Instead, it references the outer `err` variable from the `metrics.NewController()` call:

```go
metricsController, err := metrics.NewController(kruisegameInformerFactory)
if err != nil {
    setupLog.Error(err, "unable to create metrics controller")
    os.Exit(1)
}
kruisegameInformerFactory.Start(signal.Done())
go func() {
    if metricsController.Run(signal) != nil {
        setupLog.Error(err, "unable to setup metrics controller")  // wrong err
        os.Exit(1)
    }
}()
```
Since NewController succeeded (otherwise we'd have exited), err is nil by the time the goroutine runs. So if Run() fails, the log prints a nil error — making the failure impossible to diagnose.

**Fix**
Capture the return value of Run() into its own variable:
``` go func() {
    if runErr := metricsController.Run(signal); runErr != nil {
        setupLog.Error(runErr, "unable to setup metrics controller")
        os.Exit(1)
    }
}()
```

fixes #325 