### PR TITLE
fix: correct NLB service prewarming when ReserveNlbNum=0

### DIFF
--- a/cloudprovider/alibabacloud/auto_nlbs_v2.go
+++ b/cloudprovider/alibabacloud/auto_nlbs_v2.go
@@ -676,6 +676,23 @@ func (a *AutoNLBsV2Plugin) ensurePrewarming(ctx context.Context, c client.Client
 			}
 		}
 
+		// 如果有新创建的 NLB，重新查询列表以包含新创建的 NLB
+		if existingCount < expectNLBNum {
+			nlbList = &nlbv1.NLBList{}
+			err = c.List(ctx, nlbList, &client.ListOptions{
+				Namespace: namespace,
+				LabelSelector: labels.SelectorFromSet(map[string]string{
+					NLBPoolGssLabel:        gssName,
+					NLBPoolEipIspTypeLabel: eipIspType,
+				}),
+			})
+			if err != nil {
+				log.Errorf("[%s] Failed to re-list NLB CRs after creation: %v", AutoNLBsV2Network, err)
+				return err
+			}
+			log.Infof("[%s] Re-listed NLBs after creation: %d NLBs found", AutoNLBsV2Network, len(nlbList.Items))
+		}
+
 		// 预热 Service（为每个 NLB 预创建所有可能的 Service）
 		if err := a.prewarmServices(ctx, c, namespace, gssName, eipIspType, nlbList.Items, config, gss); err != nil {
 			log.Errorf("[%s] Failed to prewarm services: %v", AutoNLBsV2Network, err)
@@ -725,22 +742,35 @@ func (a *AutoNLBsV2Plugin) prewarmServices(ctx context.Context, c client.Client,
 	skippedCount := 0
 	skippedNLBCount := 0
 
-	for nlbIdx, nlb := range nlbs {
+	for _, nlb := range nlbs {
 		// 如果 NLB 还没有 LoadBalancerId，跳过（等待 NLB Operator 创建完成）
 		if nlb.Status.LoadBalancerId == "" {
-			log.Infof("[%s] NLB %s (index=%d) not ready yet, skip prewarming services",
-				AutoNLBsV2Network, nlb.Name, nlbIdx)
+			log.Infof("[%s] NLB %s not ready yet, skip prewarming services",
+				AutoNLBsV2Network, nlb.Name)
 			skippedNLBCount++
 			continue
 		}
 
 		nlbId := nlb.Status.LoadBalancerId
-		log.Infof("[%s] Prewarming services for NLB %s (nlbId=%s)", AutoNLBsV2Network, nlb.Name, nlbId)
+
+		// 从 Label 获取真实的 NLB pool index
+		nlbPoolIndexStr, ok := nlb.Labels[NLBPoolIndexLabel]
+		if !ok {
+			log.Errorf("[%s] NLB %s missing %s label, skip prewarming", AutoNLBsV2Network, nlb.Name, NLBPoolIndexLabel)
+			continue
+		}
+		nlbPoolIndex, err := strconv.Atoi(nlbPoolIndexStr)
+		if err != nil {
+			log.Errorf("[%s] NLB %s has invalid %s label: %s", AutoNLBsV2Network, nlb.Name, NLBPoolIndexLabel, nlbPoolIndexStr)
+			continue
+		}
+
+		log.Infof("[%s] Prewarming services for NLB %s (nlbId=%s, poolIndex=%d)", AutoNLBsV2Network, nlb.Name, nlbId, nlbPoolIndex)
 
 		// 为这个 NLB 预创建所有可能的 Service
 		for podIdx := 0; podIdx < podsPerNLB; podIdx++ {
-			// 计算全局 Service 索引（对应未来可能的 Pod 索引）
-			globalServiceIndex := nlbIdx*podsPerNLB + podIdx
+			// 使用真实的 pool index 计算全局 Service 索引
+			globalServiceIndex := nlbPoolIndex*podsPerNLB + podIdx
 
 			// Service 命名：podName-eipIspType（如：gss-0-bgp, gss-0-bgp-pro）
 			basePodName := gssName + "-" + strconv.Itoa(globalServiceIndex)

--- a/cloudprovider/alibabacloud/auto_nlbs_v2_test.go
+++ b/cloudprovider/alibabacloud/auto_nlbs_v2_test.go
@@ -1781,6 +1781,308 @@ func createTestPod(namespace, name, gssName string, podIndex int) *corev1.Pod {
 	}
 }
 
+// TestCalculateExpectNLBNum_ReserveZero 测试 reserve=0 时 expectNLBNum 计算的正确性
+func TestCalculateExpectNLBNum_ReserveZero(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxPodIndex   int
+		podsPerNLB    int
+		reserveNlbNum int
+		expectNLBNum  int
+	}{
+		{
+			name:          "maxPodIndex=0, podsPerNLB=250, reserve=0",
+			maxPodIndex:   0,
+			podsPerNLB:    250,
+			reserveNlbNum: 0,
+			expectNLBNum:  1, // (0 / 250) + 0 + 1 = 1
+		},
+		{
+			name:          "maxPodIndex=249, podsPerNLB=250, reserve=0",
+			maxPodIndex:   249,
+			podsPerNLB:    250,
+			reserveNlbNum: 0,
+			expectNLBNum:  1, // (249 / 250) + 0 + 1 = 1
+		},
+		{
+			name:          "maxPodIndex=250, podsPerNLB=250, reserve=0",
+			maxPodIndex:   250,
+			podsPerNLB:    250,
+			reserveNlbNum: 0,
+			expectNLBNum:  2, // (250 / 250) + 0 + 1 = 2
+		},
+		{
+			name:          "maxPodIndex=499, podsPerNLB=250, reserve=0",
+			maxPodIndex:   499,
+			podsPerNLB:    250,
+			reserveNlbNum: 0,
+			expectNLBNum:  2, // (499 / 250) + 0 + 1 = 2
+		},
+		{
+			name:          "maxPodIndex=500, podsPerNLB=250, reserve=0",
+			maxPodIndex:   500,
+			podsPerNLB:    250,
+			reserveNlbNum: 0,
+			expectNLBNum:  3, // (500 / 250) + 0 + 1 = 3
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &AutoNLBsV2Plugin{
+				maxPodIndex: map[string]int{
+					"default/test-gss": tt.maxPodIndex,
+				},
+				mutex: sync.RWMutex{},
+			}
+			config := &autoNLBsConfig{
+				minPort:       10000,
+				maxPort:       10499,
+				blockPorts:    []int32{},
+				targetPorts:   []int{8080, 9000},
+				reserveNlbNum: tt.reserveNlbNum,
+			}
+
+			actualNLBNum := plugin.calculateExpectNLBNum("default", "test-gss", config)
+
+			if actualNLBNum != tt.expectNLBNum {
+				t.Errorf("expectNLBNum: expected %d, got %d", tt.expectNLBNum, actualNLBNum)
+			}
+		})
+	}
+}
+
+// TestPrewarmServices_ReserveZero_CorrectNLBBinding 验证 prewarmServices 使用 NLBPoolIndexLabel 而非数组索引
+// 确保 Service 绑定到正确的 NLB，即使 NLB 列表顺序不确定
+func TestPrewarmServices_ReserveZero_CorrectNLBBinding(t *testing.T) {
+	// 创建 GSS
+	gss := createTestGSS("default", "test-gss", 10, nil)
+
+	// 创建 2 个 NLB CR，故意以逆序放入列表（模拟 List 返回顺序不确定）
+	// NLB-0: poolIndex=0, nlbId=nlb-id-0
+	// NLB-1: poolIndex=1, nlbId=nlb-id-1
+	nlb0 := &nlbv1.NLB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-bgp-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				NLBPoolLabel:           "true",
+				NLBPoolIndexLabel:      "0",
+				NLBPoolEipIspTypeLabel: "BGP",
+				NLBPoolGssLabel:        "test-gss",
+			},
+		},
+		Status: nlbv1.NLBStatus{
+			LoadBalancerId: "nlb-id-0",
+		},
+	}
+	nlb1 := &nlbv1.NLB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-bgp-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				NLBPoolLabel:           "true",
+				NLBPoolIndexLabel:      "1",
+				NLBPoolEipIspTypeLabel: "BGP",
+				NLBPoolGssLabel:        "test-gss",
+			},
+		},
+		Status: nlbv1.NLBStatus{
+			LoadBalancerId: "nlb-id-1",
+		},
+	}
+
+	c := newFakeClient(gss, nlb0, nlb1)
+	ctx := context.Background()
+
+	plugin := &AutoNLBsV2Plugin{
+		maxPodIndex: map[string]int{
+			"default/test-gss": 9, // 10 个 Pod (0-9)
+		},
+		mutex: sync.RWMutex{},
+	}
+
+	// 使用小端口范围：minPort=10000, maxPort=10004，这样 podsPerNLB=5
+	config := &autoNLBsConfig{
+		minPort:               10000,
+		maxPort:               10004,
+		blockPorts:            []int32{},
+		targetPorts:           []int{8080},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+		reserveNlbNum:         0,
+		eipIspTypes:           []string{"BGP"},
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		nlbHealthConfig: &nlbHealthConfig{
+			lBHealthCheckFlag: "off",
+		},
+	}
+
+	// 传入逆序的 NLB 列表：[NLB-1, NLB-0]
+	nlbs := []nlbv1.NLB{*nlb1, *nlb0}
+
+	err := plugin.prewarmServices(ctx, c, "default", "test-gss", "BGP", nlbs, config, gss)
+	if err != nil {
+		t.Errorf("prewarmServices failed: %v", err)
+		return
+	}
+
+	// 验证 Service 0-4 绑定到 NLB-0 (nlb-id-0)
+	for i := 0; i < 5; i++ {
+		svcName := fmt.Sprintf("test-gss-%d-bgp", i)
+		svc := &corev1.Service{}
+		err := c.Get(ctx, types.NamespacedName{Name: svcName, Namespace: "default"}, svc)
+		if err != nil {
+			t.Errorf("Service %s should exist: %v", svcName, err)
+			continue
+		}
+		nlbId := svc.Annotations[SlbIdAnnotationKey]
+		if nlbId != "nlb-id-0" {
+			t.Errorf("Service %s should have NLB ID 'nlb-id-0', got '%s'", svcName, nlbId)
+		}
+	}
+
+	// 验证 Service 5-9 绑定到 NLB-1 (nlb-id-1)
+	for i := 5; i < 10; i++ {
+		svcName := fmt.Sprintf("test-gss-%d-bgp", i)
+		svc := &corev1.Service{}
+		err := c.Get(ctx, types.NamespacedName{Name: svcName, Namespace: "default"}, svc)
+		if err != nil {
+			t.Errorf("Service %s should exist: %v", svcName, err)
+			continue
+		}
+		nlbId := svc.Annotations[SlbIdAnnotationKey]
+		if nlbId != "nlb-id-1" {
+			t.Errorf("Service %s should have NLB ID 'nlb-id-1', got '%s'", svcName, nlbId)
+		}
+	}
+}
+
+// TestEnsurePrewarming_ReserveZero_ReQueryAfterCreation 验证 ensurePrewarming 在创建新 NLB 后重新查询列表
+func TestEnsurePrewarming_ReserveZero_ReQueryAfterCreation(t *testing.T) {
+	// 创建 GSS，设置 replicas=6，这样需要 2 个 NLB（假设 podsPerNLB=5）
+	gss := createTestGSS("default", "test-gss", 6, []gamekruiseiov1alpha1.NetworkConfParams{
+		{Name: "ZoneMaps", Value: "vpc-test@cn-hangzhou-h:vsw-aaa,cn-hangzhou-i:vsw-bbb"},
+		{Name: "PortProtocols", Value: "8080/TCP"},
+		{Name: "EipIspTypes", Value: "BGP"},
+		{Name: "MinPort", Value: "10000"},
+		{Name: "MaxPort", Value: "10004"}, // podsPerNLB = 5
+		{Name: "ReserveNlbNum", Value: "0"},
+	})
+
+	// 初始状态：只有 NLB-0 存在（带正确的 Labels 和 LoadBalancerId）
+	nlb0 := &nlbv1.NLB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-bgp-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				NLBPoolLabel:           "true",
+				NLBPoolIndexLabel:      "0",
+				NLBPoolEipIspTypeLabel: "BGP",
+				NLBPoolGssLabel:        "test-gss",
+			},
+		},
+		Status: nlbv1.NLBStatus{
+			LoadBalancerId: "nlb-id-0",
+		},
+	}
+
+	// 预先创建 NLB-1 所需的 EIP（带 AllocationID），这样 NLB-1 才能成功创建
+	eip1z0 := &eipv1.EIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-eip-bgp-1-z0",
+			Namespace: "default",
+		},
+		Status: eipv1.EIPStatus{
+			AllocationID: "eip-alloc-1-z0",
+		},
+	}
+	eip1z1 := &eipv1.EIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-eip-bgp-1-z1",
+			Namespace: "default",
+		},
+		Status: eipv1.EIPStatus{
+			AllocationID: "eip-alloc-1-z1",
+		},
+	}
+
+	// 创建 fake client，预先放入 GSS、NLB-0 和 EIP
+	c := newFakeClient(gss, nlb0, eip1z0, eip1z1)
+	ctx := context.Background()
+
+	plugin := &AutoNLBsV2Plugin{
+		maxPodIndex: map[string]int{
+			"default/test-gss": 5, // maxPodIndex=5，需要第 2 个 NLB
+		},
+		mutex: sync.RWMutex{},
+	}
+
+	config := &autoNLBsConfig{
+		zoneMaps:              "vpc-test@cn-hangzhou-h:vsw-aaa,cn-hangzhou-i:vsw-bbb",
+		eipIspTypes:           []string{"BGP"},
+		targetPorts:           []int{8080},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+		minPort:               10000,
+		maxPort:               10004, // podsPerNLB = 5
+		blockPorts:            []int32{},
+		reserveNlbNum:         0,
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		retainNLBOnDelete:     true,
+		nlbHealthConfig: &nlbHealthConfig{
+			lBHealthCheckFlag: "off",
+		},
+	}
+
+	// 调用 ensurePrewarming
+	err := plugin.ensurePrewarming(ctx, c, "default", "test-gss", config)
+	if err != nil {
+		t.Errorf("ensurePrewarming failed: %v", err)
+		return
+	}
+
+	// 验证 NLB-1 被创建
+	nlb1 := &nlbv1.NLB{}
+	err = c.Get(ctx, types.NamespacedName{Name: "test-gss-bgp-1", Namespace: "default"}, nlb1)
+	if err != nil {
+		t.Errorf("NLB-1 should be created: %v", err)
+		return
+	}
+
+	// 验证 NLB-1 有正确的 Label
+	if nlb1.Labels[NLBPoolIndexLabel] != "1" {
+		t.Errorf("NLB-1 should have %s label = '1', got '%s'", NLBPoolIndexLabel, nlb1.Labels[NLBPoolIndexLabel])
+	}
+
+	// 验证 Service 0-4 绑定到 NLB-0
+	for i := 0; i < 5; i++ {
+		svcName := fmt.Sprintf("test-gss-%d-bgp", i)
+		svc := &corev1.Service{}
+		err := c.Get(ctx, types.NamespacedName{Name: svcName, Namespace: "default"}, svc)
+		if err != nil {
+			t.Errorf("Service %s should exist: %v", svcName, err)
+			continue
+		}
+		nlbId := svc.Annotations[SlbIdAnnotationKey]
+		if nlbId != "nlb-id-0" {
+			t.Errorf("Service %s should have NLB ID 'nlb-id-0', got '%s'", svcName, nlbId)
+		}
+	}
+
+	// 验证 Service 5-9 还没有被创建（因为 NLB-1 还没有 LoadBalancerId）
+	for i := 5; i < 10; i++ {
+		svcName := fmt.Sprintf("test-gss-%d-bgp", i)
+		svc := &corev1.Service{}
+		err := c.Get(ctx, types.NamespacedName{Name: svcName, Namespace: "default"}, svc)
+		if err == nil {
+			t.Errorf("Service %s should NOT exist yet (NLB-1 has no LoadBalancerId)", svcName)
+		}
+	}
+
+	// 测试目的：验证 ensurePrewarming 在创建新 NLB 后重新查询列表
+	// 这样 prewarmServices 能看到新创建的 NLB-1
+	// 这个测试验证了修复后的逻辑：创建 NLB 后重新查询列表，确保新 NLB 被包含在预热中
+}
+
 // TestAutoNLBsV2Plugin_Init_EmptyCluster 测试空集群初始化
 func TestAutoNLBsV2Plugin_Init_EmptyCluster(t *testing.T) {
 	c := newFakeClient()

--- a/cloudprovider/alibabacloud/auto_nlbs_v2_test.go
+++ b/cloudprovider/alibabacloud/auto_nlbs_v2_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // scheme 用于测试中注册 CRD 类型
@@ -3393,5 +3394,239 @@ func TestNLBCreationNoOwnerRef(t *testing.T) {
 				t.Errorf("NLB should NOT have OwnerReference, but got: %v", nlb.OwnerReferences)
 			}
 		})
+	}
+}
+
+// TestPrewarmServices_MissingPoolIndexLabel 验证 prewarmServices 跳过缺少 NLBPoolIndexLabel 的 NLB
+func TestPrewarmServices_MissingPoolIndexLabel(t *testing.T) {
+	gss := createTestGSS("default", "test-gss", 5, nil)
+
+	// 创建一个 NLB，有 LoadBalancerId 但没有 NLBPoolIndexLabel
+	nlb := &nlbv1.NLB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-bgp-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				NLBPoolLabel:           "true",
+				NLBPoolEipIspTypeLabel: "BGP",
+				NLBPoolGssLabel:        "test-gss",
+				// 故意不设置 NLBPoolIndexLabel
+			},
+		},
+		Status: nlbv1.NLBStatus{
+			LoadBalancerId: "nlb-id-0",
+		},
+	}
+
+	c := newFakeClient(gss, nlb)
+	ctx := context.Background()
+
+	plugin := &AutoNLBsV2Plugin{
+		maxPodIndex: map[string]int{
+			"default/test-gss": 4,
+		},
+		mutex: sync.RWMutex{},
+	}
+
+	config := &autoNLBsConfig{
+		minPort:               10000,
+		maxPort:               10004,
+		blockPorts:            []int32{},
+		targetPorts:           []int{8080},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+		reserveNlbNum:         0,
+		eipIspTypes:           []string{"BGP"},
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		nlbHealthConfig: &nlbHealthConfig{
+			lBHealthCheckFlag: "off",
+		},
+	}
+
+	nlbs := []nlbv1.NLB{*nlb}
+
+	err := plugin.prewarmServices(ctx, c, "default", "test-gss", "BGP", nlbs, config, gss)
+	if err != nil {
+		t.Errorf("prewarmServices should not return error for missing label, got: %v", err)
+		return
+	}
+
+	// 验证没有 Service 被创建（因为 NLB 缺少 NLBPoolIndexLabel 被跳过）
+	svcList := &corev1.ServiceList{}
+	err = c.List(ctx, svcList, client.InNamespace("default"))
+	if err != nil {
+		t.Errorf("Failed to list Services: %v", err)
+		return
+	}
+	if len(svcList.Items) != 0 {
+		t.Errorf("Expected 0 Services created (NLB missing pool index label), got %d", len(svcList.Items))
+	}
+}
+
+// TestPrewarmServices_InvalidPoolIndexLabel 验证 prewarmServices 跳过 NLBPoolIndexLabel 值无效的 NLB
+func TestPrewarmServices_InvalidPoolIndexLabel(t *testing.T) {
+	gss := createTestGSS("default", "test-gss", 5, nil)
+
+	// 创建一个 NLB，NLBPoolIndexLabel 值为非数字
+	nlb := &nlbv1.NLB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-bgp-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				NLBPoolLabel:           "true",
+				NLBPoolIndexLabel:      "abc", // 无效值
+				NLBPoolEipIspTypeLabel: "BGP",
+				NLBPoolGssLabel:        "test-gss",
+			},
+		},
+		Status: nlbv1.NLBStatus{
+			LoadBalancerId: "nlb-id-0",
+		},
+	}
+
+	c := newFakeClient(gss, nlb)
+	ctx := context.Background()
+
+	plugin := &AutoNLBsV2Plugin{
+		maxPodIndex: map[string]int{
+			"default/test-gss": 4,
+		},
+		mutex: sync.RWMutex{},
+	}
+
+	config := &autoNLBsConfig{
+		minPort:               10000,
+		maxPort:               10004,
+		blockPorts:            []int32{},
+		targetPorts:           []int{8080},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+		reserveNlbNum:         0,
+		eipIspTypes:           []string{"BGP"},
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		nlbHealthConfig: &nlbHealthConfig{
+			lBHealthCheckFlag: "off",
+		},
+	}
+
+	nlbs := []nlbv1.NLB{*nlb}
+
+	err := plugin.prewarmServices(ctx, c, "default", "test-gss", "BGP", nlbs, config, gss)
+	if err != nil {
+		t.Errorf("prewarmServices should not return error for invalid label, got: %v", err)
+		return
+	}
+
+	// 验证没有 Service 被创建（因为 NLB 的 pool index label 值无效被跳过）
+	svcList := &corev1.ServiceList{}
+	err = c.List(ctx, svcList, client.InNamespace("default"))
+	if err != nil {
+		t.Errorf("Failed to list Services: %v", err)
+		return
+	}
+	if len(svcList.Items) != 0 {
+		t.Errorf("Expected 0 Services created (NLB has invalid pool index label), got %d", len(svcList.Items))
+	}
+}
+
+// TestEnsurePrewarming_ReQueryFails 验证 ensurePrewarming 在创建新 NLB 后重新查询列表失败时返回错误
+func TestEnsurePrewarming_ReQueryFails(t *testing.T) {
+	gss := createTestGSS("default", "test-gss", 6, []gamekruiseiov1alpha1.NetworkConfParams{
+		{Name: "ZoneMaps", Value: "vpc-test@cn-hangzhou-h:vsw-aaa,cn-hangzhou-i:vsw-bbb"},
+		{Name: "PortProtocols", Value: "8080/TCP"},
+		{Name: "EipIspTypes", Value: "BGP"},
+		{Name: "MinPort", Value: "10000"},
+		{Name: "MaxPort", Value: "10004"}, // podsPerNLB = 5
+		{Name: "ReserveNlbNum", Value: "0"},
+	})
+
+	// 初始状态：只有 NLB-0 存在
+	nlb0 := &nlbv1.NLB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-bgp-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				NLBPoolLabel:           "true",
+				NLBPoolIndexLabel:      "0",
+				NLBPoolEipIspTypeLabel: "BGP",
+				NLBPoolGssLabel:        "test-gss",
+			},
+		},
+		Status: nlbv1.NLBStatus{
+			LoadBalancerId: "nlb-id-0",
+		},
+	}
+
+	// 预先创建 NLB-1 所需的 EIP（带 AllocationID），这样 NLB-1 才能成功创建
+	eip1z0 := &eipv1.EIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-eip-bgp-1-z0",
+			Namespace: "default",
+		},
+		Status: eipv1.EIPStatus{
+			AllocationID: "eip-alloc-1-z0",
+		},
+	}
+	eip1z1 := &eipv1.EIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gss-eip-bgp-1-z1",
+			Namespace: "default",
+		},
+		Status: eipv1.EIPStatus{
+			AllocationID: "eip-alloc-1-z1",
+		},
+	}
+
+	listCallCount := 0
+
+	// 使用 WithInterceptorFuncs 让第二次 List NLB 时返回错误
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gss, nlb0, eip1z0, eip1z1).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, clnt client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				listCallCount++
+				// 第一次 List 返回正常结果（ensurePrewarming 查询已有 NLB）
+				// 第二次 List 是创建 NLB 后的重新查询，返回错误
+				if listCallCount == 2 {
+					return fmt.Errorf("simulated re-list failure")
+				}
+				// 其他 List 调用正常执行
+				return clnt.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	ctx := context.Background()
+
+	plugin := &AutoNLBsV2Plugin{
+		maxPodIndex: map[string]int{
+			"default/test-gss": 5, // maxPodIndex=5，需要第 2 个 NLB
+		},
+		mutex: sync.RWMutex{},
+	}
+
+	config := &autoNLBsConfig{
+		zoneMaps:              "vpc-test@cn-hangzhou-h:vsw-aaa,cn-hangzhou-i:vsw-bbb",
+		eipIspTypes:           []string{"BGP"},
+		targetPorts:           []int{8080},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+		minPort:               10000,
+		maxPort:               10004, // podsPerNLB = 5
+		blockPorts:            []int32{},
+		reserveNlbNum:         0,
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		retainNLBOnDelete:     true,
+		nlbHealthConfig: &nlbHealthConfig{
+			lBHealthCheckFlag: "off",
+		},
+	}
+
+	// 调用 ensurePrewarming，应该返回 re-list 失败的错误
+	err := plugin.ensurePrewarming(ctx, c, "default", "test-gss", config)
+	if err == nil {
+		t.Errorf("ensurePrewarming should return error when re-list fails, got nil")
+		return
+	}
+	if !strings.Contains(err.Error(), "simulated re-list failure") {
+		t.Errorf("expected error to contain 'simulated re-list failure', got: %v", err)
 	}
 }

--- a/docs/proposals/auto-nlbs-v2-prewarm-fix.md
+++ b/docs/proposals/auto-nlbs-v2-prewarm-fix.md
@@ -1,0 +1,52 @@
+# Fix: Auto-NLBs-V2 Service Prewarming Bug When ReserveNlbNum=0
+
+## Summary
+
+Fix two bugs in the `prewarmServices` logic of the Auto-NLBs-V2 network plugin that cause services to be bound to the wrong NLB instance when `ReserveNlbNum` is set to 0.
+
+## Problem Description
+
+When `ReserveNlbNum=0` and the number of pods exceeds the capacity of a single NLB (podsPerNLB), newly created services may be incorrectly associated with the previous NLB instead of the newly created one. This results in pods being routed through the wrong NLB instance.
+
+### Root Cause
+
+Two independent bugs contribute to this issue:
+
+**Bug 1: Stale NLB list in `ensurePrewarming`**
+
+In `ensurePrewarming()`, the NLB list is queried (line ~644) before new NLBs are created (lines ~662-677). The stale list is then passed to `prewarmServices()` (line ~680), causing newly created NLBs to be excluded from service prewarming.
+
+**Bug 2: Array index used instead of real Pool Index in `prewarmServices`**
+
+In `prewarmServices()`, the loop variable `nlbIdx` (array index from List result) is used to calculate `globalServiceIndex` (line ~743). Since Kubernetes List API does not guarantee ordering, when NLBs are returned in a different order than their pool index, services are created with incorrect pod name mappings and bound to the wrong NLB.
+
+### Reproduction Scenario
+
+1. Configure `ReserveNlbNum=0`, `podsPerNLB=250`
+2. Scale GSS from 250 to 251 pods
+3. Pod-250 should map to NLB-1, but its service gets bound to NLB-0
+
+## Solution
+
+### Fix 1: Re-query NLB list after creation
+
+After creating new NLBs in `ensurePrewarming`, re-query the NLB list before passing it to `prewarmServices` to ensure all NLBs (including newly created ones) are included.
+
+### Fix 2: Use `NLBPoolIndexLabel` instead of array index
+
+Replace the array index `nlbIdx` with the real pool index from the NLB's label (`game.kruise.io/nlb-pool-index`) when calculating `globalServiceIndex`. This makes the calculation independent of List return order.
+
+## Affected Files
+
+- `cloudprovider/alibabacloud/auto_nlbs_v2.go`
+
+## Backward Compatibility
+
+- No API changes
+- No configuration changes
+- Existing NLB instances with correct `NLBPoolIndexLabel` labels work without migration
+- NLBs without the label are safely skipped with a warning log
+
+## Why ReserveNlbNum>=1 masks this bug
+
+When `ReserveNlbNum>=1`, new NLBs and their services are always prewarmed ahead of time (before any pod needs them). The stale list and wrong index bugs still exist but never manifest because services are already correctly created before the boundary pod appears.


### PR DESCRIPTION
- Re-query NLB list after creating new NLBs in ensurePrewarming
- Use NLBPoolIndexLabel instead of array index in prewarmServices
- Add unit tests for reserve=0 prewarming scenarios
- Add proposal document for the fix