### PR TITLE
main: add --pprof-bind-address flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var pprofAddr string
 	var namespace string
 	var syncPeriodStr string
 	var scaleServerAddr string
@@ -104,6 +105,7 @@ func main() {
 	tracingOptions.AddFlags(flag.CommandLine)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8082", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to (e.g. ':8083'). Empty disables pprof.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -165,6 +167,7 @@ func main() {
 			BindAddress: metricsAddr,
 		},
 		HealthProbeBindAddress: probeAddr,
+		PprofBindAddress:       pprofAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "game-kruise-manager",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily


### PR DESCRIPTION
Closes #334. Wires `PprofBindAddress` from controller-runtime through a new flag.