### PR TITLE
feat(googlecloud): add Passthrough NLB + Global Proxy NLB network plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ log_debug
 
 # Local issue tracking
 问题/
+
+# controller-gen emits a degenerate empty-group CRD (_.yaml) for the hand-written
+# external Config Connector bindings under cloudprovider/googlecloud/apis; it is
+# never shipped (config/crd/kustomization.yaml lists resources explicitly).
+config/crd/bases/_.yaml

--- a/cloudprovider/config.go
+++ b/cloudprovider/config.go
@@ -50,6 +50,7 @@ type CloudProviderConfig struct {
 	TencentCloudOptions       CloudProviderOptions
 	JdCloudOptions            CloudProviderOptions
 	HwCloudOptions            CloudProviderOptions
+	GoogleCloudOptions        CloudProviderOptions
 }
 
 type tomlConfigs struct {
@@ -60,6 +61,7 @@ type tomlConfigs struct {
 	TencentCloud       options.TencentCloudOptions       `toml:"tencentcloud"`
 	JdCloud            options.JdCloudOptions            `toml:"jdcloud"`
 	HwCloud            options.HwCloudOptions            `toml:"hwcloud"`
+	GoogleCloud        options.GoogleCloudOptions        `toml:"googlecloud"`
 }
 
 func (cf *ConfigFile) Parse() *CloudProviderConfig {
@@ -76,6 +78,7 @@ func (cf *ConfigFile) Parse() *CloudProviderConfig {
 		TencentCloudOptions:       config.TencentCloud,
 		JdCloudOptions:            config.JdCloud,
 		HwCloudOptions:            config.HwCloud,
+		GoogleCloudOptions:        config.GoogleCloud,
 	}
 }
 

--- a/cloudprovider/googlecloud/README.md
+++ b/cloudprovider/googlecloud/README.md
@@ -1,0 +1,136 @@
+# Google Cloud Network Plugins for OpenKruiseGame
+
+This provider exposes two network plugins that publish game-server pods on
+Google Cloud, chosen via the `spec.network.networkType` field on a
+`GameServerSet`:
+
+| Plugin | Best for | Protocols | Topology | Notes |
+|---|---|---|---|---|
+| `GoogleCloud-PassthroughNLB` | UDP-heavy real-time games (FPS, MOBA, action) and TCP workloads that want absolute lowest latency + native client IP | TCP, UDP, mixed | Regional (External or Internal), per-pod static IP | Backed by GKE container-native L4 RBS + a KCC `ComputeAddress` for the shared static VIP |
+| `GoogleCloud-GlobalProxyNLB` | TCP-only games with globally distributed players (MMO, SLG, card, casual) needing anycast + cross-region failover + Cloud Armor | TCP | Global anycast IP, GFE-backed | Authors the full KCC L4 proxy stack (ForwardingRule → TargetTcpProxy → BackendService → HealthCheck) plus a per-pod Firewall |
+
+## When to pick which
+
+| Your game | Recommended plugin |
+|---|---|
+| TCP, players globally distributed | `GoogleCloud-GlobalProxyNLB` |
+| TCP, esports / lowest possible latency | `GoogleCloud-PassthroughNLB` |
+| TCP, needs TLS offload or Cloud Armor | `GoogleCloud-GlobalProxyNLB` |
+| UDP (any scenario) | `GoogleCloud-PassthroughNLB` |
+| TCP + UDP mixed (KCP, QUIC, custom) | `GoogleCloud-PassthroughNLB` |
+| Needs real client IP, no app changes | `GoogleCloud-PassthroughNLB` |
+
+## Prerequisites (one-time, cluster-admin)
+
+1. **VPC-native GKE cluster** (alias IPs). Autopilot is VPC-native by default.
+2. **Config Connector (KCC) add-on** enabled and healthy:
+   ```bash
+   gcloud container clusters update <CLUSTER> --update-addons=ConfigConnector=ENABLED --region <REGION>
+   kubectl wait --for=condition=Available deploy -n cnrm-system --all --timeout=300s
+   ```
+3. **Workload Identity** for the `cnrm-system` ServiceAccount bound to a GCP IAM
+   service account holding `roles/compute.networkAdmin` (or a custom role
+   covering forwardingRules / targetTcpProxies / backendServices / healthChecks
+   / networkEndpointGroups / addresses / firewalls).
+4. **GCP quotas** raised proportionally to expected scale. Each game-server pod
+   consumes one `ForwardingRule`, one `BackendService`, one `HealthCheck`, one
+   `Address`, one NEG per zone, and (Global Proxy NLB only) one `TargetTcpProxy`
+   + one `Firewall`.
+
+If KCC CRDs are not installed when the plugin starts, the plugin refuses to
+register and logs the precise `gcloud` command to remediate.
+
+## Operator configuration (`/etc/kruise-game/config.toml`)
+
+```toml
+[googlecloud]
+enable = true
+project_id = "my-game-project"
+default_region = "us-central1"
+default_network = "default"
+default_subnetwork = "default-us-central1"
+
+[googlecloud.passthrough_nlb]
+enable = true
+retain_on_delete_default = false
+network_tier = "PREMIUM"
+
+[googlecloud.global_proxy_nlb]
+enable = true
+retain_on_delete_default = false
+firewall_network_ref = "default"
+```
+
+## `NetworkConf` keys
+
+### `GoogleCloud-PassthroughNLB`
+
+| Key | Required | Default | Notes |
+|---|---|---|---|
+| `PortProtocols` | yes | — | `7777/UDP,8000/TCP` — up to 5 entries per pod |
+| `Scheme` | no | `External` | `External` or `Internal` |
+| `Region` | yes (or via TOML) | TOML `default_region` | GCP region (e.g. `us-central1`) |
+| `Network` | only `Scheme=Internal` | TOML `default_network` | VPC network name |
+| `Subnetwork` | only `Scheme=Internal` | TOML `default_subnetwork` | Subnet name |
+| `AllowGlobalAccess` | no | `false` | Internal LB only |
+| `NetworkTier` | no | `PREMIUM` | `PREMIUM` or `STANDARD` |
+| `ProjectId` | no | TOML `project_id` | Per-GameServerSet project override |
+| `Annotations` | no | — | `k1=v1,k2=v2`, passed through to the Service |
+| `RetainOnDelete` | no | `false` | `true` keeps the Address + Service across pod restarts |
+
+### `GoogleCloud-GlobalProxyNLB`
+
+| Key | Required | Default | Notes |
+|---|---|---|---|
+| `Port` | yes | — | Single TCP port 1-65535 |
+| `ProxyHeader` | no | `NONE` | `NONE` or `PROXY_V1` (game must parse PROXY v1 line) |
+| `BalancingMode` | no | `CONNECTION` | `CONNECTION`, `RATE`, `UTILIZATION` |
+| `MaxConnectionsPerEndpoint` | no | `1000` | |
+| `HealthCheckIntervalSec` | no | `5` | |
+| `HealthCheckTimeoutSec` | no | `5` | Must be ≤ `HealthCheckIntervalSec` |
+| `HealthyThreshold` | no | `2` | |
+| `UnhealthyThreshold` | no | `2` | |
+| `Network` | no | TOML `firewall_network_ref` (then `default_network`) | VPC for the per-pod firewall |
+| `ProjectId` | no | TOML `project_id` | |
+| `Annotations` | no | — | Service annotations |
+| `RetainOnDelete` | no | `false` | |
+
+## Resources created per pod
+
+### Passthrough NLB
+
+```
+ComputeAddress  (per-pod static external/internal IP, KCC)
+        ↑
+Service (type=LoadBalancer, cloud.google.com/l4-rbs="enabled",
+         networking.gke.io/load-balancer-ip-addresses=<addr name>)
+        ↓ owned by GKE LB controller
+ForwardingRule + BackendService + HealthCheck (in GCP project, not in K8s)
+```
+
+### Global Proxy NLB
+
+```
+Service (type=ClusterIP, cloud.google.com/neg='{"exposed_ports":{...}}')
+   ↓ owned by GKE NEG controller
+ComputeNetworkEndpointGroup × N zones (Pod IP endpoints, automatic)
+
+ComputeHealthCheck (global, TCP, USE_SERVING_PORT)
+ComputeBackendService (global, EXTERNAL_MANAGED, TCP, NEG backends)
+ComputeTargetTCPProxy (proxyHeader)
+ComputeAddress (global, EXTERNAL, PREMIUM, IPV4)
+ComputeForwardingRule (global, EXTERNAL_MANAGED, one TCP port, target+address refs)
+ComputeFirewall (allow 35.191.0.0/16 + 130.211.0.0/22 → backend port)
+```
+
+## Limitations
+
+- **Global Proxy NLB is TCP-only**; UDP must use the Passthrough plugin.
+- **Global Proxy NLB has no Shared VPC support**; pods in a Shared VPC service
+  project must use Passthrough.
+- **Per-pod resource fan-out**: each pod gets its own forwarding rule + backend
+  service. At thousands of pods you will hit per-region quotas before you hit
+  cluster limits — request quota increases ahead of time.
+- **PROXY-protocol awareness**: with `ProxyHeader=PROXY_V1` the game-server
+  binary must parse and strip the PROXY v1 line, or the first packet will look
+  like garbage application data.

--- a/cloudprovider/googlecloud/README.md
+++ b/cloudprovider/googlecloud/README.md
@@ -123,6 +123,57 @@ ComputeForwardingRule (global, EXTERNAL_MANAGED, one TCP port, target+address re
 ComputeFirewall (allow 35.191.0.0/16 + 130.211.0.0/22 → backend port)
 ```
 
+## IP stability across Pod recreate
+
+The GCP resources for a replica are keyed on the owning **GameServerSet UID +
+replica ordinal**, not the Pod UID. A Pod that is deleted and recreated at the
+same ordinal (rolling update, eviction, manual `kubectl delete pod`, node drain)
+re-adopts the identical `ComputeAddress`, so:
+
+- the external/anycast IP does **not** change, and
+- the load balancer is **not** rebuilt (no multi-minute GCP propagation).
+
+Resources are released only on a genuine **scale-down** (the ordinal moves out
+of `spec.replicas` range) or **GameServerSet deletion**. The Passthrough Service
+and KCC CRs are owner-referenced to the GameServerSet (so Kubernetes GC reaps
+them when the GSS is deleted); the per-replica scale-down case is handled
+explicitly in the plugin's `OnPodDeleted`.
+
+With `RetainOnDelete=true` the owner reference is dropped entirely, so the
+reserved IP and load balancer survive even GameServerSet deletion (you then
+manage their lifecycle yourself).
+
+## Disabling a single GameServer's network
+
+To drain external traffic from one replica without deleting it, set
+`spec.networkDisabled: true` on the **GameServer** object (not a Pod label — the
+GameServer controller continuously reconciles the Pod label from the GameServer
+spec, so a direct Pod-label edit is reverted):
+
+```bash
+kubectl patch gameserver <gs-name> --type=merge -p '{"spec":{"networkDisabled":true}}'
+```
+
+The plugin flips the Service to `ClusterIP` (tearing down the LB) while keeping
+the reserved IP; set it back to `false` to re-attach the LB to the same IP.
+
+## Health-check latency tuning (GlobalProxyNLB)
+
+Backend health-check timing is exposed via `NetworkConf`. Defaults
+(`HealthCheckIntervalSec=5`, `UnhealthyThreshold=2`) detect a dead backend in
+~30-40s including GFE state propagation. For faster failure detection:
+
+```yaml
+networkConf:
+- {name: HealthCheckIntervalSec, value: "2"}
+- {name: HealthCheckTimeoutSec, value: "2"}
+- {name: UnhealthyThreshold, value: "1"}
+- {name: HealthyThreshold, value: "1"}
+```
+
+This brings detection down to ~15s. GCP's minimum check interval is 1s, but
+global GFE propagation sets a practical floor around 10-15s.
+
 ## Limitations
 
 - **Global Proxy NLB is TCP-only**; UDP must use the Passthrough plugin.

--- a/cloudprovider/googlecloud/address.go
+++ b/cloudprovider/googlecloud/address.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+// AddressSpec captures the per-pod parameters used to build a KCC ComputeAddress.
+type AddressSpec struct {
+	// Name is the Kubernetes metadata.name (also defaults the GCP resourceID).
+	Name string
+	// Namespace places the CR.
+	Namespace string
+	// Location is "global" or a region (e.g. "us-central1").
+	Location string
+	// AddressType is "EXTERNAL" (default) or "INTERNAL".
+	AddressType string
+	// NetworkTier is "PREMIUM" (default) or "STANDARD". Ignored for INTERNAL.
+	NetworkTier string
+	// ProjectID, when non-empty, is written as the project-id annotation.
+	ProjectID string
+	// NetworkRef is required for INTERNAL addresses.
+	NetworkRef string
+	// SubnetworkRef is required for INTERNAL addresses.
+	SubnetworkRef string
+	// ResourceID overrides the GCP-side name; defaults to Name.
+	ResourceID string
+	// OwnerRefs cascade-delete the address when the owning K8s object goes away.
+	OwnerRefs []metav1.OwnerReference
+}
+
+// EnsureComputeAddress creates or updates the ComputeAddress CR described by
+// spec, idempotent against repeated reconciles. The actual GCP IP allocation
+// is performed by KCC asynchronously; callers should poll with
+// WaitForAddressReady before referencing the IP.
+func EnsureComputeAddress(ctx context.Context, c client.Client, spec AddressSpec) (*gcpv1beta1.ComputeAddress, error) {
+	if spec.Location == "" {
+		return nil, fmt.Errorf("googlecloud: ComputeAddress Location must be set")
+	}
+	addrType := spec.AddressType
+	if addrType == "" {
+		addrType = "EXTERNAL"
+	}
+	addr := &gcpv1beta1.ComputeAddress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      spec.Name,
+			Namespace: spec.Namespace,
+		},
+	}
+	mutate := func() error {
+		if addr.Labels == nil {
+			addr.Labels = map[string]string{}
+		}
+		addr.Labels[ResourceTagKey] = ResourceTagValue
+		if spec.ProjectID != "" {
+			if addr.Annotations == nil {
+				addr.Annotations = map[string]string{}
+			}
+			addr.Annotations[ProjectIDAnnotation] = spec.ProjectID
+		}
+		if len(spec.OwnerRefs) > 0 {
+			addr.OwnerReferences = spec.OwnerRefs
+		}
+		addr.Spec.Location = spec.Location
+		addr.Spec.AddressType = ptr.To(addrType)
+		if spec.ResourceID != "" {
+			addr.Spec.ResourceID = ptr.To(spec.ResourceID)
+		}
+		if addrType == "EXTERNAL" {
+			tier := spec.NetworkTier
+			if tier == "" {
+				tier = "PREMIUM"
+			}
+			addr.Spec.NetworkTier = ptr.To(tier)
+			addr.Spec.IPVersion = ptr.To("IPV4")
+			addr.Spec.NetworkRef = nil
+			addr.Spec.SubnetworkRef = nil
+		} else {
+			addr.Spec.NetworkTier = nil
+			// GCP rejects an Internal Address that sets BOTH network and
+			// subnetwork — subnetwork is the canonical anchor and implies the
+			// network. Only set NetworkRef when no subnetwork is provided.
+			if spec.SubnetworkRef != "" {
+				addr.Spec.SubnetworkRef = subnetRefOrSelfLink(spec.ProjectID, spec.Location, spec.SubnetworkRef)
+				addr.Spec.NetworkRef = nil
+			} else if spec.NetworkRef != "" {
+				addr.Spec.NetworkRef = networkRefOrSelfLink(spec.ProjectID, spec.NetworkRef, "global/networks")
+			}
+		}
+		return nil
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, addr, mutate); err != nil {
+		return nil, fmt.Errorf("googlecloud: create/update ComputeAddress %s/%s: %w", spec.Namespace, spec.Name, err)
+	}
+	return addr, nil
+}
+
+// networkRefOrSelfLink builds an External selfLink for a native GCP VPC when
+// the user passed a bare name. If the name already looks like a selfLink path
+// (contains a slash) we pass it through verbatim.
+func networkRefOrSelfLink(projectID, name, kindPath string) *gcpv1beta1.ResourceRef {
+	if projectID == "" || strings.Contains(name, "/") {
+		// Without a project ID we can't synthesize a selfLink; fall back to
+		// the KCC-name form and let KCC try to resolve it.
+		return &gcpv1beta1.ResourceRef{Name: name}
+	}
+	return &gcpv1beta1.ResourceRef{
+		External: fmt.Sprintf("projects/%s/%s/%s", projectID, kindPath, name),
+	}
+}
+
+// subnetRefOrSelfLink synthesizes a regional subnetwork selfLink.
+func subnetRefOrSelfLink(projectID, location, name string) *gcpv1beta1.ResourceRef {
+	if projectID == "" || location == "" || strings.Contains(name, "/") {
+		return &gcpv1beta1.ResourceRef{Name: name}
+	}
+	return &gcpv1beta1.ResourceRef{
+		External: fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", projectID, location, name),
+	}
+}
+
+// WaitForAddressReady returns the allocated IP from a ComputeAddress's status,
+// plus whether it is fully Ready. (ip, ready, err). The caller polls in its
+// reconcile loop.
+func WaitForAddressReady(ctx context.Context, c client.Client, key types.NamespacedName) (ip string, ready bool, err error) {
+	addr := &gcpv1beta1.ComputeAddress{}
+	if err := c.Get(ctx, key, addr); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if !IsKCCReady(addr.Status.Conditions, derefInt64(addr.Status.ObservedGeneration), addr.Generation) {
+		return "", false, nil
+	}
+	if addr.Status.ObservedState != nil && addr.Status.ObservedState.Address != nil {
+		return *addr.Status.ObservedState.Address, true, nil
+	}
+	return "", false, nil
+}

--- a/cloudprovider/googlecloud/apis/compute/v1beta1/doc.go
+++ b/cloudprovider/googlecloud/apis/compute/v1beta1/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Package v1beta1 contains a minimal Go representation of the subset of the
+// Config Connector (KCC) compute.cnrm.cloud.google.com/v1beta1 CRD API used by
+// the kruise-game GoogleCloud network plugins.
+//
+// We hand-define these types instead of vendoring github.com/GoogleCloudPlatform/k8s-config-connector
+// to avoid pulling its large transitive dependency surface. Only the JSON
+// schema needs to match what KCC's installed CRDs expect; field selection here
+// covers exactly what the Passthrough and GlobalProxy NLB plugins read/write.
+//
+// +kubebuilder:object:generate=true
+// +groupName=compute.cnrm.cloud.google.com
+package v1beta1

--- a/cloudprovider/googlecloud/apis/compute/v1beta1/doc.go
+++ b/cloudprovider/googlecloud/apis/compute/v1beta1/doc.go
@@ -17,6 +17,10 @@ You may obtain a copy of the License at
 // schema needs to match what KCC's installed CRDs expect; field selection here
 // covers exactly what the Passthrough and GlobalProxy NLB plugins read/write.
 //
-// +kubebuilder:object:generate=true
-// +groupName=compute.cnrm.cloud.google.com
+// These are bindings for CRDs OWNED by Config Connector — kruise-game must never
+// generate or install them. The package is therefore deliberately kept out of
+// controller-gen: no +kubebuilder:object:generate / +groupName / +object:root
+// markers, and the runtime.Object plumbing (DeepCopy/DeepCopyObject) is
+// hand-written in zz_generated.deepcopy.go. Scheme registration is manual in
+// register.go.
 package v1beta1

--- a/cloudprovider/googlecloud/apis/compute/v1beta1/register.go
+++ b/cloudprovider/googlecloud/apis/compute/v1beta1/register.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1beta1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// GroupName is the Config Connector compute API group.
+	GroupName = "compute.cnrm.cloud.google.com"
+	// GroupVersion is the API version.
+	GroupVersion = "v1beta1"
+)
+
+// SchemeGroupVersion is the GroupVersion used to register these objects.
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
+
+// Resource maps a kind name to a schema.GroupResource (used by client-go errors).
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	// SchemeBuilder collects functions that register API types into a scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&ComputeAddress{}, &ComputeAddressList{},
+		&ComputeForwardingRule{}, &ComputeForwardingRuleList{},
+		&ComputeBackendService{}, &ComputeBackendServiceList{},
+		&ComputeHealthCheck{}, &ComputeHealthCheckList{},
+		&ComputeTargetTCPProxy{}, &ComputeTargetTCPProxyList{},
+		&ComputeFirewall{}, &ComputeFirewallList{},
+	)
+	// REQUIRED: registers metav1.GetOptions/ListOptions/etc. against this GV so
+	// client-go can build typed REST requests for these CRDs. Without this,
+	// client.Get returns "v1.GetOptions is not suitable for converting to ...".
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/cloudprovider/googlecloud/apis/compute/v1beta1/types.go
+++ b/cloudprovider/googlecloud/apis/compute/v1beta1/types.go
@@ -43,7 +43,6 @@ type Condition struct {
 // -----------------------------------------------------------------------------
 
 // ComputeAddress represents a Compute Engine reserved IP address.
-// +kubebuilder:object:root=true
 type ComputeAddress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +52,6 @@ type ComputeAddress struct {
 }
 
 // ComputeAddressList is a list of ComputeAddress.
-// +kubebuilder:object:root=true
 type ComputeAddressList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -104,7 +102,6 @@ type ComputeAddressObservedState struct {
 // -----------------------------------------------------------------------------
 
 // ComputeForwardingRule represents a regional or global compute forwarding rule.
-// +kubebuilder:object:root=true
 type ComputeForwardingRule struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -114,7 +111,6 @@ type ComputeForwardingRule struct {
 }
 
 // ComputeForwardingRuleList is a list of ComputeForwardingRule.
-// +kubebuilder:object:root=true
 type ComputeForwardingRuleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -171,7 +167,6 @@ type ComputeForwardingRuleStatus struct {
 // -----------------------------------------------------------------------------
 
 // ComputeBackendService represents a regional or global compute backend service.
-// +kubebuilder:object:root=true
 type ComputeBackendService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -181,7 +176,6 @@ type ComputeBackendService struct {
 }
 
 // ComputeBackendServiceList is a list of ComputeBackendService.
-// +kubebuilder:object:root=true
 type ComputeBackendServiceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -241,7 +235,6 @@ type ComputeBackendServiceStatus struct {
 // -----------------------------------------------------------------------------
 
 // ComputeHealthCheck represents a regional or global compute health check.
-// +kubebuilder:object:root=true
 type ComputeHealthCheck struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -251,7 +244,6 @@ type ComputeHealthCheck struct {
 }
 
 // ComputeHealthCheckList is a list of ComputeHealthCheck.
-// +kubebuilder:object:root=true
 type ComputeHealthCheckList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -304,7 +296,6 @@ type ComputeHealthCheckStatus struct {
 // -----------------------------------------------------------------------------
 
 // ComputeTargetTCPProxy represents a (global by default) compute target TCP proxy.
-// +kubebuilder:object:root=true
 type ComputeTargetTCPProxy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -314,7 +305,6 @@ type ComputeTargetTCPProxy struct {
 }
 
 // ComputeTargetTCPProxyList is a list of ComputeTargetTCPProxy.
-// +kubebuilder:object:root=true
 type ComputeTargetTCPProxyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -345,7 +335,6 @@ type ComputeTargetTCPProxyStatus struct {
 // -----------------------------------------------------------------------------
 
 // ComputeFirewall represents a VPC firewall rule.
-// +kubebuilder:object:root=true
 type ComputeFirewall struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -355,7 +344,6 @@ type ComputeFirewall struct {
 }
 
 // ComputeFirewallList is a list of ComputeFirewall.
-// +kubebuilder:object:root=true
 type ComputeFirewallList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/cloudprovider/googlecloud/apis/compute/v1beta1/types.go
+++ b/cloudprovider/googlecloud/apis/compute/v1beta1/types.go
@@ -86,13 +86,13 @@ type ComputeAddressSpec struct {
 }
 
 type ComputeAddressStatus struct {
-	Conditions         []Condition                 `json:"conditions,omitempty"`
-	CreationTimestamp  *string                     `json:"creationTimestamp,omitempty"`
-	LabelFingerprint   *string                     `json:"labelFingerprint,omitempty"`
-	ObservedGeneration *int64                      `json:"observedGeneration,omitempty"`
+	Conditions         []Condition                  `json:"conditions,omitempty"`
+	CreationTimestamp  *string                      `json:"creationTimestamp,omitempty"`
+	LabelFingerprint   *string                      `json:"labelFingerprint,omitempty"`
+	ObservedGeneration *int64                       `json:"observedGeneration,omitempty"`
 	ObservedState      *ComputeAddressObservedState `json:"observedState,omitempty"`
-	SelfLink           *string                     `json:"selfLink,omitempty"`
-	Users              []string                    `json:"users,omitempty"`
+	SelfLink           *string                      `json:"selfLink,omitempty"`
+	Users              []string                     `json:"users,omitempty"`
 }
 
 type ComputeAddressObservedState struct {
@@ -122,31 +122,31 @@ type ComputeForwardingRuleList struct {
 }
 
 type ComputeForwardingRuleSpec struct {
-	Location          string             `json:"location"`
-	ResourceID        *string            `json:"resourceID,omitempty"`
-	Description       *string            `json:"description,omitempty"`
-	IPProtocol        *string            `json:"ipProtocol,omitempty"`
-	IPVersion         *string            `json:"ipVersion,omitempty"`
-	LoadBalancingScheme *string          `json:"loadBalancingScheme,omitempty"`
-	NetworkTier       *string            `json:"networkTier,omitempty"`
-	PortRange         *string            `json:"portRange,omitempty"`
-	Ports             []string           `json:"ports,omitempty"`
-	AllPorts          *bool              `json:"allPorts,omitempty"`
-	AllowGlobalAccess *bool              `json:"allowGlobalAccess,omitempty"`
-	Target            *ForwardingRuleTarget   `json:"target,omitempty"`
-	BackendServiceRef *ResourceRef       `json:"backendServiceRef,omitempty"`
-	IPAddress         *ForwardingRuleIPAddress `json:"ipAddress,omitempty"`
-	NetworkRef        *ResourceRef       `json:"networkRef,omitempty"`
-	SubnetworkRef     *ResourceRef       `json:"subnetworkRef,omitempty"`
-	ServiceLabel      *string            `json:"serviceLabel,omitempty"`
+	Location            string                   `json:"location"`
+	ResourceID          *string                  `json:"resourceID,omitempty"`
+	Description         *string                  `json:"description,omitempty"`
+	IPProtocol          *string                  `json:"ipProtocol,omitempty"`
+	IPVersion           *string                  `json:"ipVersion,omitempty"`
+	LoadBalancingScheme *string                  `json:"loadBalancingScheme,omitempty"`
+	NetworkTier         *string                  `json:"networkTier,omitempty"`
+	PortRange           *string                  `json:"portRange,omitempty"`
+	Ports               []string                 `json:"ports,omitempty"`
+	AllPorts            *bool                    `json:"allPorts,omitempty"`
+	AllowGlobalAccess   *bool                    `json:"allowGlobalAccess,omitempty"`
+	Target              *ForwardingRuleTarget    `json:"target,omitempty"`
+	BackendServiceRef   *ResourceRef             `json:"backendServiceRef,omitempty"`
+	IPAddress           *ForwardingRuleIPAddress `json:"ipAddress,omitempty"`
+	NetworkRef          *ResourceRef             `json:"networkRef,omitempty"`
+	SubnetworkRef       *ResourceRef             `json:"subnetworkRef,omitempty"`
+	ServiceLabel        *string                  `json:"serviceLabel,omitempty"`
 }
 
 type ForwardingRuleTarget struct {
-	TargetTCPProxyRef *ResourceRef `json:"targetTCPProxyRef,omitempty"`
-	TargetSSLProxyRef *ResourceRef `json:"targetSSLProxyRef,omitempty"`
-	TargetHTTPProxyRef *ResourceRef `json:"targetHTTPProxyRef,omitempty"`
-	TargetHTTPSProxyRef *ResourceRef `json:"targetHTTPSProxyRef,omitempty"`
-	GoogleAPIsBundle  *string      `json:"googleAPIsBundle,omitempty"`
+	TargetTCPProxyRef    *ResourceRef `json:"targetTCPProxyRef,omitempty"`
+	TargetSSLProxyRef    *ResourceRef `json:"targetSSLProxyRef,omitempty"`
+	TargetHTTPProxyRef   *ResourceRef `json:"targetHTTPProxyRef,omitempty"`
+	TargetHTTPSProxyRef  *ResourceRef `json:"targetHTTPSProxyRef,omitempty"`
+	GoogleAPIsBundle     *string      `json:"googleAPIsBundle,omitempty"`
 	ServiceAttachmentRef *ResourceRef `json:"serviceAttachmentRef,omitempty"`
 }
 
@@ -189,18 +189,18 @@ type ComputeBackendServiceList struct {
 }
 
 type ComputeBackendServiceSpec struct {
-	Location                     string                          `json:"location"`
-	ResourceID                   *string                         `json:"resourceID,omitempty"`
-	Description                  *string                         `json:"description,omitempty"`
-	Protocol                     *string                         `json:"protocol,omitempty"`
-	LoadBalancingScheme          *string                         `json:"loadBalancingScheme,omitempty"`
-	PortName                     *string                         `json:"portName,omitempty"`
-	TimeoutSec                   *int64                          `json:"timeoutSec,omitempty"`
-	ConnectionDrainingTimeoutSec *int64                          `json:"connectionDrainingTimeoutSec,omitempty"`
-	SessionAffinity              *string                         `json:"sessionAffinity,omitempty"`
-	HealthChecks                 []BackendServiceHealthCheckRef  `json:"healthChecks,omitempty"`
-	Backend                      []BackendServiceBackend         `json:"backend,omitempty"`
-	EnableCDN                    *bool                           `json:"enableCDN,omitempty"`
+	Location                     string                         `json:"location"`
+	ResourceID                   *string                        `json:"resourceID,omitempty"`
+	Description                  *string                        `json:"description,omitempty"`
+	Protocol                     *string                        `json:"protocol,omitempty"`
+	LoadBalancingScheme          *string                        `json:"loadBalancingScheme,omitempty"`
+	PortName                     *string                        `json:"portName,omitempty"`
+	TimeoutSec                   *int64                         `json:"timeoutSec,omitempty"`
+	ConnectionDrainingTimeoutSec *int64                         `json:"connectionDrainingTimeoutSec,omitempty"`
+	SessionAffinity              *string                        `json:"sessionAffinity,omitempty"`
+	HealthChecks                 []BackendServiceHealthCheckRef `json:"healthChecks,omitempty"`
+	Backend                      []BackendServiceBackend        `json:"backend,omitempty"`
+	EnableCDN                    *bool                          `json:"enableCDN,omitempty"`
 }
 
 type BackendServiceHealthCheckRef struct {
@@ -209,17 +209,17 @@ type BackendServiceHealthCheckRef struct {
 }
 
 type BackendServiceBackend struct {
-	Description               *string             `json:"description,omitempty"`
-	Group                     BackendGroup        `json:"group"`
-	BalancingMode             *string             `json:"balancingMode,omitempty"`
-	CapacityScaler            *float64            `json:"capacityScaler,omitempty"`
-	MaxConnections            *int64              `json:"maxConnections,omitempty"`
-	MaxConnectionsPerEndpoint *int64              `json:"maxConnectionsPerEndpoint,omitempty"`
-	MaxConnectionsPerInstance *int64              `json:"maxConnectionsPerInstance,omitempty"`
-	MaxRate                   *int64              `json:"maxRate,omitempty"`
-	MaxRatePerEndpoint        *float64            `json:"maxRatePerEndpoint,omitempty"`
-	MaxRatePerInstance        *float64            `json:"maxRatePerInstance,omitempty"`
-	MaxUtilization            *float64            `json:"maxUtilization,omitempty"`
+	Description               *string      `json:"description,omitempty"`
+	Group                     BackendGroup `json:"group"`
+	BalancingMode             *string      `json:"balancingMode,omitempty"`
+	CapacityScaler            *float64     `json:"capacityScaler,omitempty"`
+	MaxConnections            *int64       `json:"maxConnections,omitempty"`
+	MaxConnectionsPerEndpoint *int64       `json:"maxConnectionsPerEndpoint,omitempty"`
+	MaxConnectionsPerInstance *int64       `json:"maxConnectionsPerInstance,omitempty"`
+	MaxRate                   *int64       `json:"maxRate,omitempty"`
+	MaxRatePerEndpoint        *float64     `json:"maxRatePerEndpoint,omitempty"`
+	MaxRatePerInstance        *float64     `json:"maxRatePerInstance,omitempty"`
+	MaxUtilization            *float64     `json:"maxUtilization,omitempty"`
 }
 
 type BackendGroup struct {
@@ -259,17 +259,17 @@ type ComputeHealthCheckList struct {
 }
 
 type ComputeHealthCheckSpec struct {
-	Location           string              `json:"location"`
-	ResourceID         *string             `json:"resourceID,omitempty"`
-	Description        *string             `json:"description,omitempty"`
-	CheckIntervalSec   *int64              `json:"checkIntervalSec,omitempty"`
-	TimeoutSec         *int64              `json:"timeoutSec,omitempty"`
-	HealthyThreshold   *int64              `json:"healthyThreshold,omitempty"`
-	UnhealthyThreshold *int64              `json:"unhealthyThreshold,omitempty"`
-	TCPHealthCheck     *HealthCheckTCP     `json:"tcpHealthCheck,omitempty"`
-	HTTPHealthCheck    *HealthCheckHTTP    `json:"httpHealthCheck,omitempty"`
-	HTTPSHealthCheck   *HealthCheckHTTP    `json:"httpsHealthCheck,omitempty"`
-	SSLHealthCheck     *HealthCheckTCP     `json:"sslHealthCheck,omitempty"`
+	Location           string           `json:"location"`
+	ResourceID         *string          `json:"resourceID,omitempty"`
+	Description        *string          `json:"description,omitempty"`
+	CheckIntervalSec   *int64           `json:"checkIntervalSec,omitempty"`
+	TimeoutSec         *int64           `json:"timeoutSec,omitempty"`
+	HealthyThreshold   *int64           `json:"healthyThreshold,omitempty"`
+	UnhealthyThreshold *int64           `json:"unhealthyThreshold,omitempty"`
+	TCPHealthCheck     *HealthCheckTCP  `json:"tcpHealthCheck,omitempty"`
+	HTTPHealthCheck    *HealthCheckHTTP `json:"httpHealthCheck,omitempty"`
+	HTTPSHealthCheck   *HealthCheckHTTP `json:"httpsHealthCheck,omitempty"`
+	SSLHealthCheck     *HealthCheckTCP  `json:"sslHealthCheck,omitempty"`
 }
 
 type HealthCheckTCP struct {

--- a/cloudprovider/googlecloud/apis/compute/v1beta1/types.go
+++ b/cloudprovider/googlecloud/apis/compute/v1beta1/types.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1beta1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourceRef references another KCC resource by name (and optional namespace),
+// or directly by external selfLink. Matches the shape of
+// github.com/GoogleCloudPlatform/k8s-config-connector apis/k8s/v1alpha1.ResourceRef.
+type ResourceRef struct {
+	// External is a selfLink (e.g. projects/foo/zones/us-central1-a/networkEndpointGroups/bar).
+	External string `json:"external,omitempty"`
+	// Kind is the kind of the referenced object.
+	Kind string `json:"kind,omitempty"`
+	// Name is the metadata.name of the referenced object.
+	Name string `json:"name,omitempty"`
+	// Namespace is the metadata.namespace of the referenced object. Defaults to
+	// the same namespace as the referrer.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// Condition is the standard KCC condition shape mirrored from apis/k8s/v1alpha1.
+type Condition struct {
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	Message            string      `json:"message,omitempty"`
+	Reason             string      `json:"reason,omitempty"`
+	Status             string      `json:"status,omitempty"`
+	Type               string      `json:"type,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// ComputeAddress
+// -----------------------------------------------------------------------------
+
+// ComputeAddress represents a Compute Engine reserved IP address.
+// +kubebuilder:object:root=true
+type ComputeAddress struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ComputeAddressSpec   `json:"spec,omitempty"`
+	Status ComputeAddressStatus `json:"status,omitempty"`
+}
+
+// ComputeAddressList is a list of ComputeAddress.
+// +kubebuilder:object:root=true
+type ComputeAddressList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ComputeAddress `json:"items"`
+}
+
+type ComputeAddressSpec struct {
+	// Location is "global" or a region name (e.g. "us-central1").
+	Location string `json:"location"`
+	// ResourceID is the immutable GCP-side name; defaults to metadata.name when unset.
+	ResourceID *string `json:"resourceID,omitempty"`
+	// Address optionally pins the IP value; let GCP allocate when unset.
+	Address *string `json:"address,omitempty"`
+	// AddressType is EXTERNAL or INTERNAL. Defaults to EXTERNAL.
+	AddressType *string `json:"addressType,omitempty"`
+	// IpVersion is IPV4 or IPV6.
+	IPVersion *string `json:"ipVersion,omitempty"`
+	// NetworkTier is PREMIUM or STANDARD; PREMIUM is required for global addresses.
+	NetworkTier *string `json:"networkTier,omitempty"`
+	// Purpose for INTERNAL addresses (e.g. GCE_ENDPOINT, SHARED_LOADBALANCER_VIP).
+	Purpose *string `json:"purpose,omitempty"`
+	// NetworkRef references the VPC network for internal addresses.
+	NetworkRef *ResourceRef `json:"networkRef,omitempty"`
+	// SubnetworkRef references the subnetwork for internal addresses.
+	SubnetworkRef *ResourceRef `json:"subnetworkRef,omitempty"`
+	// Description is an optional human-readable description.
+	Description *string `json:"description,omitempty"`
+	// PrefixLength only applies to internal IP ranges (not single IPs).
+	PrefixLength *int64 `json:"prefixLength,omitempty"`
+}
+
+type ComputeAddressStatus struct {
+	Conditions         []Condition                 `json:"conditions,omitempty"`
+	CreationTimestamp  *string                     `json:"creationTimestamp,omitempty"`
+	LabelFingerprint   *string                     `json:"labelFingerprint,omitempty"`
+	ObservedGeneration *int64                      `json:"observedGeneration,omitempty"`
+	ObservedState      *ComputeAddressObservedState `json:"observedState,omitempty"`
+	SelfLink           *string                     `json:"selfLink,omitempty"`
+	Users              []string                    `json:"users,omitempty"`
+}
+
+type ComputeAddressObservedState struct {
+	Address *string `json:"address,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// ComputeForwardingRule
+// -----------------------------------------------------------------------------
+
+// ComputeForwardingRule represents a regional or global compute forwarding rule.
+// +kubebuilder:object:root=true
+type ComputeForwardingRule struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ComputeForwardingRuleSpec   `json:"spec,omitempty"`
+	Status ComputeForwardingRuleStatus `json:"status,omitempty"`
+}
+
+// ComputeForwardingRuleList is a list of ComputeForwardingRule.
+// +kubebuilder:object:root=true
+type ComputeForwardingRuleList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ComputeForwardingRule `json:"items"`
+}
+
+type ComputeForwardingRuleSpec struct {
+	Location          string             `json:"location"`
+	ResourceID        *string            `json:"resourceID,omitempty"`
+	Description       *string            `json:"description,omitempty"`
+	IPProtocol        *string            `json:"ipProtocol,omitempty"`
+	IPVersion         *string            `json:"ipVersion,omitempty"`
+	LoadBalancingScheme *string          `json:"loadBalancingScheme,omitempty"`
+	NetworkTier       *string            `json:"networkTier,omitempty"`
+	PortRange         *string            `json:"portRange,omitempty"`
+	Ports             []string           `json:"ports,omitempty"`
+	AllPorts          *bool              `json:"allPorts,omitempty"`
+	AllowGlobalAccess *bool              `json:"allowGlobalAccess,omitempty"`
+	Target            *ForwardingRuleTarget   `json:"target,omitempty"`
+	BackendServiceRef *ResourceRef       `json:"backendServiceRef,omitempty"`
+	IPAddress         *ForwardingRuleIPAddress `json:"ipAddress,omitempty"`
+	NetworkRef        *ResourceRef       `json:"networkRef,omitempty"`
+	SubnetworkRef     *ResourceRef       `json:"subnetworkRef,omitempty"`
+	ServiceLabel      *string            `json:"serviceLabel,omitempty"`
+}
+
+type ForwardingRuleTarget struct {
+	TargetTCPProxyRef *ResourceRef `json:"targetTCPProxyRef,omitempty"`
+	TargetSSLProxyRef *ResourceRef `json:"targetSSLProxyRef,omitempty"`
+	TargetHTTPProxyRef *ResourceRef `json:"targetHTTPProxyRef,omitempty"`
+	TargetHTTPSProxyRef *ResourceRef `json:"targetHTTPSProxyRef,omitempty"`
+	GoogleAPIsBundle  *string      `json:"googleAPIsBundle,omitempty"`
+	ServiceAttachmentRef *ResourceRef `json:"serviceAttachmentRef,omitempty"`
+}
+
+type ForwardingRuleIPAddress struct {
+	AddressRef *ResourceRef `json:"addressRef,omitempty"`
+	IP         *string      `json:"ip,omitempty"`
+}
+
+type ComputeForwardingRuleStatus struct {
+	Conditions         []Condition `json:"conditions,omitempty"`
+	BaseForwardingRule *string     `json:"baseForwardingRule,omitempty"`
+	CreationTimestamp  *string     `json:"creationTimestamp,omitempty"`
+	LabelFingerprint   *string     `json:"labelFingerprint,omitempty"`
+	ObservedGeneration *int64      `json:"observedGeneration,omitempty"`
+	SelfLink           *string     `json:"selfLink,omitempty"`
+	ServiceName        *string     `json:"serviceName,omitempty"`
+	Target             *string     `json:"target,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// ComputeBackendService
+// -----------------------------------------------------------------------------
+
+// ComputeBackendService represents a regional or global compute backend service.
+// +kubebuilder:object:root=true
+type ComputeBackendService struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ComputeBackendServiceSpec   `json:"spec,omitempty"`
+	Status ComputeBackendServiceStatus `json:"status,omitempty"`
+}
+
+// ComputeBackendServiceList is a list of ComputeBackendService.
+// +kubebuilder:object:root=true
+type ComputeBackendServiceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ComputeBackendService `json:"items"`
+}
+
+type ComputeBackendServiceSpec struct {
+	Location                     string                          `json:"location"`
+	ResourceID                   *string                         `json:"resourceID,omitempty"`
+	Description                  *string                         `json:"description,omitempty"`
+	Protocol                     *string                         `json:"protocol,omitempty"`
+	LoadBalancingScheme          *string                         `json:"loadBalancingScheme,omitempty"`
+	PortName                     *string                         `json:"portName,omitempty"`
+	TimeoutSec                   *int64                          `json:"timeoutSec,omitempty"`
+	ConnectionDrainingTimeoutSec *int64                          `json:"connectionDrainingTimeoutSec,omitempty"`
+	SessionAffinity              *string                         `json:"sessionAffinity,omitempty"`
+	HealthChecks                 []BackendServiceHealthCheckRef  `json:"healthChecks,omitempty"`
+	Backend                      []BackendServiceBackend         `json:"backend,omitempty"`
+	EnableCDN                    *bool                           `json:"enableCDN,omitempty"`
+}
+
+type BackendServiceHealthCheckRef struct {
+	HealthCheckRef     *ResourceRef `json:"healthCheckRef,omitempty"`
+	HTTPHealthCheckRef *ResourceRef `json:"httpHealthCheckRef,omitempty"`
+}
+
+type BackendServiceBackend struct {
+	Description               *string             `json:"description,omitempty"`
+	Group                     BackendGroup        `json:"group"`
+	BalancingMode             *string             `json:"balancingMode,omitempty"`
+	CapacityScaler            *float64            `json:"capacityScaler,omitempty"`
+	MaxConnections            *int64              `json:"maxConnections,omitempty"`
+	MaxConnectionsPerEndpoint *int64              `json:"maxConnectionsPerEndpoint,omitempty"`
+	MaxConnectionsPerInstance *int64              `json:"maxConnectionsPerInstance,omitempty"`
+	MaxRate                   *int64              `json:"maxRate,omitempty"`
+	MaxRatePerEndpoint        *float64            `json:"maxRatePerEndpoint,omitempty"`
+	MaxRatePerInstance        *float64            `json:"maxRatePerInstance,omitempty"`
+	MaxUtilization            *float64            `json:"maxUtilization,omitempty"`
+}
+
+type BackendGroup struct {
+	NetworkEndpointGroupRef *ResourceRef `json:"networkEndpointGroupRef,omitempty"`
+	InstanceGroupRef        *ResourceRef `json:"instanceGroupRef,omitempty"`
+}
+
+type ComputeBackendServiceStatus struct {
+	Conditions         []Condition `json:"conditions,omitempty"`
+	CreationTimestamp  *string     `json:"creationTimestamp,omitempty"`
+	Fingerprint        *string     `json:"fingerprint,omitempty"`
+	GeneratedId        *int64      `json:"generatedId,omitempty"`
+	ObservedGeneration *int64      `json:"observedGeneration,omitempty"`
+	SelfLink           *string     `json:"selfLink,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// ComputeHealthCheck
+// -----------------------------------------------------------------------------
+
+// ComputeHealthCheck represents a regional or global compute health check.
+// +kubebuilder:object:root=true
+type ComputeHealthCheck struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ComputeHealthCheckSpec   `json:"spec,omitempty"`
+	Status ComputeHealthCheckStatus `json:"status,omitempty"`
+}
+
+// ComputeHealthCheckList is a list of ComputeHealthCheck.
+// +kubebuilder:object:root=true
+type ComputeHealthCheckList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ComputeHealthCheck `json:"items"`
+}
+
+type ComputeHealthCheckSpec struct {
+	Location           string              `json:"location"`
+	ResourceID         *string             `json:"resourceID,omitempty"`
+	Description        *string             `json:"description,omitempty"`
+	CheckIntervalSec   *int64              `json:"checkIntervalSec,omitempty"`
+	TimeoutSec         *int64              `json:"timeoutSec,omitempty"`
+	HealthyThreshold   *int64              `json:"healthyThreshold,omitempty"`
+	UnhealthyThreshold *int64              `json:"unhealthyThreshold,omitempty"`
+	TCPHealthCheck     *HealthCheckTCP     `json:"tcpHealthCheck,omitempty"`
+	HTTPHealthCheck    *HealthCheckHTTP    `json:"httpHealthCheck,omitempty"`
+	HTTPSHealthCheck   *HealthCheckHTTP    `json:"httpsHealthCheck,omitempty"`
+	SSLHealthCheck     *HealthCheckTCP     `json:"sslHealthCheck,omitempty"`
+}
+
+type HealthCheckTCP struct {
+	Port              *int64  `json:"port,omitempty"`
+	PortName          *string `json:"portName,omitempty"`
+	PortSpecification *string `json:"portSpecification,omitempty"`
+	ProxyHeader       *string `json:"proxyHeader,omitempty"`
+	Request           *string `json:"request,omitempty"`
+	Response          *string `json:"response,omitempty"`
+}
+
+type HealthCheckHTTP struct {
+	Port              *int64  `json:"port,omitempty"`
+	PortName          *string `json:"portName,omitempty"`
+	PortSpecification *string `json:"portSpecification,omitempty"`
+	Host              *string `json:"host,omitempty"`
+	RequestPath       *string `json:"requestPath,omitempty"`
+	Response          *string `json:"response,omitempty"`
+	ProxyHeader       *string `json:"proxyHeader,omitempty"`
+}
+
+type ComputeHealthCheckStatus struct {
+	Conditions         []Condition `json:"conditions,omitempty"`
+	CreationTimestamp  *string     `json:"creationTimestamp,omitempty"`
+	ObservedGeneration *int64      `json:"observedGeneration,omitempty"`
+	SelfLink           *string     `json:"selfLink,omitempty"`
+	Type               *string     `json:"type,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// ComputeTargetTCPProxy
+// -----------------------------------------------------------------------------
+
+// ComputeTargetTCPProxy represents a (global by default) compute target TCP proxy.
+// +kubebuilder:object:root=true
+type ComputeTargetTCPProxy struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ComputeTargetTCPProxySpec   `json:"spec,omitempty"`
+	Status ComputeTargetTCPProxyStatus `json:"status,omitempty"`
+}
+
+// ComputeTargetTCPProxyList is a list of ComputeTargetTCPProxy.
+// +kubebuilder:object:root=true
+type ComputeTargetTCPProxyList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ComputeTargetTCPProxy `json:"items"`
+}
+
+type ComputeTargetTCPProxySpec struct {
+	BackendServiceRef ResourceRef `json:"backendServiceRef"`
+	Description       *string     `json:"description,omitempty"`
+	Location          *string     `json:"location,omitempty"`
+	ProxyBind         *bool       `json:"proxyBind,omitempty"`
+	// ProxyHeader is NONE or PROXY_V1.
+	ProxyHeader *string `json:"proxyHeader,omitempty"`
+	ResourceID  *string `json:"resourceID,omitempty"`
+}
+
+type ComputeTargetTCPProxyStatus struct {
+	Conditions         []Condition `json:"conditions,omitempty"`
+	CreationTimestamp  *string     `json:"creationTimestamp,omitempty"`
+	ExternalRef        *string     `json:"externalRef,omitempty"`
+	ObservedGeneration *int64      `json:"observedGeneration,omitempty"`
+	ProxyId            *int64      `json:"proxyId,omitempty"`
+	SelfLink           *string     `json:"selfLink,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+// ComputeFirewall (used by GlobalProxyNLB to admit health-check/GFE traffic)
+// -----------------------------------------------------------------------------
+
+// ComputeFirewall represents a VPC firewall rule.
+// +kubebuilder:object:root=true
+type ComputeFirewall struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ComputeFirewallSpec   `json:"spec,omitempty"`
+	Status ComputeFirewallStatus `json:"status,omitempty"`
+}
+
+// ComputeFirewallList is a list of ComputeFirewall.
+// +kubebuilder:object:root=true
+type ComputeFirewallList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ComputeFirewall `json:"items"`
+}
+
+type ComputeFirewallSpec struct {
+	ResourceID            *string         `json:"resourceID,omitempty"`
+	Description           *string         `json:"description,omitempty"`
+	Disabled              *bool           `json:"disabled,omitempty"`
+	Direction             *string         `json:"direction,omitempty"`
+	Priority              *int64          `json:"priority,omitempty"`
+	NetworkRef            ResourceRef     `json:"networkRef"`
+	SourceRanges          []string        `json:"sourceRanges,omitempty"`
+	DestinationRanges     []string        `json:"destinationRanges,omitempty"`
+	SourceTags            []string        `json:"sourceTags,omitempty"`
+	TargetTags            []string        `json:"targetTags,omitempty"`
+	SourceServiceAccounts []string        `json:"sourceServiceAccounts,omitempty"`
+	TargetServiceAccounts []string        `json:"targetServiceAccounts,omitempty"`
+	Allowed               []FirewallRule  `json:"allow,omitempty"`
+	Denied                []FirewallRule  `json:"deny,omitempty"`
+	LogConfig             *FirewallLogCfg `json:"logConfig,omitempty"`
+}
+
+type FirewallRule struct {
+	Protocol string   `json:"protocol"`
+	Ports    []string `json:"ports,omitempty"`
+}
+
+type FirewallLogCfg struct {
+	Metadata *string `json:"metadata,omitempty"`
+}
+
+type ComputeFirewallStatus struct {
+	Conditions         []Condition `json:"conditions,omitempty"`
+	CreationTimestamp  *string     `json:"creationTimestamp,omitempty"`
+	ObservedGeneration *int64      `json:"observedGeneration,omitempty"`
+	SelfLink           *string     `json:"selfLink,omitempty"`
+}

--- a/cloudprovider/googlecloud/apis/compute/v1beta1/zz_generated.deepcopy.go
+++ b/cloudprovider/googlecloud/apis/compute/v1beta1/zz_generated.deepcopy.go
@@ -1,0 +1,623 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Hand-written DeepCopy implementations to satisfy controller-runtime's
+// runtime.Object contract. The "zz_generated" prefix matches the convention used
+// for generated code but these are maintained by hand (the package is small).
+
+package v1beta1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// stringPtr / int64Ptr / boolPtr / float64Ptr are pointer-deep-copy helpers.
+func stringPtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func int64Ptr(p *int64) *int64 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func boolPtr(p *bool) *bool {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func float64Ptr(p *float64) *float64 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func cloneStringSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneConditions(in []Condition) []Condition {
+	if in == nil {
+		return nil
+	}
+	out := make([]Condition, len(in))
+	copy(out, in)
+	return out
+}
+
+// ResourceRef -----------------------------------------------------------------
+
+func (in *ResourceRef) DeepCopy() *ResourceRef {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+// ComputeAddress --------------------------------------------------------------
+
+func (in *ComputeAddress) DeepCopyInto(out *ComputeAddress) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *ComputeAddress) DeepCopy() *ComputeAddress {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeAddress)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeAddress) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeAddressList) DeepCopyInto(out *ComputeAddressList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]ComputeAddress, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+func (in *ComputeAddressList) DeepCopy() *ComputeAddressList {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeAddressList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeAddressList) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeAddressSpec) DeepCopyInto(out *ComputeAddressSpec) {
+	*out = *in
+	out.ResourceID = stringPtr(in.ResourceID)
+	out.Address = stringPtr(in.Address)
+	out.AddressType = stringPtr(in.AddressType)
+	out.IPVersion = stringPtr(in.IPVersion)
+	out.NetworkTier = stringPtr(in.NetworkTier)
+	out.Purpose = stringPtr(in.Purpose)
+	out.Description = stringPtr(in.Description)
+	out.PrefixLength = int64Ptr(in.PrefixLength)
+	if in.NetworkRef != nil {
+		out.NetworkRef = in.NetworkRef.DeepCopy()
+	}
+	if in.SubnetworkRef != nil {
+		out.SubnetworkRef = in.SubnetworkRef.DeepCopy()
+	}
+}
+
+func (in *ComputeAddressStatus) DeepCopyInto(out *ComputeAddressStatus) {
+	*out = *in
+	out.Conditions = cloneConditions(in.Conditions)
+	out.CreationTimestamp = stringPtr(in.CreationTimestamp)
+	out.LabelFingerprint = stringPtr(in.LabelFingerprint)
+	out.ObservedGeneration = int64Ptr(in.ObservedGeneration)
+	out.SelfLink = stringPtr(in.SelfLink)
+	out.Users = cloneStringSlice(in.Users)
+	if in.ObservedState != nil {
+		obs := *in.ObservedState
+		obs.Address = stringPtr(in.ObservedState.Address)
+		out.ObservedState = &obs
+	}
+}
+
+// ComputeForwardingRule -------------------------------------------------------
+
+func (in *ComputeForwardingRule) DeepCopyInto(out *ComputeForwardingRule) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *ComputeForwardingRule) DeepCopy() *ComputeForwardingRule {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeForwardingRule)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeForwardingRule) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeForwardingRuleList) DeepCopyInto(out *ComputeForwardingRuleList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]ComputeForwardingRule, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+func (in *ComputeForwardingRuleList) DeepCopy() *ComputeForwardingRuleList {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeForwardingRuleList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeForwardingRuleList) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeForwardingRuleSpec) DeepCopyInto(out *ComputeForwardingRuleSpec) {
+	*out = *in
+	out.ResourceID = stringPtr(in.ResourceID)
+	out.Description = stringPtr(in.Description)
+	out.IPProtocol = stringPtr(in.IPProtocol)
+	out.IPVersion = stringPtr(in.IPVersion)
+	out.LoadBalancingScheme = stringPtr(in.LoadBalancingScheme)
+	out.NetworkTier = stringPtr(in.NetworkTier)
+	out.PortRange = stringPtr(in.PortRange)
+	out.Ports = cloneStringSlice(in.Ports)
+	out.AllPorts = boolPtr(in.AllPorts)
+	out.AllowGlobalAccess = boolPtr(in.AllowGlobalAccess)
+	out.ServiceLabel = stringPtr(in.ServiceLabel)
+	if in.Target != nil {
+		t := ForwardingRuleTarget{}
+		if in.Target.TargetTCPProxyRef != nil {
+			t.TargetTCPProxyRef = in.Target.TargetTCPProxyRef.DeepCopy()
+		}
+		if in.Target.TargetSSLProxyRef != nil {
+			t.TargetSSLProxyRef = in.Target.TargetSSLProxyRef.DeepCopy()
+		}
+		if in.Target.TargetHTTPProxyRef != nil {
+			t.TargetHTTPProxyRef = in.Target.TargetHTTPProxyRef.DeepCopy()
+		}
+		if in.Target.TargetHTTPSProxyRef != nil {
+			t.TargetHTTPSProxyRef = in.Target.TargetHTTPSProxyRef.DeepCopy()
+		}
+		if in.Target.ServiceAttachmentRef != nil {
+			t.ServiceAttachmentRef = in.Target.ServiceAttachmentRef.DeepCopy()
+		}
+		t.GoogleAPIsBundle = stringPtr(in.Target.GoogleAPIsBundle)
+		out.Target = &t
+	}
+	if in.BackendServiceRef != nil {
+		out.BackendServiceRef = in.BackendServiceRef.DeepCopy()
+	}
+	if in.IPAddress != nil {
+		ip := ForwardingRuleIPAddress{}
+		if in.IPAddress.AddressRef != nil {
+			ip.AddressRef = in.IPAddress.AddressRef.DeepCopy()
+		}
+		ip.IP = stringPtr(in.IPAddress.IP)
+		out.IPAddress = &ip
+	}
+	if in.NetworkRef != nil {
+		out.NetworkRef = in.NetworkRef.DeepCopy()
+	}
+	if in.SubnetworkRef != nil {
+		out.SubnetworkRef = in.SubnetworkRef.DeepCopy()
+	}
+}
+
+func (in *ComputeForwardingRuleStatus) DeepCopyInto(out *ComputeForwardingRuleStatus) {
+	*out = *in
+	out.Conditions = cloneConditions(in.Conditions)
+	out.BaseForwardingRule = stringPtr(in.BaseForwardingRule)
+	out.CreationTimestamp = stringPtr(in.CreationTimestamp)
+	out.LabelFingerprint = stringPtr(in.LabelFingerprint)
+	out.ObservedGeneration = int64Ptr(in.ObservedGeneration)
+	out.SelfLink = stringPtr(in.SelfLink)
+	out.ServiceName = stringPtr(in.ServiceName)
+	out.Target = stringPtr(in.Target)
+}
+
+// ComputeBackendService -------------------------------------------------------
+
+func (in *ComputeBackendService) DeepCopyInto(out *ComputeBackendService) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *ComputeBackendService) DeepCopy() *ComputeBackendService {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeBackendService)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeBackendService) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeBackendServiceList) DeepCopyInto(out *ComputeBackendServiceList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]ComputeBackendService, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+func (in *ComputeBackendServiceList) DeepCopy() *ComputeBackendServiceList {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeBackendServiceList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeBackendServiceList) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeBackendServiceSpec) DeepCopyInto(out *ComputeBackendServiceSpec) {
+	*out = *in
+	out.ResourceID = stringPtr(in.ResourceID)
+	out.Description = stringPtr(in.Description)
+	out.Protocol = stringPtr(in.Protocol)
+	out.LoadBalancingScheme = stringPtr(in.LoadBalancingScheme)
+	out.PortName = stringPtr(in.PortName)
+	out.TimeoutSec = int64Ptr(in.TimeoutSec)
+	out.ConnectionDrainingTimeoutSec = int64Ptr(in.ConnectionDrainingTimeoutSec)
+	out.SessionAffinity = stringPtr(in.SessionAffinity)
+	out.EnableCDN = boolPtr(in.EnableCDN)
+	if in.HealthChecks != nil {
+		out.HealthChecks = make([]BackendServiceHealthCheckRef, len(in.HealthChecks))
+		for i, hc := range in.HealthChecks {
+			h := BackendServiceHealthCheckRef{}
+			if hc.HealthCheckRef != nil {
+				h.HealthCheckRef = hc.HealthCheckRef.DeepCopy()
+			}
+			if hc.HTTPHealthCheckRef != nil {
+				h.HTTPHealthCheckRef = hc.HTTPHealthCheckRef.DeepCopy()
+			}
+			out.HealthChecks[i] = h
+		}
+	}
+	if in.Backend != nil {
+		out.Backend = make([]BackendServiceBackend, len(in.Backend))
+		for i, b := range in.Backend {
+			nb := BackendServiceBackend{
+				Description:               stringPtr(b.Description),
+				BalancingMode:             stringPtr(b.BalancingMode),
+				CapacityScaler:            float64Ptr(b.CapacityScaler),
+				MaxConnections:            int64Ptr(b.MaxConnections),
+				MaxConnectionsPerEndpoint: int64Ptr(b.MaxConnectionsPerEndpoint),
+				MaxConnectionsPerInstance: int64Ptr(b.MaxConnectionsPerInstance),
+				MaxRate:                   int64Ptr(b.MaxRate),
+				MaxRatePerEndpoint:        float64Ptr(b.MaxRatePerEndpoint),
+				MaxRatePerInstance:        float64Ptr(b.MaxRatePerInstance),
+				MaxUtilization:            float64Ptr(b.MaxUtilization),
+			}
+			if b.Group.NetworkEndpointGroupRef != nil {
+				nb.Group.NetworkEndpointGroupRef = b.Group.NetworkEndpointGroupRef.DeepCopy()
+			}
+			if b.Group.InstanceGroupRef != nil {
+				nb.Group.InstanceGroupRef = b.Group.InstanceGroupRef.DeepCopy()
+			}
+			out.Backend[i] = nb
+		}
+	}
+}
+
+func (in *ComputeBackendServiceStatus) DeepCopyInto(out *ComputeBackendServiceStatus) {
+	*out = *in
+	out.Conditions = cloneConditions(in.Conditions)
+	out.CreationTimestamp = stringPtr(in.CreationTimestamp)
+	out.Fingerprint = stringPtr(in.Fingerprint)
+	out.GeneratedId = int64Ptr(in.GeneratedId)
+	out.ObservedGeneration = int64Ptr(in.ObservedGeneration)
+	out.SelfLink = stringPtr(in.SelfLink)
+}
+
+// ComputeHealthCheck ----------------------------------------------------------
+
+func (in *ComputeHealthCheck) DeepCopyInto(out *ComputeHealthCheck) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *ComputeHealthCheck) DeepCopy() *ComputeHealthCheck {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeHealthCheck)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeHealthCheck) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeHealthCheckList) DeepCopyInto(out *ComputeHealthCheckList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]ComputeHealthCheck, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+func (in *ComputeHealthCheckList) DeepCopy() *ComputeHealthCheckList {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeHealthCheckList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeHealthCheckList) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeHealthCheckSpec) DeepCopyInto(out *ComputeHealthCheckSpec) {
+	*out = *in
+	out.ResourceID = stringPtr(in.ResourceID)
+	out.Description = stringPtr(in.Description)
+	out.CheckIntervalSec = int64Ptr(in.CheckIntervalSec)
+	out.TimeoutSec = int64Ptr(in.TimeoutSec)
+	out.HealthyThreshold = int64Ptr(in.HealthyThreshold)
+	out.UnhealthyThreshold = int64Ptr(in.UnhealthyThreshold)
+	if in.TCPHealthCheck != nil {
+		cp := *in.TCPHealthCheck
+		cp.Port = int64Ptr(in.TCPHealthCheck.Port)
+		cp.PortName = stringPtr(in.TCPHealthCheck.PortName)
+		cp.PortSpecification = stringPtr(in.TCPHealthCheck.PortSpecification)
+		cp.ProxyHeader = stringPtr(in.TCPHealthCheck.ProxyHeader)
+		cp.Request = stringPtr(in.TCPHealthCheck.Request)
+		cp.Response = stringPtr(in.TCPHealthCheck.Response)
+		out.TCPHealthCheck = &cp
+	}
+	if in.HTTPHealthCheck != nil {
+		cp := *in.HTTPHealthCheck
+		cp.Port = int64Ptr(in.HTTPHealthCheck.Port)
+		cp.PortName = stringPtr(in.HTTPHealthCheck.PortName)
+		cp.PortSpecification = stringPtr(in.HTTPHealthCheck.PortSpecification)
+		cp.Host = stringPtr(in.HTTPHealthCheck.Host)
+		cp.RequestPath = stringPtr(in.HTTPHealthCheck.RequestPath)
+		cp.Response = stringPtr(in.HTTPHealthCheck.Response)
+		cp.ProxyHeader = stringPtr(in.HTTPHealthCheck.ProxyHeader)
+		out.HTTPHealthCheck = &cp
+	}
+	if in.HTTPSHealthCheck != nil {
+		cp := *in.HTTPSHealthCheck
+		cp.Port = int64Ptr(in.HTTPSHealthCheck.Port)
+		cp.PortName = stringPtr(in.HTTPSHealthCheck.PortName)
+		cp.PortSpecification = stringPtr(in.HTTPSHealthCheck.PortSpecification)
+		cp.Host = stringPtr(in.HTTPSHealthCheck.Host)
+		cp.RequestPath = stringPtr(in.HTTPSHealthCheck.RequestPath)
+		cp.Response = stringPtr(in.HTTPSHealthCheck.Response)
+		cp.ProxyHeader = stringPtr(in.HTTPSHealthCheck.ProxyHeader)
+		out.HTTPSHealthCheck = &cp
+	}
+	if in.SSLHealthCheck != nil {
+		cp := *in.SSLHealthCheck
+		cp.Port = int64Ptr(in.SSLHealthCheck.Port)
+		cp.PortName = stringPtr(in.SSLHealthCheck.PortName)
+		cp.PortSpecification = stringPtr(in.SSLHealthCheck.PortSpecification)
+		cp.ProxyHeader = stringPtr(in.SSLHealthCheck.ProxyHeader)
+		cp.Request = stringPtr(in.SSLHealthCheck.Request)
+		cp.Response = stringPtr(in.SSLHealthCheck.Response)
+		out.SSLHealthCheck = &cp
+	}
+}
+
+func (in *ComputeHealthCheckStatus) DeepCopyInto(out *ComputeHealthCheckStatus) {
+	*out = *in
+	out.Conditions = cloneConditions(in.Conditions)
+	out.CreationTimestamp = stringPtr(in.CreationTimestamp)
+	out.ObservedGeneration = int64Ptr(in.ObservedGeneration)
+	out.SelfLink = stringPtr(in.SelfLink)
+	out.Type = stringPtr(in.Type)
+}
+
+// ComputeTargetTCPProxy -------------------------------------------------------
+
+func (in *ComputeTargetTCPProxy) DeepCopyInto(out *ComputeTargetTCPProxy) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *ComputeTargetTCPProxy) DeepCopy() *ComputeTargetTCPProxy {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeTargetTCPProxy)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeTargetTCPProxy) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeTargetTCPProxyList) DeepCopyInto(out *ComputeTargetTCPProxyList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]ComputeTargetTCPProxy, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+func (in *ComputeTargetTCPProxyList) DeepCopy() *ComputeTargetTCPProxyList {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeTargetTCPProxyList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeTargetTCPProxyList) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeTargetTCPProxySpec) DeepCopyInto(out *ComputeTargetTCPProxySpec) {
+	*out = *in
+	out.BackendServiceRef = *in.BackendServiceRef.DeepCopy()
+	out.Description = stringPtr(in.Description)
+	out.Location = stringPtr(in.Location)
+	out.ProxyBind = boolPtr(in.ProxyBind)
+	out.ProxyHeader = stringPtr(in.ProxyHeader)
+	out.ResourceID = stringPtr(in.ResourceID)
+}
+
+func (in *ComputeTargetTCPProxyStatus) DeepCopyInto(out *ComputeTargetTCPProxyStatus) {
+	*out = *in
+	out.Conditions = cloneConditions(in.Conditions)
+	out.CreationTimestamp = stringPtr(in.CreationTimestamp)
+	out.ExternalRef = stringPtr(in.ExternalRef)
+	out.ObservedGeneration = int64Ptr(in.ObservedGeneration)
+	out.ProxyId = int64Ptr(in.ProxyId)
+	out.SelfLink = stringPtr(in.SelfLink)
+}
+
+// ComputeFirewall -------------------------------------------------------------
+
+func (in *ComputeFirewall) DeepCopyInto(out *ComputeFirewall) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *ComputeFirewall) DeepCopy() *ComputeFirewall {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeFirewall)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeFirewall) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeFirewallList) DeepCopyInto(out *ComputeFirewallList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]ComputeFirewall, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+func (in *ComputeFirewallList) DeepCopy() *ComputeFirewallList {
+	if in == nil {
+		return nil
+	}
+	out := new(ComputeFirewallList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ComputeFirewallList) DeepCopyObject() runtime.Object { return in.DeepCopy() }
+
+func (in *ComputeFirewallSpec) DeepCopyInto(out *ComputeFirewallSpec) {
+	*out = *in
+	out.ResourceID = stringPtr(in.ResourceID)
+	out.Description = stringPtr(in.Description)
+	out.Disabled = boolPtr(in.Disabled)
+	out.Direction = stringPtr(in.Direction)
+	out.Priority = int64Ptr(in.Priority)
+	out.NetworkRef = *in.NetworkRef.DeepCopy()
+	out.SourceRanges = cloneStringSlice(in.SourceRanges)
+	out.DestinationRanges = cloneStringSlice(in.DestinationRanges)
+	out.SourceTags = cloneStringSlice(in.SourceTags)
+	out.TargetTags = cloneStringSlice(in.TargetTags)
+	out.SourceServiceAccounts = cloneStringSlice(in.SourceServiceAccounts)
+	out.TargetServiceAccounts = cloneStringSlice(in.TargetServiceAccounts)
+	if in.Allowed != nil {
+		out.Allowed = make([]FirewallRule, len(in.Allowed))
+		for i, r := range in.Allowed {
+			out.Allowed[i] = FirewallRule{Protocol: r.Protocol, Ports: cloneStringSlice(r.Ports)}
+		}
+	}
+	if in.Denied != nil {
+		out.Denied = make([]FirewallRule, len(in.Denied))
+		for i, r := range in.Denied {
+			out.Denied[i] = FirewallRule{Protocol: r.Protocol, Ports: cloneStringSlice(r.Ports)}
+		}
+	}
+	if in.LogConfig != nil {
+		cp := *in.LogConfig
+		cp.Metadata = stringPtr(in.LogConfig.Metadata)
+		out.LogConfig = &cp
+	}
+}
+
+func (in *ComputeFirewallStatus) DeepCopyInto(out *ComputeFirewallStatus) {
+	*out = *in
+	out.Conditions = cloneConditions(in.Conditions)
+	out.CreationTimestamp = stringPtr(in.CreationTimestamp)
+	out.ObservedGeneration = int64Ptr(in.ObservedGeneration)
+	out.SelfLink = stringPtr(in.SelfLink)
+}

--- a/cloudprovider/googlecloud/consts.go
+++ b/cloudprovider/googlecloud/consts.go
@@ -73,12 +73,12 @@ const (
 // share these so users can mix-and-match on the same GameServerSet template.
 const (
 	// Shared.
-	ConfRetainOnDelete  = "RetainOnDelete"
-	ConfProjectID       = "ProjectId"
-	ConfNetwork         = "Network"
-	ConfSubnetwork      = "Subnetwork"
-	ConfAnnotations     = "Annotations"
-	ConfAllowNotReady   = "AllowNotReadyContainers"
+	ConfRetainOnDelete = "RetainOnDelete"
+	ConfProjectID      = "ProjectId"
+	ConfNetwork        = "Network"
+	ConfSubnetwork     = "Subnetwork"
+	ConfAnnotations    = "Annotations"
+	ConfAllowNotReady  = "AllowNotReadyContainers"
 
 	// Passthrough-only.
 	ConfRegion            = "Region"
@@ -88,13 +88,13 @@ const (
 	ConfPortProtocols     = "PortProtocols"
 
 	// Proxy-only.
-	ConfPort                  = "Port" // single 1-65535
-	ConfProxyHeader           = "ProxyHeader" // NONE | PROXY_V1
-	ConfHealthCheckIntervalSec = "HealthCheckIntervalSec"
-	ConfHealthCheckTimeoutSec  = "HealthCheckTimeoutSec"
-	ConfHealthyThreshold       = "HealthyThreshold"
-	ConfUnhealthyThreshold     = "UnhealthyThreshold"
-	ConfBalancingMode          = "BalancingMode"
+	ConfPort                      = "Port"        // single 1-65535
+	ConfProxyHeader               = "ProxyHeader" // NONE | PROXY_V1
+	ConfHealthCheckIntervalSec    = "HealthCheckIntervalSec"
+	ConfHealthCheckTimeoutSec     = "HealthCheckTimeoutSec"
+	ConfHealthyThreshold          = "HealthyThreshold"
+	ConfUnhealthyThreshold        = "UnhealthyThreshold"
+	ConfBalancingMode             = "BalancingMode"
 	ConfMaxConnectionsPerEndpoint = "MaxConnectionsPerEndpoint"
 )
 

--- a/cloudprovider/googlecloud/consts.go
+++ b/cloudprovider/googlecloud/consts.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+// Constants shared by the GoogleCloud plugins.
+const (
+	// ProjectIDAnnotation is set on every KCC CR to override the default project.
+	ProjectIDAnnotation = "cnrm.cloud.google.com/project-id"
+
+	// ResourceTagKey labels resources managed by this operator so they can be
+	// listed for cleanup and informer filtering.
+	//
+	// GCP label values MUST NOT contain dots (KCC propagates K8s labels into
+	// GCP labels), so we use the dash form here while keeping the
+	// game.kruise.io semantics in the key namespace.
+	ResourceTagKey   = "managed-by"
+	ResourceTagValue = "game-kruise-io"
+
+	// SvcSelectorKey is the Pod label written by Kruise advanced StatefulSet
+	// for the per-pod identity. Services use it as their selector.
+	SvcSelectorKey = "statefulset.kubernetes.io/pod-name"
+
+	// ConfigHashKey is annotated on every K8s resource we author so we can
+	// detect drift between the live object and the desired spec hash.
+	ConfigHashKey = "game.kruise.io/network-config-hash"
+
+	// RetainFinalizer guards a KCC CR from cascade deletion when the user has
+	// asked us to retain the underlying cloud resources past Pod deletion.
+	RetainFinalizer = "game.kruise.io/google-retain"
+
+	// PodFinalizer is added to Pods when RetainOnDelete=false so we can run
+	// cleanup of KCC CRs before the Pod object is removed.
+	PodFinalizer = "game.kruise.io/google-delete-on-pod-deleted"
+
+	// GssDeletingLabelKey is set on a Pod by OnPodUpdated when its owning GSS
+	// has started deletion; OnPodDeleted reads it to decide whether to cascade
+	// delete shared resources (mirrors the alibabacloud/auto_nlbs_v2 pattern).
+	GssDeletingLabelKey = "game.kruise.io/gss-deleting"
+
+	// NEGAnnotationKey is the GKE Service annotation that triggers standalone
+	// NEG creation. Value is JSON like {"exposed_ports":{"7777":{"name":"..."}}}.
+	NEGAnnotationKey = "cloud.google.com/neg"
+
+	// NEGStatusAnnotationKey is written back by the GKE NEG controller, mapping
+	// service port to per-zone NEG names.
+	NEGStatusAnnotationKey = "cloud.google.com/neg-status"
+
+	// L4RBSAnnotationKey enables the Regional Backend Service backed Passthrough
+	// NLB for a Service. Requires GKE >= 1.32.2-gke.1652000.
+	L4RBSAnnotationKey = "cloud.google.com/l4-rbs"
+
+	// GKELoadBalancerIPAnnotationKey tells the GKE LB controller to adopt a
+	// pre-reserved IP address by name (the ComputeAddress.spec.resourceID).
+	GKELoadBalancerIPAnnotationKey = "networking.gke.io/load-balancer-ip-addresses"
+
+	// GKELoadBalancerTypeAnnotationKey switches the Service into an internal
+	// passthrough LB when set to "Internal".
+	GKELoadBalancerTypeAnnotationKey = "networking.gke.io/load-balancer-type"
+
+	// NetworkTierAnnotationKey sets PREMIUM or STANDARD on a Service.
+	NetworkTierAnnotationKey = "cloud.google.com/network-tier"
+)
+
+// Configuration parameter names used in NetworkConfParams entries. Plugins
+// share these so users can mix-and-match on the same GameServerSet template.
+const (
+	// Shared.
+	ConfRetainOnDelete  = "RetainOnDelete"
+	ConfProjectID       = "ProjectId"
+	ConfNetwork         = "Network"
+	ConfSubnetwork      = "Subnetwork"
+	ConfAnnotations     = "Annotations"
+	ConfAllowNotReady   = "AllowNotReadyContainers"
+
+	// Passthrough-only.
+	ConfRegion            = "Region"
+	ConfScheme            = "Scheme" // External | Internal
+	ConfAllowGlobalAccess = "AllowGlobalAccess"
+	ConfNetworkTier       = "NetworkTier" // PREMIUM | STANDARD
+	ConfPortProtocols     = "PortProtocols"
+
+	// Proxy-only.
+	ConfPort                  = "Port" // single 1-65535
+	ConfProxyHeader           = "ProxyHeader" // NONE | PROXY_V1
+	ConfHealthCheckIntervalSec = "HealthCheckIntervalSec"
+	ConfHealthCheckTimeoutSec  = "HealthCheckTimeoutSec"
+	ConfHealthyThreshold       = "HealthyThreshold"
+	ConfUnhealthyThreshold     = "UnhealthyThreshold"
+	ConfBalancingMode          = "BalancingMode"
+	ConfMaxConnectionsPerEndpoint = "MaxConnectionsPerEndpoint"
+)
+
+// Scheme values for ConfScheme.
+const (
+	SchemeExternal = "External"
+	SchemeInternal = "Internal"
+)
+
+// Proxy header values for TargetTcpProxy.
+const (
+	ProxyHeaderNone = "NONE"
+	ProxyHeaderV1   = "PROXY_V1"
+)
+
+// Default health check probe ranges that must be allowed to reach pod ports.
+var DefaultHealthCheckSourceRanges = []string{
+	"35.191.0.0/16",
+	"130.211.0.0/22",
+}

--- a/cloudprovider/googlecloud/coverage_branches_test.go
+++ b/cloudprovider/googlecloud/coverage_branches_test.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+// nonGamePod is a Pod with no game.kruise.io network-type annotation, so
+// NewNetworkManager returns nil and the On* hooks short-circuit.
+func nonGamePod() *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "plain", Namespace: "ns1"}}
+}
+
+func TestOnHooks_NilNetworkManager(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	ctx := context.Background()
+
+	pp := newPlugin(t)
+	if _, perr := pp.OnPodAdded(cli, nonGamePod(), ctx); perr != nil {
+		t.Errorf("passthrough OnPodAdded nil-nm: %v", perr)
+	}
+	if _, perr := pp.OnPodUpdated(cli, nonGamePod(), ctx); perr != nil {
+		t.Errorf("passthrough OnPodUpdated nil-nm: %v", perr)
+	}
+	if perr := pp.OnPodDeleted(cli, nonGamePod(), ctx); perr != nil {
+		t.Errorf("passthrough OnPodDeleted nil-nm: %v", perr)
+	}
+
+	gp := newProxyPlugin(t)
+	if _, perr := gp.OnPodAdded(cli, nonGamePod(), ctx); perr != nil {
+		t.Errorf("proxy OnPodAdded nil-nm: %v", perr)
+	}
+	if _, perr := gp.OnPodUpdated(cli, nonGamePod(), ctx); perr != nil {
+		t.Errorf("proxy OnPodUpdated nil-nm: %v", perr)
+	}
+	if perr := gp.OnPodDeleted(cli, nonGamePod(), ctx); perr != nil {
+		t.Errorf("proxy OnPodDeleted nil-nm: %v", perr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// passthrough OnPodUpdated: Internal scheme + ingress-not-assigned + errors
+// ---------------------------------------------------------------------------
+
+func TestPassthroughOnPodUpdated_InternalReady(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Scheme", "Internal"),
+		confEntry("PortProtocols", "7777/UDP"),
+	})
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "10.20.30.40")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "10.20.30.40"}}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr, svc).Build()
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated internal: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "10.20.30.40") {
+		t.Errorf("expected internal LB IP in status")
+	}
+	// Internal LB adopts the IP via spec.loadBalancerIP.
+	got := &corev1.Service{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: addrName}, got); err != nil {
+		t.Fatalf("get svc: %v", err)
+	}
+	if got.Spec.LoadBalancerIP != "10.20.30.40" {
+		t.Errorf("internal LB should set spec.loadBalancerIP, got %q", got.Spec.LoadBalancerIP)
+	}
+}
+
+func TestPassthroughOnPodUpdated_IngressNotAssigned(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.7")
+	// Service exists but no LoadBalancer ingress assigned yet -> NotReady gate.
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr, svc).Build()
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady while LB ingress unassigned")
+	}
+}
+
+func TestPassthroughOnPodDeleted_DeleteErrors(t *testing.T) {
+	scheme := testScheme(t)
+	mk := func() (*corev1.Pod, *gcpv1beta1.ComputeAddress, *corev1.Service) {
+		pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+		pod.Finalizers = []string{PodFinalizer}
+		addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+		return pod,
+			&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}
+	}
+
+	// Service delete fails.
+	pod, addr, svc := mk()
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, addr, svc).WithInterceptorFuncs(interceptor.Funcs{
+		Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+			if _, ok := obj.(*corev1.Service); ok {
+				return errors.New("boom-svc")
+			}
+			return nil
+		},
+	}).Build()
+	if perr := newPlugin(t).OnPodDeleted(cli, pod, context.Background()); perr == nil {
+		t.Errorf("expected Service delete error to surface")
+	}
+
+	// Address delete fails (Service delete succeeds).
+	pod, addr, svc = mk()
+	cli = fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, addr, svc).WithInterceptorFuncs(interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, ok := obj.(*gcpv1beta1.ComputeAddress); ok {
+				return errors.New("boom-addr")
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	}).Build()
+	if perr := newPlugin(t).OnPodDeleted(cli, pod, context.Background()); perr == nil {
+		t.Errorf("expected Address delete error to surface")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// passthrough ensureService variants
+// ---------------------------------------------------------------------------
+
+func TestPassthroughEnsureService_DisabledAndInternalIP(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newPlugin(t)
+	pod := newGamePod("gs-0", "ns1", nil)
+
+	// disabled=true -> ClusterIP, no loadBalancerIP.
+	extCfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+		confEntry("Annotations", "k=v"),
+	})
+	svc, err := p.ensureService(context.Background(), cli, pod, extCfg, "svc-dis", "addr", "", true, nil)
+	if err != nil {
+		t.Fatalf("ensureService disabled: %v", err)
+	}
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP || svc.Spec.LoadBalancerIP != "" {
+		t.Errorf("disabled should be ClusterIP with no LB IP: %+v", svc.Spec)
+	}
+	if svc.Annotations["k"] != "v" {
+		t.Errorf("user annotation not layered: %v", svc.Annotations)
+	}
+
+	// Internal + addrIPValue -> spec.loadBalancerIP set.
+	intCfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Scheme", "Internal"),
+		confEntry("PortProtocols", "7777/UDP"),
+	})
+	svc2, err := p.ensureService(context.Background(), cli, pod, intCfg, "svc-int", "addr", "10.9.8.7", false, nil)
+	if err != nil {
+		t.Fatalf("ensureService internal: %v", err)
+	}
+	if svc2.Spec.LoadBalancerIP != "10.9.8.7" {
+		t.Errorf("internal LB should adopt IP via loadBalancerIP, got %q", svc2.Spec.LoadBalancerIP)
+	}
+}
+
+func TestPassthroughEnsureService_CreateError(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+			return errors.New("boom")
+		},
+	}).Build()
+	p := newPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	if _, err := p.ensureService(context.Background(), cli, newGamePod("gs-0", "ns1", nil), cfg, "svc", "addr", "", false, nil); err == nil {
+		t.Errorf("expected create error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// proxy OnPodUpdated remaining branches
+// ---------------------------------------------------------------------------
+
+func TestProxyOnPodUpdated_NetworkStatusUnmarshalError(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	pod.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus] = "{bad"
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	if _, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected unmarshal error")
+	}
+}
+
+func TestProxyOnPodUpdated_GssDeletingFlagsPod(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	now := metav1.Now()
+	gss.DeletionTimestamp = &now
+	gss.Finalizers = []string{"x"}
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod).Build()
+	out, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if out.Labels[GssDeletingLabelKey] != "true" {
+		t.Errorf("expected gss-deleting label")
+	}
+}
+
+func TestProxyOnPodUpdated_KCCNotReady(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	svcName := DeriveServiceName(pod.Name, proxySuffix)
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: svcName, Namespace: "ns1",
+		Annotations: map[string]string{
+			NEGStatusAnnotationKey: `{"network_endpoint_groups":{"7777":"neg-7777"},"zones":["us-central1-a"]}`,
+		},
+	}}
+	// neg-status present so the KCC graph is created, but nothing is pre-seeded
+	// Ready -> checkReady false -> NotReady (covers the not-ready return path).
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, svc).Build()
+	out, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady while KCC graph settling")
+	}
+}
+
+func TestProxyOnPodUpdated_EnsureErrorsPerKind(t *testing.T) {
+	scheme := testScheme(t)
+	failKinds := []struct {
+		name string
+		obj  client.Object
+	}{
+		{"BES", &gcpv1beta1.ComputeBackendService{}},
+		{"TP", &gcpv1beta1.ComputeTargetTCPProxy{}},
+		{"Addr", &gcpv1beta1.ComputeAddress{}},
+		{"FR", &gcpv1beta1.ComputeForwardingRule{}},
+		{"FW", &gcpv1beta1.ComputeFirewall{}},
+	}
+	for _, fk := range failKinds {
+		fk := fk
+		t.Run(fk.name, func(t *testing.T) {
+			gss := gssForTest("gs", "ns1", "u1", 3)
+			pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+			svcName := DeriveServiceName(pod.Name, proxySuffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+				Name: svcName, Namespace: "ns1",
+				Annotations: map[string]string{
+					NEGStatusAnnotationKey: `{"network_endpoint_groups":{"7777":"neg-7777"},"zones":["us-central1-a"]}`,
+				},
+			}}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, svc).WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if sameKind(obj, fk.obj) {
+						return errors.New("boom-" + fk.name)
+					}
+					return c.Create(ctx, obj, opts...)
+				},
+			}).Build()
+			if _, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+				t.Fatalf("expected ensure error for %s", fk.name)
+			}
+		})
+	}
+}
+
+func sameKind(a, b client.Object) bool {
+	switch a.(type) {
+	case *gcpv1beta1.ComputeBackendService:
+		_, ok := b.(*gcpv1beta1.ComputeBackendService)
+		return ok
+	case *gcpv1beta1.ComputeTargetTCPProxy:
+		_, ok := b.(*gcpv1beta1.ComputeTargetTCPProxy)
+		return ok
+	case *gcpv1beta1.ComputeAddress:
+		_, ok := b.(*gcpv1beta1.ComputeAddress)
+		return ok
+	case *gcpv1beta1.ComputeForwardingRule:
+		_, ok := b.(*gcpv1beta1.ComputeForwardingRule)
+		return ok
+	case *gcpv1beta1.ComputeFirewall:
+		_, ok := b.(*gcpv1beta1.ComputeFirewall)
+		return ok
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// proxy ensureService / ensureFirewall small branches
+// ---------------------------------------------------------------------------
+
+func TestProxyEnsureService_UserAnnotationsAndCreateError(t *testing.T) {
+	scheme := testScheme(t)
+	p := newProxyPlugin(t)
+	pod := newGamePod("gs-0", "ns1", nil)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+		confEntry("Annotations", "k=v"),
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	svc, err := p.ensureService(context.Background(), cli, pod, cfg, "svc", pod.UID, 0, nil)
+	if err != nil {
+		t.Fatalf("ensureService: %v", err)
+	}
+	if svc.Annotations["k"] != "v" {
+		t.Errorf("user annotation not applied: %v", svc.Annotations)
+	}
+
+	errCli := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+			return errors.New("boom")
+		},
+	}).Build()
+	if _, err := p.ensureService(context.Background(), errCli, pod, cfg, "svc2", pod.UID, 0, nil); err == nil {
+		t.Errorf("expected create error")
+	}
+}
+
+func TestProxyEnsureFirewall_ProjectFallback(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newProxyPlugin(t)
+	p.projectID = "" // force the cfg.ProjectID=="" -> p.projectID fallback branch
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+		confEntry("Network", "vpc-fallback"),
+	})
+	if cfg.ProjectID != "" {
+		t.Fatalf("precondition: cfg.ProjectID should be empty, got %q", cfg.ProjectID)
+	}
+	if err := p.ensureFirewall(context.Background(), cli, newGamePod("gs-0", "ns1", nil), cfg, "fw", nil); err != nil {
+		t.Fatalf("ensureFirewall: %v", err)
+	}
+	fw := &gcpv1beta1.ComputeFirewall{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "fw"}, fw); err != nil {
+		t.Fatalf("get fw: %v", err)
+	}
+	if !strings.Contains(fw.Spec.NetworkRef.External, "vpc-fallback") {
+		t.Errorf("expected network selflink with vpc-fallback, got %q", fw.Spec.NetworkRef.External)
+	}
+}
+
+func TestProxyOnPodDeleted_DeleteError(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 1) // ordinal 0 >= replicas 1 -> release path
+	pod := newGamePod("gs-1", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	pod.Finalizers = []string{PodFinalizer}
+	frName := DeriveStableResourceID(gss.UID, 1, "gpnlb-fr")
+	fr := &gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: frName, Namespace: "ns1"}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, fr).WithInterceptorFuncs(interceptor.Funcs{
+		Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+			if _, ok := obj.(*gcpv1beta1.ComputeForwardingRule); ok {
+				return errors.New("boom-fr")
+			}
+			return nil
+		},
+	}).Build()
+	if perr := newProxyPlugin(t).OnPodDeleted(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected delete error to surface")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extra parseConfig error branches
+// ---------------------------------------------------------------------------
+
+func TestProxyParseConfig_NonNumericAndUtilization(t *testing.T) {
+	p := newProxyPlugin(t)
+	if _, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"), confEntry("MaxConnectionsPerEndpoint", "x"),
+	}); err == nil {
+		t.Errorf("expected non-numeric MaxConnectionsPerEndpoint error")
+	}
+	cfg, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"), confEntry("BalancingMode", "UTILIZATION"),
+	})
+	if err != nil || cfg.BalancingMode != "UTILIZATION" {
+		t.Errorf("UTILIZATION should be valid, got cfg=%+v err=%v", cfg, err)
+	}
+}

--- a/cloudprovider/googlecloud/coverage_errors_test.go
+++ b/cloudprovider/googlecloud/coverage_errors_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+// ---------------------------------------------------------------------------
+// kccClient: apiClient-populated branch (both plugins)
+// ---------------------------------------------------------------------------
+
+func TestKccClient_PrefersAPIClient(t *testing.T) {
+	apiCli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	fallback := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	pp := newPlugin(t)
+	pp.apiClient = apiCli
+	if pp.kccClient(fallback) != apiCli {
+		t.Errorf("passthrough kccClient should return apiClient when set")
+	}
+
+	gp := newProxyPlugin(t)
+	gp.apiClient = apiCli
+	if gp.kccClient(fallback) != apiCli {
+		t.Errorf("proxy kccClient should return apiClient when set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// finalizer multi-element removal
+// ---------------------------------------------------------------------------
+
+func TestRemoveFinalizer_KeepsOthers(t *testing.T) {
+	got := removeFinalizer([]string{"a", PodFinalizer, "b"}, PodFinalizer)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("expected [a b], got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OnPodAdded parse-error branches
+// ---------------------------------------------------------------------------
+
+func TestOnPodAdded_ParseError(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pPod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "bad")})
+	if _, perr := newPlugin(t).OnPodAdded(cli, pPod, context.Background()); perr == nil {
+		t.Errorf("passthrough OnPodAdded: expected parse error")
+	}
+
+	gPod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "bad")})
+	if _, perr := newProxyPlugin(t).OnPodAdded(cli, gPod, context.Background()); perr == nil {
+		t.Errorf("proxy OnPodAdded: expected parse error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnsureComputeAddress: default EXTERNAL/PREMIUM + create error
+// ---------------------------------------------------------------------------
+
+func TestEnsureComputeAddress_DefaultsExternalPremium(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	if _, err := EnsureComputeAddress(context.Background(), cli, AddressSpec{
+		Name: "a", Namespace: "ns1", Location: "us-central1", // AddressType + NetworkTier empty
+	}); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	got := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "a"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.AddressType == nil || *got.Spec.AddressType != "EXTERNAL" {
+		t.Errorf("default AddressType should be EXTERNAL, got %+v", got.Spec.AddressType)
+	}
+	if got.Spec.NetworkTier == nil || *got.Spec.NetworkTier != "PREMIUM" {
+		t.Errorf("default NetworkTier should be PREMIUM, got %+v", got.Spec.NetworkTier)
+	}
+}
+
+func TestEnsureComputeAddress_CreateError(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+			return errors.New("boom-create")
+		},
+	}).Build()
+	if _, err := EnsureComputeAddress(context.Background(), cli, AddressSpec{
+		Name: "a", Namespace: "ns1", Location: "us-central1", AddressType: "EXTERNAL",
+	}); err == nil {
+		t.Fatalf("expected create error to surface")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WaitForAddressReady: non-NotFound Get error
+// ---------------------------------------------------------------------------
+
+func TestWaitForAddressReady_GetError(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return errors.New("boom-get")
+		},
+	}).Build()
+	if _, _, err := WaitForAddressReady(context.Background(), cli, types.NamespacedName{Namespace: "ns1", Name: "x"}); err == nil {
+		t.Fatalf("expected get error to surface")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RemovePodFinalizerPlugin: Update error path
+// ---------------------------------------------------------------------------
+
+func TestRemovePodFinalizerPlugin_UpdateError(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns1", Finalizers: []string{PodFinalizer}}}
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(pod).WithInterceptorFuncs(interceptor.Funcs{
+		Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+			return errors.New("boom-update")
+		},
+	}).Build()
+	if perr := RemovePodFinalizerPlugin(context.Background(), cli, pod); perr == nil {
+		t.Fatalf("expected update error to surface as PluginError")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// passthrough OnPodUpdated: remaining branches
+// ---------------------------------------------------------------------------
+
+func TestPassthroughOnPodUpdated_NetworkStatusUnmarshalError(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	pod.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus] = "{not-json"
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	if _, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected unmarshal error to surface")
+	}
+}
+
+func TestPassthroughOnPodUpdated_GssNotFound_StillReady(t *testing.T) {
+	scheme := testScheme(t)
+	// No GameServerSet object -> gssErr != nil; owner refs dropped but reconcile
+	// proceeds and still reaches Ready when addr + svc are healthy.
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.5")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.5"}}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, addr, svc).Build()
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "203.0.113.5") {
+		t.Errorf("expected Ready with IP even without GSS, got %q", out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus])
+	}
+}
+
+func TestPassthroughOnPodUpdated_AllowNotReadyContainers(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	// A realistic GSS carries a Network spec; AllowNotReadyContainers reads it.
+	gss.Spec.Network = &gamekruiseiov1alpha1.Network{
+		NetworkType: PassthroughNlbNetwork,
+		NetworkConf: []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("AllowNotReadyContainers", "true"),
+		},
+	}
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+		confEntry("AllowNotReadyContainers", "true"),
+	})
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.6")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.6"}}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr, svc).Build()
+	if _, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodUpdated with AllowNotReadyContainers: %v", perr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// proxy OnPodUpdated: remaining branches
+// ---------------------------------------------------------------------------
+
+func TestProxyOnPodUpdated_NEGParseError(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	svcName := DeriveServiceName(pod.Name, proxySuffix)
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: svcName, Namespace: "ns1",
+		Annotations: map[string]string{NEGStatusAnnotationKey: "{bad-json"},
+	}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, svc).Build()
+	if _, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected NEG parse error")
+	}
+}
+
+func TestProxyOnPodUpdated_EnsureError(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	svcName := DeriveServiceName(pod.Name, proxySuffix)
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: svcName, Namespace: "ns1",
+		Annotations: map[string]string{
+			NEGStatusAnnotationKey: `{"network_endpoint_groups":{"7777":"neg-7777"},"zones":["us-central1-a"]}`,
+		},
+	}}
+	// Fail creation of the HealthCheck (first KCC object) -> ensureHealthCheck errors.
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, svc).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*gcpv1beta1.ComputeHealthCheck); ok {
+				return errors.New("boom-hc")
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	}).Build()
+	if _, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected ensureHealthCheck error to surface")
+	}
+}
+
+func TestProxyOnPodUpdated_GssNotFound_NotReady(t *testing.T) {
+	scheme := testScheme(t)
+	// No GSS -> gssErr != nil branch; reconcile proceeds, Service created, no
+	// neg-status yet -> NotReady (covers the gssErr!=nil owner-skip path).
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	out, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkReady: get-error gates for BES / TP / FW / FR
+// ---------------------------------------------------------------------------
+
+func TestCheckReady_GetErrorGates(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", nil)
+	uid := pod.UID
+	hc := DeriveResourceID(uid, "hc")
+	bes := DeriveResourceID(uid, "bes")
+	tp := DeriveResourceID(uid, "tp")
+	addr := DeriveResourceID(uid, "addr")
+	fr := DeriveResourceID(uid, "fr")
+	fw := DeriveResourceID(uid, "fw")
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+
+	readyHC := func() client.Object {
+		return withReady(&gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: hc, Namespace: "ns1"}})
+	}
+	readyBES := func() client.Object {
+		return withReady(&gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: bes, Namespace: "ns1"}})
+	}
+	readyTP := func() client.Object {
+		return withReady(&gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: tp, Namespace: "ns1"}})
+	}
+	readyFW := func() client.Object {
+		return withReady(&gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: fw, Namespace: "ns1"}})
+	}
+
+	cases := []struct {
+		name string
+		objs []client.Object
+		want string
+	}{
+		{"get BES", []client.Object{readyHC()}, "get BES"},
+		{"get TP", []client.Object{readyHC(), readyBES()}, "get TargetTcpProxy"},
+		{"get FW", []client.Object{readyHC(), readyBES(), readyTP()}, "get FW"},
+		{"get FR", []client.Object{readyHC(), readyBES(), readyTP(), readyFW()}, "get FR"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objs...).Build()
+			ready, _, msg := p.checkReady(context.Background(), cli, pod, cfg, hc, bes, tp, addr, fr, fw)
+			if ready || !strings.Contains(msg, tc.want) {
+				t.Fatalf("want msg %q, got ready=%v msg=%q", tc.want, ready, msg)
+			}
+		})
+	}
+}

--- a/cloudprovider/googlecloud/coverage_final_test.go
+++ b/cloudprovider/googlecloud/coverage_final_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+// ---------------------------------------------------------------------------
+// parseConfig: empty trailing-segment "continue" branches
+// ---------------------------------------------------------------------------
+
+func TestParseConfig_TrailingCommaSegments(t *testing.T) {
+	// Passthrough: trailing comma in PortProtocols and Annotations -> empty
+	// segment skipped via continue.
+	pc, err := newPlugin(t).parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP,"),
+		confEntry("Annotations", "k=v,"),
+	})
+	if err != nil || len(pc.TargetPorts) != 1 || pc.Annotations["k"] != "v" {
+		t.Fatalf("passthrough trailing-comma parse wrong: cfg=%+v err=%v", pc, err)
+	}
+
+	// Proxy: trailing comma in Annotations -> empty segment skipped.
+	gc, err := newProxyPlugin(t).parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+		confEntry("Annotations", "k=v,"),
+	})
+	if err != nil || gc.Annotations["k"] != "v" {
+		t.Fatalf("proxy trailing-comma parse wrong: cfg=%+v err=%v", gc, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// proxy OnPodUpdated: parseConfig error + ensureService error
+// ---------------------------------------------------------------------------
+
+func TestProxyOnPodUpdated_ParseError(t *testing.T) {
+	scheme := testScheme(t)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "bad")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	if _, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+func TestProxyOnPodUpdated_EnsureServiceError(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+			if _, ok := obj.(*corev1.Service); ok {
+				return errors.New("boom-svc")
+			}
+			return nil
+		},
+	}).Build()
+	if _, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected ensureService error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// passthrough OnPodUpdated: EnsureComputeAddress error + ensureService error
+// + AllowNotReadyContainers GSS-resolution error
+// ---------------------------------------------------------------------------
+
+func TestPassthroughOnPodUpdated_EnsureAddressError(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+			if _, ok := obj.(*gcpv1beta1.ComputeAddress); ok {
+				return errors.New("boom-addr")
+			}
+			return nil
+		},
+	}).Build()
+	if _, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected EnsureComputeAddress error")
+	}
+}
+
+func TestPassthroughOnPodUpdated_EnsureServiceError(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	// Pre-seed a Ready address so EnsureComputeAddress takes the update path and
+	// WaitForAddressReady succeeds; then fail the Service create at ensureService.
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.8")
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*corev1.Service); ok {
+				return errors.New("boom-svc")
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	}).Build()
+	if _, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected ensureService error")
+	}
+}
+
+func TestPassthroughOnPodUpdated_AllowNotReadyGssError(t *testing.T) {
+	scheme := testScheme(t)
+	// No GSS object -> AllowNotReadyContainers' GetGameServerSetOfPod errors,
+	// surfaced as a PluginError (covers the perr!=nil branch).
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+		confEntry("AllowNotReadyContainers", "true"),
+	})
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.9")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.9"}}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, addr, svc).Build()
+	if _, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected AllowNotReadyContainers GSS-resolution error to surface")
+	} else if !strings.Contains(strings.ToLower(perr.Error()), "not found") {
+		t.Logf("note: surfaced error = %v", perr.Error())
+	}
+}

--- a/cloudprovider/googlecloud/coverage_last_test.go
+++ b/cloudprovider/googlecloud/coverage_last_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"testing"
+
+	kruisePub "github.com/openkruise/kruise-api/apps/pub"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+	provideroptions "github.com/openkruise/kruise-game/cloudprovider/options"
+)
+
+// VerifyKCCInstalled: group present but one required kind missing -> the
+// "CRDs missing" error branch (install only five of the six CRDs).
+func TestVerifyKCCInstalled_EnvtestMissingOneKind(t *testing.T) {
+	cfg := startEnvtest(t)
+	all := kccComputeCRDs()
+	partial := all[:len(all)-1] // drop ComputeFirewall
+	if _, err := installPartial(t, cfg, partial); err != nil {
+		t.Fatalf("install partial CRDs: %v", err)
+	}
+	err := VerifyKCCInstalled(cfg)
+	if err == nil {
+		t.Fatalf("expected missing-kind error when one CRD is absent")
+	}
+}
+
+// Init returns the VerifyKCCInstalled error when KCC is absent (no CRDs).
+func TestInit_EnvtestVerifyError(t *testing.T) {
+	cfg := startEnvtest(t)
+	writeKubeconfig(t, cfg)
+	opts := provideroptions.GoogleCloudOptions{
+		Enable: true, ProjectID: "demo-project",
+		PassthroughNLB: provideroptions.PassthroughNLBOptions{Enable: true},
+		GlobalProxyNLB: provideroptions.GlobalProxyNLBOptions{Enable: true},
+	}
+	c := newEnvtestClient(t, cfg)
+	if err := (&PassthroughNlbPlugin{}).Init(c, opts, context.Background()); err == nil {
+		t.Errorf("passthrough Init should fail when KCC CRDs absent")
+	}
+	if err := (&GlobalProxyNlbPlugin{}).Init(c, opts, context.Background()); err == nil {
+		t.Errorf("proxy Init should fail when KCC CRDs absent")
+	}
+}
+
+// passthrough OnPodUpdated: AllowNotReadyContainers flips PublishNotReadyAddresses
+// during a PreparingUpdate, so the plugin persists the Service (changed=true ->
+// c.Update path).
+func TestPassthroughOnPodUpdated_AllowNotReadyChanged(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	gss.Spec.Network = &gamekruiseiov1alpha1.Network{
+		NetworkConf: []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry(gamekruiseiov1alpha1.AllowNotReadyContainersNetworkConfName, "game"),
+		},
+	}
+	gss.Spec.GameServerTemplate.Spec.Containers = []corev1.Container{{Name: "game", Image: "img:v2"}}
+
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+		confEntry("AllowNotReadyContainers", "true"),
+	})
+	// PreparingUpdate + a container whose running image differs from the template
+	// makes IsContainersPreInplaceUpdating true.
+	pod.Labels[kruisePub.LifecycleStateKey] = string(kruisePub.LifecycleStatePreparingUpdate)
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "game", Image: "img:v1"}}
+
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.11")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.11"}}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr, svc).Build()
+	if _, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	// The Service must have been re-persisted with PublishNotReadyAddresses=true.
+	got := &corev1.Service{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: addrName}, got); err != nil {
+		t.Fatalf("get svc: %v", err)
+	}
+	if !got.Spec.PublishNotReadyAddresses {
+		t.Errorf("expected PublishNotReadyAddresses=true after AllowNotReadyContainers update")
+	}
+}

--- a/cloudprovider/googlecloud/coverage_test.go
+++ b/cloudprovider/googlecloud/coverage_test.go
@@ -1,0 +1,828 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/cloudprovider"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+	provideroptions "github.com/openkruise/kruise-game/cloudprovider/options"
+)
+
+// ---------------------------------------------------------------------------
+// provider registry (googlecloud.go)
+// ---------------------------------------------------------------------------
+
+func TestProvider_NameAndListPlugins(t *testing.T) {
+	cp, err := NewGoogleCloudProvider()
+	if err != nil {
+		t.Fatalf("NewGoogleCloudProvider: %v", err)
+	}
+	if cp.Name() != GoogleCloud {
+		t.Errorf("Name: want %q, got %q", GoogleCloud, cp.Name())
+	}
+	plugins, err := cp.ListPlugins()
+	if err != nil {
+		t.Fatalf("ListPlugins: %v", err)
+	}
+	// Both plugins register themselves via init().
+	if _, ok := plugins[PassthroughNlbNetwork]; !ok {
+		t.Errorf("PassthroughNLB plugin not registered: %v", keys(plugins))
+	}
+	if _, ok := plugins[GlobalProxyNlbNetwork]; !ok {
+		t.Errorf("GlobalProxyNLB plugin not registered: %v", keys(plugins))
+	}
+}
+
+func TestProvider_ListPluginsNilMap(t *testing.T) {
+	p := &Provider{} // plugins == nil
+	got, err := p.ListPlugins()
+	if err != nil || got == nil || len(got) != 0 {
+		t.Fatalf("want empty non-nil map, got (%v, %v)", got, err)
+	}
+}
+
+func keys(m map[string]cloudprovider.Plugin) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Alias + Init early branches (both plugins)
+// ---------------------------------------------------------------------------
+
+func TestAlias_BothPlugins(t *testing.T) {
+	if (&PassthroughNlbPlugin{}).Alias() != AliasPassthroughNlb {
+		t.Errorf("passthrough alias wrong")
+	}
+	if (&GlobalProxyNlbPlugin{}).Alias() != AliasGlobalProxyNlb {
+		t.Errorf("proxy alias wrong")
+	}
+}
+
+// notGCPOptions is a stand-in CloudProviderOptions of the wrong concrete type,
+// used to exercise the type-assertion guard in Init.
+type notGCPOptions struct{}
+
+func (notGCPOptions) Enabled() bool { return true }
+func (notGCPOptions) Valid() bool   { return true }
+
+func TestInit_WrongOptionType(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	if err := (&PassthroughNlbPlugin{}).Init(cli, notGCPOptions{}, context.Background()); err == nil {
+		t.Errorf("passthrough Init: expected type-mismatch error")
+	}
+	if err := (&GlobalProxyNlbPlugin{}).Init(cli, notGCPOptions{}, context.Background()); err == nil {
+		t.Errorf("proxy Init: expected type-mismatch error")
+	}
+}
+
+func TestInit_DisabledIsNoop(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	// PassthroughNLB.Enable defaults to false -> Init returns nil without touching
+	// the cluster (never reaches GetConfigOrDie/VerifyKCCInstalled).
+	if err := (&PassthroughNlbPlugin{}).Init(cli, provideroptions.GoogleCloudOptions{}, context.Background()); err != nil {
+		t.Errorf("passthrough disabled Init: want nil, got %v", err)
+	}
+	if err := (&GlobalProxyNlbPlugin{}).Init(cli, provideroptions.GoogleCloudOptions{}, context.Background()); err != nil {
+		t.Errorf("proxy disabled Init: want nil, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// prereq.go
+// ---------------------------------------------------------------------------
+
+func TestVerifyKCCInstalled_NilConfig(t *testing.T) {
+	if err := VerifyKCCInstalled(nil); err == nil {
+		t.Fatalf("expected error for nil rest.Config")
+	}
+}
+
+func TestNotInstalledError_MentionsGcloud(t *testing.T) {
+	err := notInstalledError()
+	if err == nil || !strings.Contains(err.Error(), "ConfigConnector=ENABLED") {
+		t.Fatalf("notInstalledError missing remediation text: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// readiness.go
+// ---------------------------------------------------------------------------
+
+func TestIsKCCReady_Branches(t *testing.T) {
+	ready := []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}}
+	if IsKCCReady(ready, 1, 2) {
+		t.Errorf("stale observedGeneration should not be Ready")
+	}
+	if !IsKCCReady(ready, 2, 2) {
+		t.Errorf("caught-up Ready=True should be Ready")
+	}
+	if IsKCCReady([]gcpv1beta1.Condition{{Type: "Ready", Status: "False"}}, 1, 1) {
+		t.Errorf("Ready=False should not be Ready")
+	}
+	if IsKCCReady(nil, 1, 1) {
+		t.Errorf("no conditions should not be Ready")
+	}
+}
+
+func TestCondReasonAndMessage(t *testing.T) {
+	conds := []gcpv1beta1.Condition{{Type: "Ready", Status: "False", Reason: "Pending", Message: "creating"}}
+	if CondReason(conds) != "Pending" {
+		t.Errorf("CondReason: got %q", CondReason(conds))
+	}
+	if CondMessage(conds) != "creating" {
+		t.Errorf("CondMessage: got %q", CondMessage(conds))
+	}
+	// Absent Ready condition -> empty strings.
+	if CondReason(nil) != "" || CondMessage(nil) != "" {
+		t.Errorf("expected empty reason/message for nil conditions")
+	}
+}
+
+func TestDerefInt64(t *testing.T) {
+	if derefInt64(nil) != 0 {
+		t.Errorf("nil -> 0")
+	}
+	v := int64(7)
+	if derefInt64(&v) != 7 {
+		t.Errorf("deref wrong")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// naming.go (truncation + sanitize edge cases)
+// ---------------------------------------------------------------------------
+
+func TestNaming_TruncationAndSanitize(t *testing.T) {
+	longSuffix := strings.Repeat("abcdefgh", 12) // 96 chars, forces >63 truncation
+	if got := DeriveResourceID(types.UID("u1"), longSuffix); len(got) > 63 {
+		t.Errorf("DeriveResourceID not capped: %d", len(got))
+	}
+	if got := DeriveStableResourceID(types.UID("u1"), 0, longSuffix); len(got) > 63 {
+		t.Errorf("DeriveStableResourceID not capped: %d", len(got))
+	}
+	// sanitizeSuffix collapses an all-invalid suffix to the "x" placeholder.
+	if got := DeriveResourceID(types.UID("u1"), "***"); !strings.Contains(got, "-x-") {
+		t.Errorf("expected placeholder suffix, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ownership.go
+// ---------------------------------------------------------------------------
+
+func TestGssOwnerRef(t *testing.T) {
+	gss := gssForTest("gs", "ns1", "u-123", 3)
+	gss.APIVersion = "game.kruise.io/v1alpha1"
+	gss.Kind = "GameServerSet"
+	ref := gssOwnerRef(gss)
+	if ref.UID != "u-123" || ref.Name != "gs" || ref.Controller == nil || !*ref.Controller {
+		t.Fatalf("owner ref wrong: %+v", ref)
+	}
+}
+
+func TestShouldReleaseSlot_NilReplicas(t *testing.T) {
+	gss := &gamekruiseiov1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs", Namespace: "ns1", UID: "u1"},
+	} // Spec.Replicas == nil
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(gss).Build()
+	if shouldReleaseSlot(context.Background(), cli, "ns1", "gs", "gs-0") {
+		t.Fatalf("nil replicas should preserve (return false)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// address.go (uncovered branches)
+// ---------------------------------------------------------------------------
+
+func TestEnsureComputeAddress_LocationRequired(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	if _, err := EnsureComputeAddress(context.Background(), cli, AddressSpec{Name: "a", Namespace: "ns1"}); err == nil {
+		t.Fatalf("expected error when Location empty")
+	}
+}
+
+func TestEnsureComputeAddress_InternalSubnetwork(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	_, err := EnsureComputeAddress(context.Background(), cli, AddressSpec{
+		Name:          "ia",
+		Namespace:     "ns1",
+		Location:      "us-central1",
+		AddressType:   "INTERNAL",
+		ProjectID:     "proj-1",
+		SubnetworkRef: "sub-1",
+	})
+	if err != nil {
+		t.Fatalf("ensure internal: %v", err)
+	}
+	got := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "ia"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.NetworkTier != nil {
+		t.Errorf("INTERNAL address must not set NetworkTier")
+	}
+	if got.Spec.SubnetworkRef == nil || got.Spec.SubnetworkRef.External == "" {
+		t.Errorf("expected subnetwork selfLink, got %+v", got.Spec.SubnetworkRef)
+	}
+	if got.Spec.NetworkRef != nil {
+		t.Errorf("subnetwork-anchored INTERNAL address must not also set NetworkRef")
+	}
+}
+
+func TestEnsureComputeAddress_InternalNetworkOnly(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	_, err := EnsureComputeAddress(context.Background(), cli, AddressSpec{
+		Name:        "ia2",
+		Namespace:   "ns1",
+		Location:    "us-central1",
+		AddressType: "INTERNAL",
+		ProjectID:   "proj-1",
+		NetworkRef:  "vpc-1",
+	})
+	if err != nil {
+		t.Fatalf("ensure internal net-only: %v", err)
+	}
+	got := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "ia2"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.NetworkRef == nil || got.Spec.NetworkRef.External == "" {
+		t.Errorf("expected network selfLink, got %+v", got.Spec.NetworkRef)
+	}
+}
+
+func TestNetworkRefOrSelfLink_Fallbacks(t *testing.T) {
+	// No projectID -> bare Name form.
+	if r := networkRefOrSelfLink("", "vpc", "global/networks"); r.Name != "vpc" || r.External != "" {
+		t.Errorf("empty project should fall back to Name: %+v", r)
+	}
+	// Name already a path -> bare Name form.
+	if r := networkRefOrSelfLink("proj", "projects/x/global/networks/vpc", "global/networks"); r.External != "" {
+		t.Errorf("path-like name should fall back to Name: %+v", r)
+	}
+	// Normal -> External selfLink.
+	if r := networkRefOrSelfLink("proj", "vpc", "global/networks"); r.External != "projects/proj/global/networks/vpc" {
+		t.Errorf("selfLink wrong: %+v", r)
+	}
+}
+
+func TestSubnetRefOrSelfLink_Fallbacks(t *testing.T) {
+	if r := subnetRefOrSelfLink("", "us-central1", "sub"); r.Name != "sub" || r.External != "" {
+		t.Errorf("empty project fallback: %+v", r)
+	}
+	if r := subnetRefOrSelfLink("proj", "", "sub"); r.Name != "sub" {
+		t.Errorf("empty location fallback: %+v", r)
+	}
+	if r := subnetRefOrSelfLink("proj", "us-central1", "sub"); r.External != "projects/proj/regions/us-central1/subnetworks/sub" {
+		t.Errorf("subnet selfLink wrong: %+v", r)
+	}
+}
+
+func TestWaitForAddressReady_NotFoundAndNoState(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	// Absent object -> ("", false, nil).
+	ip, ready, err := WaitForAddressReady(context.Background(), cli, types.NamespacedName{Namespace: "ns1", Name: "missing"})
+	if ip != "" || ready || err != nil {
+		t.Fatalf("missing addr: want ('',false,nil), got (%q,%v,%v)", ip, ready, err)
+	}
+
+	// Ready=True but ObservedState nil -> ("", false, nil).
+	addr := &gcpv1beta1.ComputeAddress{
+		ObjectMeta: metav1.ObjectMeta{Name: "noip", Namespace: "ns1", Generation: 1},
+		Status: gcpv1beta1.ComputeAddressStatus{
+			ObservedGeneration: int64Ptr2(1),
+			Conditions:         []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}},
+		},
+	}
+	cli2 := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(addr).Build()
+	ip, ready, err = WaitForAddressReady(context.Background(), cli2, types.NamespacedName{Namespace: "ns1", Name: "noip"})
+	if ip != "" || ready || err != nil {
+		t.Fatalf("ready-but-no-IP: want ('',false,nil), got (%q,%v,%v)", ip, ready, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// finalizer.go (already-present branch)
+// ---------------------------------------------------------------------------
+
+func TestEnsurePodFinalizer_AlreadyPresent(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{PodFinalizer}}}
+	if EnsurePodFinalizer(pod, PodFinalizer) {
+		t.Fatalf("expected no mutation when finalizer already present")
+	}
+}
+
+func TestRemovePodFinalizer_Absent(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns1"}}
+	if err := RemovePodFinalizer(context.Background(), cli, pod, PodFinalizer); err != nil {
+		t.Fatalf("removing an absent finalizer should be a no-op, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// neg_watcher.go (error branches)
+// ---------------------------------------------------------------------------
+
+func TestParseNEGStatusAnnotation_Errors(t *testing.T) {
+	bad := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "s", Namespace: "ns1",
+		Annotations: map[string]string{NEGStatusAnnotationKey: "{not-json"},
+	}}
+	if _, err := ParseNEGStatusAnnotation(bad); err == nil {
+		t.Errorf("expected JSON parse error")
+	}
+
+	badPort := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "s", Namespace: "ns1",
+		Annotations: map[string]string{
+			NEGStatusAnnotationKey: `{"network_endpoint_groups":{"notaport":"neg"},"zones":["z1"]}`,
+		},
+	}}
+	if _, err := ParseNEGStatusAnnotation(badPort); err == nil {
+		t.Errorf("expected invalid-port error")
+	}
+
+	// Present groups but no zones -> (nil, nil).
+	noZones := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "s", Namespace: "ns1",
+		Annotations: map[string]string{
+			NEGStatusAnnotationKey: `{"network_endpoint_groups":{"7777":"neg"},"zones":[]}`,
+		},
+	}}
+	got, err := ParseNEGStatusAnnotation(noZones)
+	if err != nil || got != nil {
+		t.Errorf("empty zones: want (nil,nil), got (%v,%v)", got, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// proxy parseConfig: all override + error branches
+// ---------------------------------------------------------------------------
+
+func TestProxyParseConfig_AllFields(t *testing.T) {
+	p := newProxyPlugin(t)
+	cfg, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("ProjectId", "proj-x"),
+		confEntry("Network", "vpc-x"),
+		confEntry("Port", "9000"),
+		confEntry("ProxyHeader", "PROXY_V1"),
+		confEntry("HealthCheckIntervalSec", "10"),
+		confEntry("HealthCheckTimeoutSec", "8"),
+		confEntry("HealthyThreshold", "3"),
+		confEntry("UnhealthyThreshold", "4"),
+		confEntry("BalancingMode", "RATE"),
+		confEntry("MaxConnectionsPerEndpoint", "500"),
+		confEntry("Annotations", "a=b"),
+		confEntry("RetainOnDelete", "true"),
+	})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.ProjectID != "proj-x" || cfg.Network != "vpc-x" || cfg.Port != 9000 ||
+		cfg.ProxyHeader != "PROXY_V1" || cfg.HealthCheckIntervalSec != 10 ||
+		cfg.HealthCheckTimeoutSec != 8 || cfg.HealthyThreshold != 3 ||
+		cfg.UnhealthyThreshold != 4 || cfg.BalancingMode != "RATE" ||
+		cfg.MaxConnectionsPerEndpoint != 500 || !cfg.RetainOnDelete ||
+		cfg.Annotations["a"] != "b" {
+		t.Fatalf("overrides not all applied: %+v", cfg)
+	}
+}
+
+func TestProxyParseConfig_MoreErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []gamekruiseiov1alpha1.NetworkConfParams
+		want    string
+	}{
+		{"bad port", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "abc")}, "invalid Port"},
+		{"bad interval", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1"), confEntry("HealthCheckIntervalSec", "0")}, "invalid HealthCheckIntervalSec"},
+		{"bad timeout", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1"), confEntry("HealthCheckTimeoutSec", "x")}, "invalid HealthCheckTimeoutSec"},
+		{"bad healthy", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1"), confEntry("HealthyThreshold", "0")}, "invalid HealthyThreshold"},
+		{"bad unhealthy", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1"), confEntry("UnhealthyThreshold", "-1")}, "invalid UnhealthyThreshold"},
+		{"bad maxconn", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1"), confEntry("MaxConnectionsPerEndpoint", "0")}, "invalid MaxConnectionsPerEndpoint"},
+		{"bad annotation", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1"), confEntry("Annotations", "novalue")}, "invalid Annotations entry"},
+		{"bad retain", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1"), confEntry("RetainOnDelete", "maybe")}, "invalid RetainOnDelete"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			p := newProxyPlugin(t)
+			_, err := p.parseConfig(tc.entries)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestProxyParseConfig_NetworkRequired(t *testing.T) {
+	p := newProxyPlugin(t)
+	p.firewallNetworkRef = "" // clear default
+	if _, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "1")}); err == nil ||
+		!strings.Contains(err.Error(), "network is required") {
+		t.Fatalf("expected network-required error, got %v", err)
+	}
+}
+
+func TestPassthroughParseConfig_MoreErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []gamekruiseiov1alpha1.NetworkConfParams
+		want    string
+	}{
+		{"bad allowglobal", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "1"), confEntry("AllowGlobalAccess", "x")}, "invalid AllowGlobalAccess"},
+		{"bad networktier", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "1"), confEntry("NetworkTier", "GOLD")}, "invalid NetworkTier"},
+		{"bad retain", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "1"), confEntry("RetainOnDelete", "x")}, "invalid RetainOnDelete"},
+		{"bad port text", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "abc")}, "invalid PortProtocols port"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := newPlugin(t).parseConfig(tc.entries)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestPassthroughParseConfig_InternalNeedsSubnetwork(t *testing.T) {
+	p := newPlugin(t)
+	p.defaultSubnetwork = "" // network present, subnetwork cleared
+	_, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Scheme", "Internal"),
+		confEntry("PortProtocols", "7777"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "subnetwork is required") {
+		t.Fatalf("expected subnetwork-required error, got %v", err)
+	}
+}
+
+func TestPassthroughParseConfig_RegionRequired(t *testing.T) {
+	p := newPlugin(t)
+	p.defaultRegion = ""
+	_, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777")})
+	if err == nil || !strings.Contains(err.Error(), "region is required") {
+		t.Fatalf("expected region-required error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkReady gate-by-gate (proxy)
+// ---------------------------------------------------------------------------
+
+func TestCheckReady_EachGate(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", nil)
+	uid := pod.UID
+	hc := DeriveResourceID(uid, "hc")
+	bes := DeriveResourceID(uid, "bes")
+	tp := DeriveResourceID(uid, "tp")
+	addr := DeriveResourceID(uid, "addr")
+	fr := DeriveResourceID(uid, "fr")
+	fw := DeriveResourceID(uid, "fw")
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+
+	// All objects present and ready EXCEPT one, walked across the chain. The
+	// readiness gates short-circuit in order HC->BES->TP->FW->FR->Addr.
+	type step struct {
+		omitReady string // which kind is present-but-not-ready
+		wantMsg   string
+	}
+	build := func(notReady string) []client.Object {
+		mk := func(kind string, o client.Object) client.Object {
+			if kind == notReady {
+				return o // present, no ready status
+			}
+			return withReady(o)
+		}
+		return []client.Object{
+			mk("hc", &gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: hc, Namespace: "ns1"}}),
+			mk("bes", &gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: bes, Namespace: "ns1"}}),
+			mk("tp", &gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: tp, Namespace: "ns1"}}),
+			mk("fw", &gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: fw, Namespace: "ns1"}}),
+			mk("fr", &gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: fr, Namespace: "ns1"}}),
+		}
+	}
+	for _, s := range []step{
+		{"hc", "HealthCheck not Ready"},
+		{"bes", "BackendService not Ready"},
+		{"tp", "TargetTCPProxy not Ready"},
+		{"fw", "Firewall not Ready"},
+		{"fr", "ForwardingRule not Ready"},
+	} {
+		objs := build(s.omitReady)
+		// Address ready so the gate that fails is the intended one.
+		objs = append(objs, withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addr, Namespace: "ns1"}}, "1.2.3.4"))
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		ready, _, msg := p.checkReady(context.Background(), cli, pod, cfg, hc, bes, tp, addr, fr, fw)
+		if ready || !strings.Contains(msg, s.wantMsg) {
+			t.Errorf("omit %q: want not-ready msg %q, got ready=%v msg=%q", s.omitReady, s.wantMsg, ready, msg)
+		}
+	}
+
+	// Missing HC object entirely -> "get HC" error path.
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if ready, _, msg := p.checkReady(context.Background(), cli, pod, cfg, hc, bes, tp, addr, fr, fw); ready || !strings.Contains(msg, "get HC") {
+		t.Errorf("missing HC: want get-HC error, got ready=%v msg=%q", ready, msg)
+	}
+
+	// Address present+ready but IP empty -> "Address Ready but IP empty".
+	// withReadyAddress(..., "") yields a Ready address whose ObservedState.Address
+	// is a non-nil pointer to the empty string, the only way to reach that gate.
+	objs := build("")
+	emptyIP := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addr, Namespace: "ns1"}}, "")
+	objs = append(objs, emptyIP)
+	cli2 := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	if ready, _, msg := p.checkReady(context.Background(), cli2, pod, cfg, hc, bes, tp, addr, fr, fw); ready || !strings.Contains(msg, "IP empty") {
+		t.Errorf("empty IP: want IP-empty msg, got ready=%v msg=%q", ready, msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OnPodUpdated: not-ready + fully-ready reconcile paths (both plugins)
+// ---------------------------------------------------------------------------
+
+// podWithStatus returns a game Pod carrying a NetworkStatus annotation (so
+// GetNetworkStatus returns non-nil) and a PodIP, owned by GSS "gs".
+func podWithStatus(name, ns string, conf []gamekruiseiov1alpha1.NetworkConfParams) *corev1.Pod {
+	pod := newGamePod(name, ns, conf)
+	pod.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus] = `{"currentNetworkState":"NotReady"}`
+	pod.Status.PodIP = "10.0.0.5"
+	return pod
+}
+
+func TestPassthroughOnPodUpdated_NilNetworkStatus(t *testing.T) {
+	// No NetworkStatus annotation -> GetNetworkStatus returns nil -> NotReady set.
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady status, got %q", out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus])
+	}
+}
+
+func TestPassthroughOnPodUpdated_ParseError(t *testing.T) {
+	scheme := testScheme(t)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "bad")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	if _, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+func TestPassthroughOnPodUpdated_AddressNotReady(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod).Build()
+	// EnsureComputeAddress creates the addr (no status) -> WaitForAddressReady
+	// reports not-ready -> overall NotReady, no panic.
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady while address provisioning")
+	}
+}
+
+func TestPassthroughOnPodUpdated_FullyReady(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP,7778/TCP")})
+
+	// Pre-seed the ComputeAddress (Ready + IP) and Service (LB ingress assigned)
+	// at the names the reconcile derives, so CreateOrUpdate adopts them and the
+	// reconcile walks all the way to NetworkReady.
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.9")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.9"}}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr, svc).Build()
+
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	status := out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus]
+	if !strings.Contains(status, "Ready") || strings.Contains(status, "NotReady") {
+		t.Fatalf("expected NetworkReady, got %q", status)
+	}
+	if !strings.Contains(status, "203.0.113.9") {
+		t.Errorf("expected external IP in status, got %q", status)
+	}
+}
+
+func TestPassthroughOnPodUpdated_Disabled(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	pod.Labels[gamekruiseiov1alpha1.GameServerNetworkDisabled] = "true"
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "203.0.113.9")
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr).Build()
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated disabled: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("disabled network should report NotReady")
+	}
+	// Service must be ClusterIP (LB torn down) when disabled.
+	got := &corev1.Service{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: addrName}, got); err != nil {
+		t.Fatalf("get svc: %v", err)
+	}
+	if got.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Errorf("disabled -> ClusterIP, got %q", got.Spec.Type)
+	}
+}
+
+func TestPassthroughOnPodUpdated_GssDeletingFlagsPod(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	now := metav1.Now()
+	gss.DeletionTimestamp = &now
+	gss.Finalizers = []string{"x"}
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "7777/UDP")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod).Build()
+	out, perr := newPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if out.Labels[GssDeletingLabelKey] != "true" {
+		t.Errorf("expected gss-deleting label set on pod")
+	}
+}
+
+func TestProxyOnPodUpdated_NilNetworkStatus(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	out, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady")
+	}
+}
+
+func TestProxyOnPodUpdated_WaitingForNEG(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod).Build()
+	// Service gets created but neg-status annotation is absent -> NotReady gate (1).
+	out, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	if !strings.Contains(out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady while waiting for NEG")
+	}
+}
+
+func TestProxyOnPodUpdated_FullyReady(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := podWithStatus("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	ordinal := 0
+
+	svcName := DeriveServiceName(pod.Name, proxySuffix)
+	// Pre-seed Service with the neg-status annotation GKE would publish.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: svcName, Namespace: "ns1",
+			Annotations: map[string]string{
+				NEGStatusAnnotationKey: `{"network_endpoint_groups":{"7777":"neg-7777"},"zones":["us-central1-a"]}`,
+			},
+		},
+	}
+	// Pre-seed all six KCC objects Ready at their stable names.
+	hc := DeriveStableResourceID(gss.UID, ordinal, "gpnlb-hc")
+	bes := DeriveStableResourceID(gss.UID, ordinal, "gpnlb-bes")
+	tp := DeriveStableResourceID(gss.UID, ordinal, "gpnlb-tp")
+	addr := DeriveStableResourceID(gss.UID, ordinal, "gpnlb-addr")
+	fr := DeriveStableResourceID(gss.UID, ordinal, "gpnlb-fr")
+	fw := DeriveStableResourceID(gss.UID, ordinal, "gpnlb-fw")
+	objs := []client.Object{
+		gss, pod, svc,
+		withReady(&gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: hc, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: bes, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: tp, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: fw, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: fr, Namespace: "ns1"}}),
+		withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addr, Namespace: "ns1"}}, "34.120.0.7"),
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	out, perr := newProxyPlugin(t).OnPodUpdated(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated: %v", perr)
+	}
+	status := out.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus]
+	if !strings.Contains(status, "Ready") || strings.Contains(status, "NotReady") {
+		t.Fatalf("expected NetworkReady, got %q", status)
+	}
+	if !strings.Contains(status, "34.120.0.7") {
+		t.Errorf("expected anycast IP in status, got %q", status)
+	}
+}
+
+func TestProxyOnPodDeleted_PreservesOnRecreate(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	pod.Finalizers = []string{PodFinalizer}
+	addrName := DeriveStableResourceID(gss.UID, 0, "gpnlb-addr")
+	addr := &gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr).Build()
+	if perr := newProxyPlugin(t).OnPodDeleted(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodDeleted: %v", perr)
+	}
+	// In-range ordinal -> address preserved.
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: addrName}, &gcpv1beta1.ComputeAddress{}); err != nil {
+		t.Errorf("address should be preserved on recreate, got %v", err)
+	}
+}
+
+func TestProxyOnPodDeleted_ParseErrorStillRemovesFinalizer(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "bad")})
+	pod.Finalizers = []string{PodFinalizer}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	if perr := newProxyPlugin(t).OnPodDeleted(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected parse error surfaced")
+	}
+	got := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "gs-0"}, got); err == nil {
+		if containsFinalizer(got.Finalizers, PodFinalizer) {
+			t.Errorf("finalizer should be removed even on parse error")
+		}
+	}
+}
+
+func TestPassthroughOnPodDeleted_ParseErrorStillRemovesFinalizer(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("PortProtocols", "bad")})
+	pod.Finalizers = []string{PodFinalizer}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	if perr := newPlugin(t).OnPodDeleted(cli, pod, context.Background()); perr == nil {
+		t.Fatalf("expected parse error surfaced")
+	}
+	got := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "gs-0"}, got); err == nil {
+		if containsFinalizer(got.Finalizers, PodFinalizer) {
+			t.Errorf("finalizer should be removed even on parse error")
+		}
+	}
+}
+
+// OnPodAdded for proxy (passthrough OnPodAdded is already covered elsewhere).
+func TestProxyOnPodAdded_AddsFinalizer(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	out, perr := newProxyPlugin(t).OnPodAdded(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodAdded: %v", perr)
+	}
+	if !containsFinalizer(out.Finalizers, PodFinalizer) {
+		t.Errorf("expected finalizer added")
+	}
+}

--- a/cloudprovider/googlecloud/envtest_init_test.go
+++ b/cloudprovider/googlecloud/envtest_init_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+	provideroptions "github.com/openkruise/kruise-game/cloudprovider/options"
+)
+
+// These tests exercise the cluster-bootstrap paths (VerifyKCCInstalled discovery
+// + Init) that a fake client cannot reach. They require the envtest control-plane
+// binaries; when KUBEBUILDER_ASSETS is unset (bare `go test`), they skip. The
+// Makefile's `test` target sets KUBEBUILDER_ASSETS so CI exercises them.
+
+func startEnvtest(t *testing.T) *rest.Config {
+	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; skipping envtest-backed test")
+	}
+	env := &envtest.Environment{}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() { _ = env.Stop() })
+	return cfg
+}
+
+// kccComputeCRDs builds minimal CRDs for the six KCC compute kinds the plugins
+// depend on, so VerifyKCCInstalled's discovery probe finds them.
+func kccComputeCRDs() []*apiextensionsv1.CustomResourceDefinition {
+	kinds := []struct{ kind, plural string }{
+		{"ComputeAddress", "computeaddresses"},
+		{"ComputeForwardingRule", "computeforwardingrules"},
+		{"ComputeBackendService", "computebackendservices"},
+		{"ComputeHealthCheck", "computehealthchecks"},
+		{"ComputeTargetTCPProxy", "computetargettcpproxies"},
+		{"ComputeFirewall", "computefirewalls"},
+	}
+	preserve := true
+	out := make([]*apiextensionsv1.CustomResourceDefinition, 0, len(kinds))
+	for _, k := range kinds {
+		out = append(out, &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: k.plural + "." + gcpv1beta1.GroupName},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: gcpv1beta1.GroupName,
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: k.plural,
+					Kind:   k.kind,
+				},
+				Scope: apiextensionsv1.NamespaceScoped,
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+					Name:    gcpv1beta1.GroupVersion,
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: &preserve,
+						},
+					},
+				}},
+			},
+		})
+	}
+	return out
+}
+
+// installPartial installs an explicit subset of CRDs (used to simulate a
+// cluster where the compute group exists but a required kind is missing).
+func installPartial(t *testing.T, cfg *rest.Config, crds []*apiextensionsv1.CustomResourceDefinition) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	t.Helper()
+	return envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{CRDs: crds})
+}
+
+// newEnvtestClient builds a controller-runtime client wired with the schemes the
+// plugins expect.
+func newEnvtestClient(t *testing.T, cfg *rest.Config) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	if err := gcpv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("gcp scheme: %v", err)
+	}
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	return c
+}
+
+func TestVerifyKCCInstalled_EnvtestMissingThenPresent(t *testing.T) {
+	cfg := startEnvtest(t)
+
+	// (1) Compute group absent -> notInstalledError path.
+	if err := VerifyKCCInstalled(cfg); err == nil {
+		t.Fatalf("expected error before KCC CRDs are installed")
+	}
+
+	// (2) Install the KCC compute CRDs, then the probe should pass.
+	if _, err := envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{
+		CRDs: kccComputeCRDs(),
+	}); err != nil {
+		t.Fatalf("install KCC CRDs: %v", err)
+	}
+	if err := VerifyKCCInstalled(cfg); err != nil {
+		t.Fatalf("expected success after KCC CRDs installed, got %v", err)
+	}
+}
+
+func TestInit_EnvtestHappyPath(t *testing.T) {
+	cfg := startEnvtest(t)
+	if _, err := envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{CRDs: kccComputeCRDs()}); err != nil {
+		t.Fatalf("install KCC CRDs: %v", err)
+	}
+
+	// Init calls ctrl.GetConfigOrDie(), which reads KUBECONFIG. Point it at a
+	// kubeconfig synthesized from the envtest control plane.
+	writeKubeconfig(t, cfg)
+
+	c := newEnvtestClient(t, cfg)
+
+	opts := provideroptions.GoogleCloudOptions{
+		Enable:         true,
+		ProjectID:      "demo-project",
+		PassthroughNLB: provideroptions.PassthroughNLBOptions{Enable: true},
+		GlobalProxyNLB: provideroptions.GlobalProxyNLBOptions{Enable: true},
+	}
+
+	pp := &PassthroughNlbPlugin{}
+	if err := pp.Init(c, opts, context.Background()); err != nil {
+		t.Fatalf("passthrough Init happy path: %v", err)
+	}
+	if pp.kccClient(c) == nil {
+		t.Errorf("passthrough apiClient should be populated after Init")
+	}
+
+	gp := &GlobalProxyNlbPlugin{}
+	if err := gp.Init(c, opts, context.Background()); err != nil {
+		t.Fatalf("proxy Init happy path: %v", err)
+	}
+	if gp.kccClient(c) == nil {
+		t.Errorf("proxy apiClient should be populated after Init")
+	}
+}
+
+// writeKubeconfig synthesizes a kubeconfig from the envtest control plane's
+// admin TLS credentials and points KUBECONFIG at it for the test's duration.
+func writeKubeconfig(t *testing.T, cfg *rest.Config) {
+	t.Helper()
+	kc := clientcmdapi.NewConfig()
+	kc.Clusters["envtest"] = &clientcmdapi.Cluster{
+		Server:                   cfg.Host,
+		CertificateAuthorityData: cfg.CAData,
+	}
+	kc.AuthInfos["admin"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: cfg.CertData,
+		ClientKeyData:         cfg.KeyData,
+	}
+	kc.Contexts["envtest"] = &clientcmdapi.Context{Cluster: "envtest", AuthInfo: "admin"}
+	kc.CurrentContext = "envtest"
+	kubeconfig, err := clientcmd.Write(*kc)
+	if err != nil {
+		t.Fatalf("write kubeconfig bytes: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, kubeconfig, 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	old := os.Getenv("KUBECONFIG")
+	if err := os.Setenv("KUBECONFIG", path); err != nil {
+		t.Fatalf("set KUBECONFIG: %v", err)
+	}
+	t.Cleanup(func() {
+		if old == "" {
+			_ = os.Unsetenv("KUBECONFIG")
+		} else {
+			_ = os.Setenv("KUBECONFIG", old)
+		}
+	})
+}

--- a/cloudprovider/googlecloud/finalizer.go
+++ b/cloudprovider/googlecloud/finalizer.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// hasFinalizer reports whether a slice already contains the given name.
+func hasFinalizer(list []string, name string) bool {
+	for _, f := range list {
+		if f == name {
+			return true
+		}
+	}
+	return false
+}
+
+// removeFinalizer returns the slice with the named finalizer removed (if any).
+func removeFinalizer(list []string, name string) []string {
+	out := make([]string, 0, len(list))
+	for _, f := range list {
+		if f == name {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// EnsurePodFinalizer adds name to obj's finalizers in-place and returns true
+// when a mutation happened. The caller is responsible for persisting via the
+// admission-webhook return value (Plugin contract) or a client.Update call.
+func EnsurePodFinalizer(obj client.Object, name string) (mutated bool) {
+	finals := obj.GetFinalizers()
+	if hasFinalizer(finals, name) {
+		return false
+	}
+	obj.SetFinalizers(append(finals, name))
+	return true
+}
+
+// RemovePodFinalizer drops the named finalizer from obj and persists via Update.
+// Caller handles the returned error.
+func RemovePodFinalizer(ctx context.Context, c client.Client, obj client.Object, name string) error {
+	finals := obj.GetFinalizers()
+	if !hasFinalizer(finals, name) {
+		return nil
+	}
+	obj.SetFinalizers(removeFinalizer(finals, name))
+	return c.Update(ctx, obj)
+}

--- a/cloudprovider/googlecloud/global_proxy_nlb.go
+++ b/cloudprovider/googlecloud/global_proxy_nlb.go
@@ -271,9 +271,9 @@ func (p *GlobalProxyNlbPlugin) OnPodAdded(c client.Client, pod *corev1.Pod, ctx 
 }
 
 // OnPodUpdated reconciles the full KCC stack. Three-stage gate:
-//   1. Service+NEG annotation present, neg-status published by GKE
-//   2. KCC HC + BES + TargetTCPProxy + Address all Ready
-//   3. ComputeForwardingRule Ready + IP assigned
+//  1. Service+NEG annotation present, neg-status published by GKE
+//  2. KCC HC + BES + TargetTCPProxy + Address all Ready
+//  3. ComputeForwardingRule Ready + IP assigned
 func (p *GlobalProxyNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
 	nm := utils.NewNetworkManager(pod, c)
 	if nm == nil {

--- a/cloudprovider/googlecloud/global_proxy_nlb.go
+++ b/cloudprovider/googlecloud/global_proxy_nlb.go
@@ -294,26 +294,31 @@ func (p *GlobalProxyNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ct
 		return out, cperrors.ToPluginError(err, cperrors.InternalError)
 	}
 
-	// Mark GSS deletion on the pod so OnPodDeleted has a non-racy signal.
+	// Resolve the owning GameServerSet — the stable anchor for resourceID
+	// (so the anycast IP + KCC graph survive Pod recreate) and OwnerReference.
 	gssName := pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
-	if gssName != "" {
-		gss := &gamekruiseiov1alpha1.GameServerSet{}
-		gerr := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: gssName}, gss)
-		if gerr == nil && gss.DeletionTimestamp != nil {
-			if pod.Labels == nil {
-				pod.Labels = map[string]string{}
-			}
-			if _, ok := pod.Labels[GssDeletingLabelKey]; !ok {
-				pod.Labels[GssDeletingLabelKey] = "true"
-				return pod, nil
-			}
+	gss := &gamekruiseiov1alpha1.GameServerSet{}
+	gssErr := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: gssName}, gss)
+	if gssErr == nil && gss.DeletionTimestamp != nil {
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
 		}
+		if _, ok := pod.Labels[GssDeletingLabelKey]; !ok {
+			pod.Labels[GssDeletingLabelKey] = "true"
+			return pod, nil
+		}
+	}
+	ordinal := util.GetIndexFromGsName(pod.Name)
+	var gssRef *metav1.OwnerReference
+	if !cfg.RetainOnDelete && gssErr == nil {
+		o := gssOwnerRef(gss)
+		gssRef = &o
 	}
 
 	// (1) Ensure the per-pod Service + NEG annotation. The GKE NEG controller
 	// reads the annotation and creates per-zone NEGs targeting Pod IP:port.
 	svcName := DeriveServiceName(pod.Name, proxySuffix)
-	svc, serr := p.ensureService(ctx, c, pod, cfg, svcName)
+	svc, serr := p.ensureService(ctx, c, pod, cfg, svcName, gss.GetUID(), ordinal, gssRef)
 	if serr != nil {
 		return pod, cperrors.ToPluginError(serr, cperrors.ApiCallError)
 	}
@@ -330,23 +335,27 @@ func (p *GlobalProxyNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ct
 		return out, cperrors.ToPluginError(uerr, cperrors.InternalError)
 	}
 
-	// (2) Reconcile KCC graph in dependency order.
-	hcName := DeriveResourceID(pod.UID, "gpnlb-hc")
-	besName := DeriveResourceID(pod.UID, "gpnlb-bes")
-	tcpProxyName := DeriveResourceID(pod.UID, "gpnlb-tp")
-	addrName := DeriveResourceID(pod.UID, "gpnlb-addr")
-	frName := DeriveResourceID(pod.UID, "gpnlb-fr")
-	fwName := DeriveResourceID(pod.UID, "gpnlb-fw")
+	// (2) Reconcile KCC graph in dependency order. Names anchored on GSS+ordinal.
+	hcName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-hc")
+	besName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-bes")
+	tcpProxyName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-tp")
+	addrName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-addr")
+	frName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-fr")
+	fwName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-fw")
 
 	kccClient := p.kccClient(c)
-	if perr := p.ensureHealthCheck(ctx, kccClient, pod, cfg, hcName); perr != nil {
+	if perr := p.ensureHealthCheck(ctx, kccClient, pod, cfg, hcName, gssRef); perr != nil {
 		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
 	}
-	if perr := p.ensureBackendService(ctx, kccClient, pod, cfg, besName, hcName, thisPortNEGs); perr != nil {
+	if perr := p.ensureBackendService(ctx, kccClient, pod, cfg, besName, hcName, thisPortNEGs, gssRef); perr != nil {
 		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
 	}
-	if perr := p.ensureTargetTCPProxy(ctx, kccClient, pod, cfg, tcpProxyName, besName); perr != nil {
+	if perr := p.ensureTargetTCPProxy(ctx, kccClient, pod, cfg, tcpProxyName, besName, gssRef); perr != nil {
 		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
+	}
+	var addrOwners []metav1.OwnerReference
+	if gssRef != nil {
+		addrOwners = []metav1.OwnerReference{*gssRef}
 	}
 	if _, aerr := EnsureComputeAddress(ctx, kccClient, AddressSpec{
 		Name:        addrName,
@@ -356,14 +365,14 @@ func (p *GlobalProxyNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ct
 		NetworkTier: "PREMIUM",
 		ProjectID:   cfg.ProjectID,
 		ResourceID:  addrName,
-		OwnerRefs:   []metav1.OwnerReference{podOwnerRef(pod)},
+		OwnerRefs:   addrOwners,
 	}); aerr != nil {
 		return pod, cperrors.ToPluginError(aerr, cperrors.ApiCallError)
 	}
-	if perr := p.ensureForwardingRule(ctx, kccClient, pod, cfg, frName, tcpProxyName, addrName); perr != nil {
+	if perr := p.ensureForwardingRule(ctx, kccClient, pod, cfg, frName, tcpProxyName, addrName, gssRef); perr != nil {
 		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
 	}
-	if perr := p.ensureFirewall(ctx, kccClient, pod, cfg, fwName); perr != nil {
+	if perr := p.ensureFirewall(ctx, kccClient, pod, cfg, fwName, gssRef); perr != nil {
 		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
 	}
 
@@ -410,13 +419,29 @@ func (p *GlobalProxyNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ct
 		return RemovePodFinalizerPlugin(ctx, c, pod)
 	}
 
+	gssName := pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+	gssDeleting := pod.Labels[GssDeletingLabelKey] == "true"
+	if !gssDeleting && !shouldReleaseSlot(ctx, c, pod.Namespace, gssName, pod.Name) {
+		// Transient recreate at an in-range ordinal — keep the anycast IP + KCC
+		// graph so the new Pod re-adopts them; just release the Pod.
+		log.Infof("[%s] pod %s/%s recreating at in-range ordinal; preserving anycast IP + KCC graph",
+			GlobalProxyNlbNetwork, pod.Namespace, pod.Name)
+		return RemovePodFinalizerPlugin(ctx, c, pod)
+	}
+
+	// Resolve the GSS UID to rebuild the stable resource names. If the GSS is
+	// already gone we fall back to a zero UID — the names won't match live CRs,
+	// but the owner-reference GC will reap them when the GSS was deleted.
+	gss := &gamekruiseiov1alpha1.GameServerSet{}
+	_ = c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: gssName}, gss)
+	ordinal := util.GetIndexFromGsName(pod.Name)
 	svcName := DeriveServiceName(pod.Name, proxySuffix)
-	hcName := DeriveResourceID(pod.UID, "gpnlb-hc")
-	besName := DeriveResourceID(pod.UID, "gpnlb-bes")
-	tcpProxyName := DeriveResourceID(pod.UID, "gpnlb-tp")
-	addrName := DeriveResourceID(pod.UID, "gpnlb-addr")
-	frName := DeriveResourceID(pod.UID, "gpnlb-fr")
-	fwName := DeriveResourceID(pod.UID, "gpnlb-fw")
+	hcName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-hc")
+	besName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-bes")
+	tcpProxyName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-tp")
+	addrName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-addr")
+	frName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-fr")
+	fwName := DeriveStableResourceID(gss.GetUID(), ordinal, "gpnlb-fw")
 
 	// Delete in reverse dependency order. Errors other than NotFound surface
 	// as RetryError so the controller revisits.
@@ -445,8 +470,8 @@ func (p *GlobalProxyNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ct
 
 // ensureService creates the ClusterIP Service that carries the cloud.google.com/neg
 // annotation. The GKE NEG controller reacts and publishes zonal NEGs.
-func (p *GlobalProxyNlbPlugin) ensureService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, svcName string) (*corev1.Service, error) {
-	negName := DeriveResourceID(pod.UID, fmt.Sprintf("neg-%d", cfg.Port))
+func (p *GlobalProxyNlbPlugin) ensureService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, svcName string, gssUID types.UID, ordinal int, owner *metav1.OwnerReference) (*corev1.Service, error) {
+	negName := DeriveStableResourceID(gssUID, ordinal, fmt.Sprintf("neg-%d", cfg.Port))
 	annValue, _ := json.Marshal(map[string]any{
 		"exposed_ports": map[string]any{
 			strconv.Itoa(cfg.Port): map[string]string{"name": negName},
@@ -478,8 +503,8 @@ func (p *GlobalProxyNlbPlugin) ensureService(ctx context.Context, c client.Clien
 			TargetPort: intstr.FromInt(cfg.Port),
 			Protocol:   corev1.ProtocolTCP,
 		}}
-		if !cfg.RetainOnDelete {
-			svc.OwnerReferences = []metav1.OwnerReference{podOwnerRef(pod)}
+		if owner != nil {
+			svc.OwnerReferences = []metav1.OwnerReference{*owner}
 		}
 		return nil
 	}
@@ -489,10 +514,10 @@ func (p *GlobalProxyNlbPlugin) ensureService(ctx context.Context, c client.Clien
 	return svc, nil
 }
 
-func (p *GlobalProxyNlbPlugin) ensureHealthCheck(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name string) error {
+func (p *GlobalProxyNlbPlugin) ensureHealthCheck(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name string, owner *metav1.OwnerReference) error {
 	hc := &gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
 	mutate := func() error {
-		applyProjectAndOwner(hc, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		applyProjectAndOwner(hc, cfg.ProjectID, pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey], owner)
 		hc.Spec.Location = "global"
 		hc.Spec.ResourceID = ptr.To(name)
 		hc.Spec.CheckIntervalSec = ptr.To(cfg.HealthCheckIntervalSec)
@@ -509,10 +534,10 @@ func (p *GlobalProxyNlbPlugin) ensureHealthCheck(ctx context.Context, c client.C
 	return err
 }
 
-func (p *GlobalProxyNlbPlugin) ensureBackendService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, hcName string, negs []NEGRef) error {
+func (p *GlobalProxyNlbPlugin) ensureBackendService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, hcName string, negs []NEGRef, owner *metav1.OwnerReference) error {
 	bes := &gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
 	mutate := func() error {
-		applyProjectAndOwner(bes, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		applyProjectAndOwner(bes, cfg.ProjectID, pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey], owner)
 		bes.Spec.Location = "global"
 		bes.Spec.ResourceID = ptr.To(name)
 		bes.Spec.Protocol = ptr.To("TCP")
@@ -544,10 +569,10 @@ func (p *GlobalProxyNlbPlugin) ensureBackendService(ctx context.Context, c clien
 	return err
 }
 
-func (p *GlobalProxyNlbPlugin) ensureTargetTCPProxy(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, besName string) error {
+func (p *GlobalProxyNlbPlugin) ensureTargetTCPProxy(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, besName string, owner *metav1.OwnerReference) error {
 	tp := &gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
 	mutate := func() error {
-		applyProjectAndOwner(tp, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		applyProjectAndOwner(tp, cfg.ProjectID, pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey], owner)
 		tp.Spec.ResourceID = ptr.To(name)
 		tp.Spec.BackendServiceRef = gcpv1beta1.ResourceRef{Name: besName}
 		tp.Spec.ProxyHeader = ptr.To(cfg.ProxyHeader)
@@ -557,10 +582,10 @@ func (p *GlobalProxyNlbPlugin) ensureTargetTCPProxy(ctx context.Context, c clien
 	return err
 }
 
-func (p *GlobalProxyNlbPlugin) ensureForwardingRule(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, tpName, addrName string) error {
+func (p *GlobalProxyNlbPlugin) ensureForwardingRule(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, tpName, addrName string, owner *metav1.OwnerReference) error {
 	fr := &gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
 	mutate := func() error {
-		applyProjectAndOwner(fr, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		applyProjectAndOwner(fr, cfg.ProjectID, pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey], owner)
 		fr.Spec.Location = "global"
 		fr.Spec.ResourceID = ptr.To(name)
 		fr.Spec.LoadBalancingScheme = ptr.To("EXTERNAL_MANAGED")
@@ -582,10 +607,10 @@ func (p *GlobalProxyNlbPlugin) ensureForwardingRule(ctx context.Context, c clien
 	return err
 }
 
-func (p *GlobalProxyNlbPlugin) ensureFirewall(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name string) error {
+func (p *GlobalProxyNlbPlugin) ensureFirewall(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name string, owner *metav1.OwnerReference) error {
 	fw := &gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
 	mutate := func() error {
-		applyProjectAndOwner(fw, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		applyProjectAndOwner(fw, cfg.ProjectID, pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey], owner)
 		fw.Spec.ResourceID = ptr.To(name)
 		fw.Spec.Direction = ptr.To("INGRESS")
 		fw.Spec.Priority = ptr.To(int64(1000))
@@ -659,15 +684,16 @@ func (p *GlobalProxyNlbPlugin) checkReady(ctx context.Context, c client.Client, 
 }
 
 // applyProjectAndOwner stamps the project-id annotation, managed-by label, and
-// optionally a Pod OwnerReference on a KCC CR.
-func applyProjectAndOwner(obj client.Object, projectID string, pod *corev1.Pod, retain bool) {
+// (when owner != nil) the GameServerSet OwnerReference on a KCC CR. Anchoring
+// on the GSS keeps the resource alive across Pod recreate; owner is nil when
+// RetainOnDelete=true so the resource outlives even the GSS.
+func applyProjectAndOwner(obj client.Object, projectID, gssName string, owner *metav1.OwnerReference) {
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
 	labels[ResourceTagKey] = ResourceTagValue
-	labels[gamekruiseiov1alpha1.GameServerOwnerGssKey] =
-		pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+	labels[gamekruiseiov1alpha1.GameServerOwnerGssKey] = gssName
 	obj.SetLabels(labels)
 	if projectID != "" {
 		anns := obj.GetAnnotations()
@@ -677,8 +703,8 @@ func applyProjectAndOwner(obj client.Object, projectID string, pod *corev1.Pod, 
 		anns[ProjectIDAnnotation] = projectID
 		obj.SetAnnotations(anns)
 	}
-	if !retain {
-		obj.SetOwnerReferences([]metav1.OwnerReference{podOwnerRef(pod)})
+	if owner != nil {
+		obj.SetOwnerReferences([]metav1.OwnerReference{*owner})
 	}
 }
 

--- a/cloudprovider/googlecloud/global_proxy_nlb.go
+++ b/cloudprovider/googlecloud/global_proxy_nlb.go
@@ -1,0 +1,687 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	log "k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/cloudprovider"
+	cperrors "github.com/openkruise/kruise-game/cloudprovider/errors"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+	provideroptions "github.com/openkruise/kruise-game/cloudprovider/options"
+	"github.com/openkruise/kruise-game/cloudprovider/utils"
+	"github.com/openkruise/kruise-game/pkg/util"
+)
+
+const (
+	// GlobalProxyNlbNetwork is the value users put in spec.network.networkType
+	// to pick this plugin.
+	GlobalProxyNlbNetwork = "GoogleCloud-GlobalProxyNLB"
+	// AliasGlobalProxyNlb is the cross-cloud alias.
+	AliasGlobalProxyNlb = "GlobalProxyNLB-Network"
+
+	// proxySuffix tags resources owned by this plugin.
+	proxySuffix = "gcp-gpnlb"
+)
+
+// GlobalProxyNlbPlugin provisions a per-pod Global External Proxy Network Load
+// Balancer (loadBalancingScheme=EXTERNAL_MANAGED, anycast IP, GFE-backed).
+//
+// Stack per pod:
+//
+//	Service (ClusterIP + cloud.google.com/neg annotation)
+//	    -> GKE NEG controller creates zonal ComputeNetworkEndpointGroups (Pod IP)
+//	ComputeHealthCheck (global, TCP, USE_SERVING_PORT)
+//	ComputeBackendService (global, EXTERNAL_MANAGED, TCP, backends=NEGs, HC ref)
+//	ComputeTargetTCPProxy (proxyHeader=PROXY_V1 if requested)
+//	ComputeAddress (global, EXTERNAL, PREMIUM, IPV4)
+//	ComputeForwardingRule (global, EXTERNAL_MANAGED, TCP, single port, address ref, target ref)
+//	ComputeFirewall (allow 35.191.0.0/16 + 130.211.0.0/22 to backend pod port)
+type GlobalProxyNlbPlugin struct {
+	projectID             string
+	defaultNetwork        string
+	firewallNetworkRef    string
+	retainOnDeleteDefault bool
+	// apiClient is a non-caching client for KCC CR operations. See the
+	// same field on PassthroughNlbPlugin for the rationale.
+	apiClient client.Client
+	mutex     sync.RWMutex
+}
+
+// Name implements cloudprovider.Plugin.
+func (p *GlobalProxyNlbPlugin) Name() string { return GlobalProxyNlbNetwork }
+
+// Alias implements cloudprovider.Plugin.
+func (p *GlobalProxyNlbPlugin) Alias() string { return AliasGlobalProxyNlb }
+
+// Init implements cloudprovider.Plugin.
+func (p *GlobalProxyNlbPlugin) Init(c client.Client, opts cloudprovider.CloudProviderOptions, ctx context.Context) error {
+	gcpOpts, ok := opts.(provideroptions.GoogleCloudOptions)
+	if !ok {
+		return fmt.Errorf("googlecloud proxy: expected GoogleCloudOptions, got %T", opts)
+	}
+	if !gcpOpts.GlobalProxyNLB.Enable {
+		log.Infof("[%s] plugin disabled via GlobalProxyNLB.Enable=false", GlobalProxyNlbNetwork)
+		return nil
+	}
+
+	p.mutex.Lock()
+	p.projectID = gcpOpts.ProjectID
+	p.defaultNetwork = gcpOpts.DefaultNetwork
+	p.firewallNetworkRef = gcpOpts.GlobalProxyNLB.FirewallNetworkRef
+	if p.firewallNetworkRef == "" {
+		p.firewallNetworkRef = gcpOpts.DefaultNetwork
+	}
+	p.retainOnDeleteDefault = gcpOpts.GlobalProxyNLB.RetainOnDeleteDefault
+	p.mutex.Unlock()
+
+	cfg := ctrl.GetConfigOrDie()
+	if err := VerifyKCCInstalled(cfg); err != nil {
+		return err
+	}
+	apiClient, err := client.New(cfg, client.Options{Scheme: c.Scheme(), Mapper: c.RESTMapper()})
+	if err != nil {
+		return fmt.Errorf("googlecloud proxy: build non-caching client: %w", err)
+	}
+	p.mutex.Lock()
+	p.apiClient = apiClient
+	p.mutex.Unlock()
+	log.Infof("[%s] initialized (projectID=%s firewallNetwork=%s)",
+		GlobalProxyNlbNetwork, p.projectID, p.firewallNetworkRef)
+	return nil
+}
+
+// kccClient returns the non-caching API client when Init has populated it.
+func (p *GlobalProxyNlbPlugin) kccClient(fallback client.Client) client.Client {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	if p.apiClient != nil {
+		return p.apiClient
+	}
+	return fallback
+}
+
+// proxyConfig holds the parsed NetworkConfParams for one GameServer.
+type proxyConfig struct {
+	ProjectID                 string
+	Network                   string
+	Port                      int
+	Protocol                  corev1.Protocol
+	ProxyHeader               string
+	HealthCheckIntervalSec    int64
+	HealthCheckTimeoutSec     int64
+	HealthyThreshold          int64
+	UnhealthyThreshold        int64
+	BalancingMode             string
+	MaxConnectionsPerEndpoint int64
+	Annotations               map[string]string
+	RetainOnDelete            bool
+}
+
+func (p *GlobalProxyNlbPlugin) parseConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) (*proxyConfig, error) {
+	p.mutex.RLock()
+	out := &proxyConfig{
+		ProjectID:                 p.projectID,
+		Network:                   p.firewallNetworkRef,
+		ProxyHeader:               ProxyHeaderNone,
+		HealthCheckIntervalSec:    5,
+		HealthCheckTimeoutSec:     5,
+		HealthyThreshold:          2,
+		UnhealthyThreshold:        2,
+		BalancingMode:             "CONNECTION",
+		MaxConnectionsPerEndpoint: 1000,
+		Protocol:                  corev1.ProtocolTCP,
+		Annotations:               map[string]string{},
+		RetainOnDelete:            p.retainOnDeleteDefault,
+	}
+	p.mutex.RUnlock()
+	for _, c := range conf {
+		v := strings.TrimSpace(c.Value)
+		switch c.Name {
+		case ConfProjectID:
+			out.ProjectID = v
+		case ConfNetwork:
+			out.Network = v
+		case ConfPort:
+			port, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid Port %q: %w", v, err)
+			}
+			if port < 1 || port > 65535 {
+				return nil, fmt.Errorf("invalid Port %d (1-65535)", port)
+			}
+			out.Port = port
+		case ConfProxyHeader:
+			ph := strings.ToUpper(v)
+			if ph != ProxyHeaderNone && ph != ProxyHeaderV1 {
+				return nil, fmt.Errorf("invalid ProxyHeader %q (want NONE or PROXY_V1)", v)
+			}
+			out.ProxyHeader = ph
+		case ConfHealthCheckIntervalSec:
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 1 {
+				return nil, fmt.Errorf("invalid HealthCheckIntervalSec %q", v)
+			}
+			out.HealthCheckIntervalSec = n
+		case ConfHealthCheckTimeoutSec:
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 1 {
+				return nil, fmt.Errorf("invalid HealthCheckTimeoutSec %q", v)
+			}
+			out.HealthCheckTimeoutSec = n
+		case ConfHealthyThreshold:
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 1 {
+				return nil, fmt.Errorf("invalid HealthyThreshold %q", v)
+			}
+			out.HealthyThreshold = n
+		case ConfUnhealthyThreshold:
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 1 {
+				return nil, fmt.Errorf("invalid UnhealthyThreshold %q", v)
+			}
+			out.UnhealthyThreshold = n
+		case ConfBalancingMode:
+			bm := strings.ToUpper(v)
+			if bm != "CONNECTION" && bm != "RATE" && bm != "UTILIZATION" {
+				return nil, fmt.Errorf("invalid BalancingMode %q", v)
+			}
+			out.BalancingMode = bm
+		case ConfMaxConnectionsPerEndpoint:
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 1 {
+				return nil, fmt.Errorf("invalid MaxConnectionsPerEndpoint %q", v)
+			}
+			out.MaxConnectionsPerEndpoint = n
+		case ConfAnnotations:
+			for _, kv := range strings.Split(v, ",") {
+				kv = strings.TrimSpace(kv)
+				if kv == "" {
+					continue
+				}
+				eq := strings.Index(kv, "=")
+				if eq <= 0 || eq == len(kv)-1 {
+					return nil, fmt.Errorf("invalid Annotations entry %q", kv)
+				}
+				out.Annotations[kv[:eq]] = kv[eq+1:]
+			}
+		case ConfRetainOnDelete:
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid RetainOnDelete: %w", err)
+			}
+			out.RetainOnDelete = b
+		}
+	}
+	if out.Port == 0 {
+		return nil, fmt.Errorf("port is required (NetworkConf Port=<single value 1-65535>)")
+	}
+	if out.HealthCheckTimeoutSec > out.HealthCheckIntervalSec {
+		return nil, fmt.Errorf("HealthCheckTimeoutSec (%d) must be <= HealthCheckIntervalSec (%d)",
+			out.HealthCheckTimeoutSec, out.HealthCheckIntervalSec)
+	}
+	if out.Network == "" {
+		return nil, fmt.Errorf("network is required (set per-GSS via NetworkConf Network= or default_network in TOML)")
+	}
+	return out, nil
+}
+
+// OnPodAdded attaches the Finalizer when !RetainOnDelete.
+func (p *GlobalProxyNlbPlugin) OnPodAdded(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	nm := utils.NewNetworkManager(pod, c)
+	if nm == nil {
+		return pod, nil
+	}
+	cfg, err := p.parseConfig(nm.GetNetworkConfig())
+	if err != nil {
+		return pod, cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+	if !cfg.RetainOnDelete {
+		if EnsurePodFinalizer(pod, PodFinalizer) {
+			log.Infof("[%s] added Finalizer to pod %s/%s", GlobalProxyNlbNetwork, pod.Namespace, pod.Name)
+		}
+	}
+	return pod, nil
+}
+
+// OnPodUpdated reconciles the full KCC stack. Three-stage gate:
+//   1. Service+NEG annotation present, neg-status published by GKE
+//   2. KCC HC + BES + TargetTCPProxy + Address all Ready
+//   3. ComputeForwardingRule Ready + IP assigned
+func (p *GlobalProxyNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	nm := utils.NewNetworkManager(pod, c)
+	if nm == nil {
+		return pod, nil
+	}
+	cfg, err := p.parseConfig(nm.GetNetworkConfig())
+	if err != nil {
+		return pod, cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+	netStatus, err := nm.GetNetworkStatus()
+	if err != nil {
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+	if netStatus == nil {
+		out, err := nm.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return out, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	// Mark GSS deletion on the pod so OnPodDeleted has a non-racy signal.
+	gssName := pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+	if gssName != "" {
+		gss := &gamekruiseiov1alpha1.GameServerSet{}
+		gerr := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: gssName}, gss)
+		if gerr == nil && gss.DeletionTimestamp != nil {
+			if pod.Labels == nil {
+				pod.Labels = map[string]string{}
+			}
+			if _, ok := pod.Labels[GssDeletingLabelKey]; !ok {
+				pod.Labels[GssDeletingLabelKey] = "true"
+				return pod, nil
+			}
+		}
+	}
+
+	// (1) Ensure the per-pod Service + NEG annotation. The GKE NEG controller
+	// reads the annotation and creates per-zone NEGs targeting Pod IP:port.
+	svcName := DeriveServiceName(pod.Name, proxySuffix)
+	svc, serr := p.ensureService(ctx, c, pod, cfg, svcName)
+	if serr != nil {
+		return pod, cperrors.ToPluginError(serr, cperrors.ApiCallError)
+	}
+	negRefs, perr := ParseNEGStatusAnnotation(svc)
+	if perr != nil {
+		return pod, cperrors.NewPluginError(cperrors.InternalError, perr.Error())
+	}
+	thisPortNEGs, hasNEGs := negRefs[int32(cfg.Port)]
+	if !hasNEGs || len(thisPortNEGs) == 0 {
+		log.V(1).Infof("[%s] waiting for GKE NEG controller to publish neg-status for %s/%s", GlobalProxyNlbNetwork, pod.Namespace, svc.Name)
+		out, uerr := nm.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return out, cperrors.ToPluginError(uerr, cperrors.InternalError)
+	}
+
+	// (2) Reconcile KCC graph in dependency order.
+	hcName := DeriveResourceID(pod.UID, "gpnlb-hc")
+	besName := DeriveResourceID(pod.UID, "gpnlb-bes")
+	tcpProxyName := DeriveResourceID(pod.UID, "gpnlb-tp")
+	addrName := DeriveResourceID(pod.UID, "gpnlb-addr")
+	frName := DeriveResourceID(pod.UID, "gpnlb-fr")
+	fwName := DeriveResourceID(pod.UID, "gpnlb-fw")
+
+	kccClient := p.kccClient(c)
+	if perr := p.ensureHealthCheck(ctx, kccClient, pod, cfg, hcName); perr != nil {
+		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
+	}
+	if perr := p.ensureBackendService(ctx, kccClient, pod, cfg, besName, hcName, thisPortNEGs); perr != nil {
+		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
+	}
+	if perr := p.ensureTargetTCPProxy(ctx, kccClient, pod, cfg, tcpProxyName, besName); perr != nil {
+		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
+	}
+	if _, aerr := EnsureComputeAddress(ctx, kccClient, AddressSpec{
+		Name:        addrName,
+		Namespace:   pod.Namespace,
+		Location:    "global",
+		AddressType: "EXTERNAL",
+		NetworkTier: "PREMIUM",
+		ProjectID:   cfg.ProjectID,
+		ResourceID:  addrName,
+		OwnerRefs:   []metav1.OwnerReference{podOwnerRef(pod)},
+	}); aerr != nil {
+		return pod, cperrors.ToPluginError(aerr, cperrors.ApiCallError)
+	}
+	if perr := p.ensureForwardingRule(ctx, kccClient, pod, cfg, frName, tcpProxyName, addrName); perr != nil {
+		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
+	}
+	if perr := p.ensureFirewall(ctx, kccClient, pod, cfg, fwName); perr != nil {
+		return pod, cperrors.ToPluginError(perr, cperrors.ApiCallError)
+	}
+
+	// (3) Read back readiness from each KCC object.
+	allReady, ip, gateMsg := p.checkReady(ctx, kccClient, pod, cfg, hcName, besName, tcpProxyName, addrName, frName, fwName)
+	if !allReady {
+		log.V(1).Infof("[%s] not yet ready for %s/%s: %s", GlobalProxyNlbNetwork, pod.Namespace, pod.Name, gateMsg)
+		out, uerr := nm.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return out, cperrors.ToPluginError(uerr, cperrors.InternalError)
+	}
+
+	intPort := intstr.FromInt(cfg.Port)
+	netStatus.InternalAddresses = []gamekruiseiov1alpha1.NetworkAddress{{
+		IP: pod.Status.PodIP,
+		Ports: []gamekruiseiov1alpha1.NetworkPort{{
+			Name: strconv.Itoa(cfg.Port), Port: &intPort, Protocol: cfg.Protocol,
+		}},
+	}}
+	netStatus.ExternalAddresses = []gamekruiseiov1alpha1.NetworkAddress{{
+		IP: ip,
+		Ports: []gamekruiseiov1alpha1.NetworkPort{{
+			Name: strconv.Itoa(cfg.Port), Port: &intPort, Protocol: cfg.Protocol,
+		}},
+	}}
+	netStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkReady
+	out, uerr := nm.UpdateNetworkStatus(*netStatus, pod)
+	return out, cperrors.ToPluginError(uerr, cperrors.InternalError)
+}
+
+// OnPodDeleted clears the KCC graph and the Pod Finalizer when RetainOnDelete=false.
+func (p *GlobalProxyNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ctx context.Context) cperrors.PluginError {
+	nm := utils.NewNetworkManager(pod, c)
+	if nm == nil {
+		return nil
+	}
+	cfg, err := p.parseConfig(nm.GetNetworkConfig())
+	if err != nil {
+		_ = RemovePodFinalizer(ctx, c, pod, PodFinalizer)
+		return cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+	if cfg.RetainOnDelete {
+		return RemovePodFinalizerPlugin(ctx, c, pod)
+	}
+
+	svcName := DeriveServiceName(pod.Name, proxySuffix)
+	hcName := DeriveResourceID(pod.UID, "gpnlb-hc")
+	besName := DeriveResourceID(pod.UID, "gpnlb-bes")
+	tcpProxyName := DeriveResourceID(pod.UID, "gpnlb-tp")
+	addrName := DeriveResourceID(pod.UID, "gpnlb-addr")
+	frName := DeriveResourceID(pod.UID, "gpnlb-fr")
+	fwName := DeriveResourceID(pod.UID, "gpnlb-fw")
+
+	// Delete in reverse dependency order. Errors other than NotFound surface
+	// as RetryError so the controller revisits.
+	deleteOrder := []client.Object{
+		&gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: frName, Namespace: pod.Namespace}},
+		&gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: fwName, Namespace: pod.Namespace}},
+		&gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: tcpProxyName, Namespace: pod.Namespace}},
+		&gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: besName, Namespace: pod.Namespace}},
+		&gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: pod.Namespace}},
+		&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: pod.Namespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: pod.Namespace}},
+	}
+	kccClient := p.kccClient(c)
+	for _, obj := range deleteOrder {
+		delClient := kccClient
+		if _, isService := obj.(*corev1.Service); isService {
+			delClient = c
+		}
+		if derr := delClient.Delete(ctx, obj); derr != nil && !apierrors.IsNotFound(derr) {
+			log.Errorf("[%s] delete %T %s/%s: %v", GlobalProxyNlbNetwork, obj, obj.GetNamespace(), obj.GetName(), derr)
+			return cperrors.ToPluginError(derr, cperrors.ApiCallError)
+		}
+	}
+	return RemovePodFinalizerPlugin(ctx, c, pod)
+}
+
+// ensureService creates the ClusterIP Service that carries the cloud.google.com/neg
+// annotation. The GKE NEG controller reacts and publishes zonal NEGs.
+func (p *GlobalProxyNlbPlugin) ensureService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, svcName string) (*corev1.Service, error) {
+	negName := DeriveResourceID(pod.UID, fmt.Sprintf("neg-%d", cfg.Port))
+	annValue, _ := json.Marshal(map[string]any{
+		"exposed_ports": map[string]any{
+			strconv.Itoa(cfg.Port): map[string]string{"name": negName},
+		},
+	})
+
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: pod.Namespace}}
+	mutate := func() error {
+		if svc.Labels == nil {
+			svc.Labels = map[string]string{}
+		}
+		svc.Labels[ResourceTagKey] = ResourceTagValue
+		svc.Labels[gamekruiseiov1alpha1.GameServerOwnerGssKey] =
+			pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+		if svc.Annotations == nil {
+			svc.Annotations = map[string]string{}
+		}
+		svc.Annotations[NEGAnnotationKey] = string(annValue)
+		svc.Annotations[ConfigHashKey] = util.GetHash(cfg)
+		for k, v := range cfg.Annotations {
+			svc.Annotations[k] = v
+		}
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		svc.Spec.Selector = map[string]string{SvcSelectorKey: pod.Name}
+		port := int32(cfg.Port)
+		svc.Spec.Ports = []corev1.ServicePort{{
+			Name:       fmt.Sprintf("p%d", cfg.Port),
+			Port:       port,
+			TargetPort: intstr.FromInt(cfg.Port),
+			Protocol:   corev1.ProtocolTCP,
+		}}
+		if !cfg.RetainOnDelete {
+			svc.OwnerReferences = []metav1.OwnerReference{podOwnerRef(pod)}
+		}
+		return nil
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, svc, mutate); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func (p *GlobalProxyNlbPlugin) ensureHealthCheck(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name string) error {
+	hc := &gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
+	mutate := func() error {
+		applyProjectAndOwner(hc, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		hc.Spec.Location = "global"
+		hc.Spec.ResourceID = ptr.To(name)
+		hc.Spec.CheckIntervalSec = ptr.To(cfg.HealthCheckIntervalSec)
+		hc.Spec.TimeoutSec = ptr.To(cfg.HealthCheckTimeoutSec)
+		hc.Spec.HealthyThreshold = ptr.To(cfg.HealthyThreshold)
+		hc.Spec.UnhealthyThreshold = ptr.To(cfg.UnhealthyThreshold)
+		hc.Spec.TCPHealthCheck = &gcpv1beta1.HealthCheckTCP{
+			PortSpecification: ptr.To("USE_SERVING_PORT"),
+			ProxyHeader:       ptr.To(ProxyHeaderNone),
+		}
+		return nil
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, c, hc, mutate)
+	return err
+}
+
+func (p *GlobalProxyNlbPlugin) ensureBackendService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, hcName string, negs []NEGRef) error {
+	bes := &gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
+	mutate := func() error {
+		applyProjectAndOwner(bes, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		bes.Spec.Location = "global"
+		bes.Spec.ResourceID = ptr.To(name)
+		bes.Spec.Protocol = ptr.To("TCP")
+		bes.Spec.LoadBalancingScheme = ptr.To("EXTERNAL_MANAGED")
+		bes.Spec.TimeoutSec = ptr.To(int64(30))
+		bes.Spec.ConnectionDrainingTimeoutSec = ptr.To(int64(60))
+		bes.Spec.HealthChecks = []gcpv1beta1.BackendServiceHealthCheckRef{{
+			HealthCheckRef: &gcpv1beta1.ResourceRef{Name: hcName},
+		}}
+		// Stable backend order — sort NEGRefs by zone so reconciles don't
+		// thrash on slice ordering.
+		sortedNegs := append([]NEGRef(nil), negs...)
+		sort.Slice(sortedNegs, func(i, j int) bool { return sortedNegs[i].Zone < sortedNegs[j].Zone })
+		bes.Spec.Backend = make([]gcpv1beta1.BackendServiceBackend, 0, len(sortedNegs))
+		for _, n := range sortedNegs {
+			bes.Spec.Backend = append(bes.Spec.Backend, gcpv1beta1.BackendServiceBackend{
+				Group: gcpv1beta1.BackendGroup{
+					NetworkEndpointGroupRef: &gcpv1beta1.ResourceRef{
+						External: n.SelfLink(cfg.ProjectID),
+					},
+				},
+				BalancingMode:             ptr.To(cfg.BalancingMode),
+				MaxConnectionsPerEndpoint: ptr.To(cfg.MaxConnectionsPerEndpoint),
+			})
+		}
+		return nil
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, c, bes, mutate)
+	return err
+}
+
+func (p *GlobalProxyNlbPlugin) ensureTargetTCPProxy(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, besName string) error {
+	tp := &gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
+	mutate := func() error {
+		applyProjectAndOwner(tp, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		tp.Spec.ResourceID = ptr.To(name)
+		tp.Spec.BackendServiceRef = gcpv1beta1.ResourceRef{Name: besName}
+		tp.Spec.ProxyHeader = ptr.To(cfg.ProxyHeader)
+		return nil
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, c, tp, mutate)
+	return err
+}
+
+func (p *GlobalProxyNlbPlugin) ensureForwardingRule(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name, tpName, addrName string) error {
+	fr := &gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
+	mutate := func() error {
+		applyProjectAndOwner(fr, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		fr.Spec.Location = "global"
+		fr.Spec.ResourceID = ptr.To(name)
+		fr.Spec.LoadBalancingScheme = ptr.To("EXTERNAL_MANAGED")
+		fr.Spec.NetworkTier = ptr.To("PREMIUM")
+		fr.Spec.IPProtocol = ptr.To("TCP")
+		// Do NOT set IPVersion when ipAddress.addressRef is also set — GCP rejects
+		// the combination because the address resource already constrains the family.
+		fr.Spec.IPVersion = nil
+		fr.Spec.PortRange = ptr.To(strconv.Itoa(cfg.Port))
+		fr.Spec.Target = &gcpv1beta1.ForwardingRuleTarget{
+			TargetTCPProxyRef: &gcpv1beta1.ResourceRef{Name: tpName},
+		}
+		fr.Spec.IPAddress = &gcpv1beta1.ForwardingRuleIPAddress{
+			AddressRef: &gcpv1beta1.ResourceRef{Name: addrName},
+		}
+		return nil
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, c, fr, mutate)
+	return err
+}
+
+func (p *GlobalProxyNlbPlugin) ensureFirewall(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, name string) error {
+	fw := &gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: pod.Namespace}}
+	mutate := func() error {
+		applyProjectAndOwner(fw, cfg.ProjectID, pod, cfg.RetainOnDelete)
+		fw.Spec.ResourceID = ptr.To(name)
+		fw.Spec.Direction = ptr.To("INGRESS")
+		fw.Spec.Priority = ptr.To(int64(1000))
+		// Reference the GCP network by selfLink (External) rather than by KCC
+		// ComputeNetwork name. The "default" VPC is a GCP-native resource that
+		// usually does not have a corresponding KCC CR.
+		project := cfg.ProjectID
+		if project == "" {
+			project = p.projectID
+		}
+		fw.Spec.NetworkRef = gcpv1beta1.ResourceRef{
+			External: fmt.Sprintf("projects/%s/global/networks/%s", project, cfg.Network),
+		}
+		fw.Spec.SourceRanges = append([]string(nil), DefaultHealthCheckSourceRanges...)
+		fw.Spec.Allowed = []gcpv1beta1.FirewallRule{{
+			Protocol: "tcp",
+			Ports:    []string{strconv.Itoa(cfg.Port)},
+		}}
+		return nil
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, c, fw, mutate)
+	return err
+}
+
+// checkReady inspects the readiness of every KCC object the plugin owns and
+// returns (allReady, externalIP, message).
+func (p *GlobalProxyNlbPlugin) checkReady(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *proxyConfig, hcName, besName, tpName, addrName, frName, fwName string) (bool, string, string) {
+	hc := &gcpv1beta1.ComputeHealthCheck{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: hcName}, hc); err != nil {
+		return false, "", fmt.Sprintf("get HC: %v", err)
+	}
+	if !IsKCCReady(hc.Status.Conditions, derefInt64(hc.Status.ObservedGeneration), hc.Generation) {
+		return false, "", "HealthCheck not Ready"
+	}
+	bes := &gcpv1beta1.ComputeBackendService{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: besName}, bes); err != nil {
+		return false, "", fmt.Sprintf("get BES: %v", err)
+	}
+	if !IsKCCReady(bes.Status.Conditions, derefInt64(bes.Status.ObservedGeneration), bes.Generation) {
+		return false, "", "BackendService not Ready"
+	}
+	tp := &gcpv1beta1.ComputeTargetTCPProxy{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: tpName}, tp); err != nil {
+		return false, "", fmt.Sprintf("get TargetTcpProxy: %v", err)
+	}
+	if !IsKCCReady(tp.Status.Conditions, derefInt64(tp.Status.ObservedGeneration), tp.Generation) {
+		return false, "", "TargetTCPProxy not Ready"
+	}
+	fw := &gcpv1beta1.ComputeFirewall{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: fwName}, fw); err != nil {
+		return false, "", fmt.Sprintf("get FW: %v", err)
+	}
+	if !IsKCCReady(fw.Status.Conditions, derefInt64(fw.Status.ObservedGeneration), fw.Generation) {
+		return false, "", "Firewall not Ready"
+	}
+	fr := &gcpv1beta1.ComputeForwardingRule{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: frName}, fr); err != nil {
+		return false, "", fmt.Sprintf("get FR: %v", err)
+	}
+	if !IsKCCReady(fr.Status.Conditions, derefInt64(fr.Status.ObservedGeneration), fr.Generation) {
+		return false, "", "ForwardingRule not Ready"
+	}
+	addrIP, addrReady, _ := WaitForAddressReady(ctx, c, types.NamespacedName{Namespace: pod.Namespace, Name: addrName})
+	if !addrReady {
+		return false, "", "Address not Ready"
+	}
+	if addrIP == "" {
+		return false, "", "Address Ready but IP empty"
+	}
+	return true, addrIP, "all KCC objects Ready"
+}
+
+// applyProjectAndOwner stamps the project-id annotation, managed-by label, and
+// optionally a Pod OwnerReference on a KCC CR.
+func applyProjectAndOwner(obj client.Object, projectID string, pod *corev1.Pod, retain bool) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[ResourceTagKey] = ResourceTagValue
+	labels[gamekruiseiov1alpha1.GameServerOwnerGssKey] =
+		pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+	obj.SetLabels(labels)
+	if projectID != "" {
+		anns := obj.GetAnnotations()
+		if anns == nil {
+			anns = map[string]string{}
+		}
+		anns[ProjectIDAnnotation] = projectID
+		obj.SetAnnotations(anns)
+	}
+	if !retain {
+		obj.SetOwnerReferences([]metav1.OwnerReference{podOwnerRef(pod)})
+	}
+}
+
+func init() {
+	googleCloudProvider.registerPlugin(&GlobalProxyNlbPlugin{})
+}

--- a/cloudprovider/googlecloud/global_proxy_nlb_test.go
+++ b/cloudprovider/googlecloud/global_proxy_nlb_test.go
@@ -102,7 +102,7 @@ func TestEnsureService_NEGAnnotationShape(t *testing.T) {
 		t.Fatalf("parseConfig: %v", err)
 	}
 	pod := newGamePod("gs-0", "ns1", nil)
-	svc, err := p.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc")
+	svc, err := p.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc", pod.UID, 0, nil)
 	if err != nil {
 		t.Fatalf("ensureService: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestEnsureHealthCheck_GlobalUSEServingPort(t *testing.T) {
 	p := newProxyPlugin(t)
 	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
 	pod := newGamePod("gs-0", "ns1", nil)
-	if err := p.ensureHealthCheck(context.Background(), cli, pod, cfg, "hc-0"); err != nil {
+	if err := p.ensureHealthCheck(context.Background(), cli, pod, cfg, "hc-0", nil); err != nil {
 		t.Fatalf("ensureHealthCheck: %v", err)
 	}
 	hc := &gcpv1beta1.ComputeHealthCheck{}
@@ -163,7 +163,7 @@ func TestEnsureBackendService_NEGSorted(t *testing.T) {
 		{Name: "neg-x", Zone: "us-central1-a"},
 		{Name: "neg-x", Zone: "us-central1-b"},
 	}
-	if err := p.ensureBackendService(context.Background(), cli, pod, cfg, "bes-0", "hc-0", negs); err != nil {
+	if err := p.ensureBackendService(context.Background(), cli, pod, cfg, "bes-0", "hc-0", negs, nil); err != nil {
 		t.Fatalf("ensureBackendService: %v", err)
 	}
 	bes := &gcpv1beta1.ComputeBackendService{}
@@ -197,7 +197,7 @@ func TestEnsureTargetTCPProxy_ProxyHeader(t *testing.T) {
 		confEntry("ProxyHeader", "PROXY_V1"),
 	})
 	pod := newGamePod("gs-0", "ns1", nil)
-	if err := p.ensureTargetTCPProxy(context.Background(), cli, pod, cfg, "tp-0", "bes-0"); err != nil {
+	if err := p.ensureTargetTCPProxy(context.Background(), cli, pod, cfg, "tp-0", "bes-0", nil); err != nil {
 		t.Fatalf("ensureTargetTCPProxy: %v", err)
 	}
 	tp := &gcpv1beta1.ComputeTargetTCPProxy{}
@@ -218,7 +218,7 @@ func TestEnsureForwardingRule_SinglePortPremium(t *testing.T) {
 	p := newProxyPlugin(t)
 	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
 	pod := newGamePod("gs-0", "ns1", nil)
-	if err := p.ensureForwardingRule(context.Background(), cli, pod, cfg, "fr-0", "tp-0", "addr-0"); err != nil {
+	if err := p.ensureForwardingRule(context.Background(), cli, pod, cfg, "fr-0", "tp-0", "addr-0", nil); err != nil {
 		t.Fatalf("ensureForwardingRule: %v", err)
 	}
 	fr := &gcpv1beta1.ComputeForwardingRule{}
@@ -246,7 +246,7 @@ func TestEnsureFirewall_HCRangesAndPort(t *testing.T) {
 	p := newProxyPlugin(t)
 	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
 	pod := newGamePod("gs-0", "ns1", nil)
-	if err := p.ensureFirewall(context.Background(), cli, pod, cfg, "fw-0"); err != nil {
+	if err := p.ensureFirewall(context.Background(), cli, pod, cfg, "fw-0", nil); err != nil {
 		t.Fatalf("ensureFirewall: %v", err)
 	}
 	fw := &gcpv1beta1.ComputeFirewall{}

--- a/cloudprovider/googlecloud/global_proxy_nlb_test.go
+++ b/cloudprovider/googlecloud/global_proxy_nlb_test.go
@@ -1,0 +1,470 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+func newProxyPlugin(t *testing.T) *GlobalProxyNlbPlugin {
+	t.Helper()
+	return &GlobalProxyNlbPlugin{
+		projectID:             "demo-project",
+		defaultNetwork:        "default",
+		firewallNetworkRef:    "default",
+		retainOnDeleteDefault: false,
+	}
+}
+
+func TestProxyParseConfig_Defaults(t *testing.T) {
+	p := newProxyPlugin(t)
+	cfg, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != 7777 || cfg.ProxyHeader != ProxyHeaderNone {
+		t.Errorf("defaults wrong: %+v", cfg)
+	}
+	if cfg.BalancingMode != "CONNECTION" || cfg.MaxConnectionsPerEndpoint != 1000 {
+		t.Errorf("balancing defaults wrong: %+v", cfg)
+	}
+	if cfg.RetainOnDelete != false {
+		t.Errorf("RetainOnDelete default: want false, got true")
+	}
+}
+
+func TestProxyParseConfig_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []gamekruiseiov1alpha1.NetworkConfParams
+		want    string
+	}{
+		{"missing Port", nil, "port is required"},
+		{"invalid Port out of range", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("Port", "99999"),
+		}, "invalid Port 99999"},
+		{"timeout greater than interval", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("Port", "7777"),
+			confEntry("HealthCheckIntervalSec", "2"),
+			confEntry("HealthCheckTimeoutSec", "5"),
+		}, "HealthCheckTimeoutSec"},
+		{"invalid ProxyHeader", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("Port", "7777"),
+			confEntry("ProxyHeader", "PROXY_V2"),
+		}, "invalid ProxyHeader"},
+		{"invalid BalancingMode", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("Port", "7777"),
+			confEntry("BalancingMode", "NOPE"),
+		}, "invalid BalancingMode"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			p := newProxyPlugin(t)
+			_, err := p.parseConfig(tc.entries)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestEnsureService_NEGAnnotationShape(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newProxyPlugin(t)
+	cfg, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+	})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	pod := newGamePod("gs-0", "ns1", nil)
+	svc, err := p.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc")
+	if err != nil {
+		t.Fatalf("ensureService: %v", err)
+	}
+	raw, ok := svc.Annotations[NEGAnnotationKey]
+	if !ok {
+		t.Fatalf("missing NEG annotation; have %v", svc.Annotations)
+	}
+	var ann map[string]map[string]map[string]string
+	if err := json.Unmarshal([]byte(raw), &ann); err != nil {
+		t.Fatalf("NEG annotation parse: %v / %q", err, raw)
+	}
+	ports, ok := ann["exposed_ports"]
+	if !ok || ports["7777"] == nil {
+		t.Fatalf("expected exposed_ports[7777], got %v", ann)
+	}
+	if ports["7777"]["name"] == "" {
+		t.Fatalf("expected NEG name to be set, got %v", ports["7777"])
+	}
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Errorf("expected ClusterIP, got %q", svc.Spec.Type)
+	}
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 7777 {
+		t.Errorf("unexpected ports: %+v", svc.Spec.Ports)
+	}
+}
+
+func TestEnsureHealthCheck_GlobalUSEServingPort(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	pod := newGamePod("gs-0", "ns1", nil)
+	if err := p.ensureHealthCheck(context.Background(), cli, pod, cfg, "hc-0"); err != nil {
+		t.Fatalf("ensureHealthCheck: %v", err)
+	}
+	hc := &gcpv1beta1.ComputeHealthCheck{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "hc-0"}, hc); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if hc.Spec.Location != "global" {
+		t.Errorf("expected global location, got %q", hc.Spec.Location)
+	}
+	if hc.Spec.TCPHealthCheck == nil || hc.Spec.TCPHealthCheck.PortSpecification == nil ||
+		*hc.Spec.TCPHealthCheck.PortSpecification != "USE_SERVING_PORT" {
+		t.Errorf("expected TCP USE_SERVING_PORT, got %+v", hc.Spec.TCPHealthCheck)
+	}
+}
+
+func TestEnsureBackendService_NEGSorted(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	pod := newGamePod("gs-0", "ns1", nil)
+	// Pass NEGs in non-alphabetical zone order; expect sorted output.
+	negs := []NEGRef{
+		{Name: "neg-x", Zone: "us-central1-c"},
+		{Name: "neg-x", Zone: "us-central1-a"},
+		{Name: "neg-x", Zone: "us-central1-b"},
+	}
+	if err := p.ensureBackendService(context.Background(), cli, pod, cfg, "bes-0", "hc-0", negs); err != nil {
+		t.Fatalf("ensureBackendService: %v", err)
+	}
+	bes := &gcpv1beta1.ComputeBackendService{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "bes-0"}, bes); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if bes.Spec.Location != "global" || *bes.Spec.LoadBalancingScheme != "EXTERNAL_MANAGED" {
+		t.Errorf("scheme/location wrong: %+v", bes.Spec)
+	}
+	if len(bes.Spec.Backend) != 3 {
+		t.Fatalf("expected 3 backends, got %d", len(bes.Spec.Backend))
+	}
+	prev := ""
+	for i, b := range bes.Spec.Backend {
+		if b.Group.NetworkEndpointGroupRef == nil || b.Group.NetworkEndpointGroupRef.External == "" {
+			t.Fatalf("backend %d missing NEG external ref", i)
+		}
+		if prev != "" && b.Group.NetworkEndpointGroupRef.External < prev {
+			t.Errorf("backends not sorted by zone-encoded selflink: %q < %q", b.Group.NetworkEndpointGroupRef.External, prev)
+		}
+		prev = b.Group.NetworkEndpointGroupRef.External
+	}
+}
+
+func TestEnsureTargetTCPProxy_ProxyHeader(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+		confEntry("ProxyHeader", "PROXY_V1"),
+	})
+	pod := newGamePod("gs-0", "ns1", nil)
+	if err := p.ensureTargetTCPProxy(context.Background(), cli, pod, cfg, "tp-0", "bes-0"); err != nil {
+		t.Fatalf("ensureTargetTCPProxy: %v", err)
+	}
+	tp := &gcpv1beta1.ComputeTargetTCPProxy{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "tp-0"}, tp); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if tp.Spec.ProxyHeader == nil || *tp.Spec.ProxyHeader != "PROXY_V1" {
+		t.Errorf("expected proxyHeader=PROXY_V1, got %+v", tp.Spec.ProxyHeader)
+	}
+	if tp.Spec.BackendServiceRef.Name != "bes-0" {
+		t.Errorf("backendServiceRef wrong: %+v", tp.Spec.BackendServiceRef)
+	}
+}
+
+func TestEnsureForwardingRule_SinglePortPremium(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	pod := newGamePod("gs-0", "ns1", nil)
+	if err := p.ensureForwardingRule(context.Background(), cli, pod, cfg, "fr-0", "tp-0", "addr-0"); err != nil {
+		t.Fatalf("ensureForwardingRule: %v", err)
+	}
+	fr := &gcpv1beta1.ComputeForwardingRule{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "fr-0"}, fr); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fr.Spec.Location != "global" || *fr.Spec.LoadBalancingScheme != "EXTERNAL_MANAGED" ||
+		*fr.Spec.NetworkTier != "PREMIUM" || *fr.Spec.IPProtocol != "TCP" {
+		t.Errorf("FR fields wrong: %+v", fr.Spec)
+	}
+	if fr.Spec.PortRange == nil || *fr.Spec.PortRange != "7777" {
+		t.Errorf("expected single-port portRange '7777', got %+v", fr.Spec.PortRange)
+	}
+	if fr.Spec.Target == nil || fr.Spec.Target.TargetTCPProxyRef == nil || fr.Spec.Target.TargetTCPProxyRef.Name != "tp-0" {
+		t.Errorf("target ref wrong: %+v", fr.Spec.Target)
+	}
+	if fr.Spec.IPAddress == nil || fr.Spec.IPAddress.AddressRef == nil || fr.Spec.IPAddress.AddressRef.Name != "addr-0" {
+		t.Errorf("address ref wrong: %+v", fr.Spec.IPAddress)
+	}
+}
+
+func TestEnsureFirewall_HCRangesAndPort(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	pod := newGamePod("gs-0", "ns1", nil)
+	if err := p.ensureFirewall(context.Background(), cli, pod, cfg, "fw-0"); err != nil {
+		t.Fatalf("ensureFirewall: %v", err)
+	}
+	fw := &gcpv1beta1.ComputeFirewall{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "fw-0"}, fw); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if *fw.Spec.Direction != "INGRESS" {
+		t.Errorf("expected INGRESS, got %v", fw.Spec.Direction)
+	}
+	srcOK := map[string]bool{"35.191.0.0/16": false, "130.211.0.0/22": false}
+	for _, s := range fw.Spec.SourceRanges {
+		if _, want := srcOK[s]; want {
+			srcOK[s] = true
+		}
+	}
+	for s, present := range srcOK {
+		if !present {
+			t.Errorf("missing source range %q (have %v)", s, fw.Spec.SourceRanges)
+		}
+	}
+	if len(fw.Spec.Allowed) != 1 || fw.Spec.Allowed[0].Protocol != "tcp" ||
+		len(fw.Spec.Allowed[0].Ports) != 1 || fw.Spec.Allowed[0].Ports[0] != "7777" {
+		t.Errorf("allowed wrong: %+v", fw.Spec.Allowed)
+	}
+	if fw.Spec.NetworkRef.External != "projects/demo-project/global/networks/default" {
+		t.Errorf("networkRef wrong (want External selfLink): %+v", fw.Spec.NetworkRef)
+	}
+}
+
+func TestProxyOnPodDeleted_DeletesEverythingInOrder(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+	})
+	pod.Finalizers = []string{PodFinalizer}
+	uid := pod.UID
+	hcName := DeriveResourceID(uid, "gpnlb-hc")
+	besName := DeriveResourceID(uid, "gpnlb-bes")
+	tpName := DeriveResourceID(uid, "gpnlb-tp")
+	addrName := DeriveResourceID(uid, "gpnlb-addr")
+	frName := DeriveResourceID(uid, "gpnlb-fr")
+	fwName := DeriveResourceID(uid, "gpnlb-fw")
+	svcName := DeriveServiceName(pod.Name, proxySuffix)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		pod,
+		&gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: frName, Namespace: "ns1"}},
+		&gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: tpName, Namespace: "ns1"}},
+		&gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: besName, Namespace: "ns1"}},
+		&gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: "ns1"}},
+		&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}},
+		&gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: fwName, Namespace: "ns1"}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: "ns1"}},
+	).Build()
+	p := newProxyPlugin(t)
+	if perr := p.OnPodDeleted(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodDeleted: %v", perr)
+	}
+	// Each KCC kind should be gone.
+	for _, key := range []types.NamespacedName{
+		{Namespace: "ns1", Name: frName},
+		{Namespace: "ns1", Name: tpName},
+		{Namespace: "ns1", Name: besName},
+		{Namespace: "ns1", Name: hcName},
+		{Namespace: "ns1", Name: addrName},
+		{Namespace: "ns1", Name: fwName},
+		{Namespace: "ns1", Name: svcName},
+	} {
+		obj := &corev1.Service{}
+		err := cli.Get(context.Background(), key, obj)
+		if err == nil {
+			// Service exists — for others, get with respective type would also fail.
+			t.Errorf("%s still exists after delete", key)
+		}
+	}
+	// Finalizer removed.
+	got := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "gs-0"}, got); err == nil {
+		if containsFinalizer(got.Finalizers, PodFinalizer) {
+			t.Errorf("Finalizer should have been removed, got %v", got.Finalizers)
+		}
+	}
+}
+
+func TestProxyOnPodDeleted_RetainedSkipsCleanup(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Port", "7777"),
+		confEntry("RetainOnDelete", "true"),
+	})
+	addrName := DeriveResourceID(pod.UID, "gpnlb-addr")
+	addr := &gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, addr).Build()
+	p := newProxyPlugin(t)
+	if perr := p.OnPodDeleted(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodDeleted: %v", perr)
+	}
+	got := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: addrName}, got); err != nil {
+		t.Errorf("Address should survive RetainOnDelete=true, got %v", err)
+	}
+}
+
+func TestParseNEGStatusAnnotation_ZoneFanout(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gs-0",
+			Namespace: "ns1",
+			Annotations: map[string]string{
+				NEGStatusAnnotationKey: `{"network_endpoint_groups":{"7777":"neg-7777"},"zones":["us-central1-c","us-central1-a","us-central1-b"]}`,
+			},
+		},
+	}
+	got, err := ParseNEGStatusAnnotation(svc)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	refs := got[7777]
+	if len(refs) != 3 {
+		t.Fatalf("want 3 zone refs, got %d", len(refs))
+	}
+	for i, z := range []string{"us-central1-a", "us-central1-b", "us-central1-c"} {
+		if refs[i].Zone != z {
+			t.Errorf("zone[%d]: want %q, got %q", i, z, refs[i].Zone)
+		}
+		if refs[i].Name != "neg-7777" {
+			t.Errorf("name[%d]: want %q, got %q", i, "neg-7777", refs[i].Name)
+		}
+		if refs[i].SelfLink("my-proj") != "projects/my-proj/zones/"+z+"/networkEndpointGroups/neg-7777" {
+			t.Errorf("selflink[%d]: %q", i, refs[i].SelfLink("my-proj"))
+		}
+	}
+}
+
+func TestParseNEGStatusAnnotation_Empty(t *testing.T) {
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "y"}}
+	got, err := ParseNEGStatusAnnotation(svc)
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil, nil), got (%v, %v)", got, err)
+	}
+}
+
+func TestCheckReady_AllStagesGate(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", nil)
+	uid := pod.UID
+	hcName := DeriveResourceID(uid, "gpnlb-hc")
+	besName := DeriveResourceID(uid, "gpnlb-bes")
+	tpName := DeriveResourceID(uid, "gpnlb-tp")
+	addrName := DeriveResourceID(uid, "gpnlb-addr")
+	frName := DeriveResourceID(uid, "gpnlb-fr")
+	fwName := DeriveResourceID(uid, "gpnlb-fw")
+
+	objs := []client.Object{
+		withReady(&gcpv1beta1.ComputeHealthCheck{ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeBackendService{ObjectMeta: metav1.ObjectMeta{Name: besName, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeTargetTCPProxy{ObjectMeta: metav1.ObjectMeta{Name: tpName, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeFirewall{ObjectMeta: metav1.ObjectMeta{Name: fwName, Namespace: "ns1"}}),
+		withReady(&gcpv1beta1.ComputeForwardingRule{ObjectMeta: metav1.ObjectMeta{Name: frName, Namespace: "ns1"}}),
+		withReadyAddress(&gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}, "34.120.0.1"),
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	p := newProxyPlugin(t)
+	cfg, _ := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{confEntry("Port", "7777")})
+	ready, ip, msg := p.checkReady(context.Background(), cli, pod, cfg, hcName, besName, tpName, addrName, frName, fwName)
+	if !ready {
+		t.Fatalf("expected ready, got msg=%q", msg)
+	}
+	if ip != "34.120.0.1" {
+		t.Errorf("expected IP, got %q", ip)
+	}
+
+	// Flip address to NotReady -> overall NotReady.
+	addr := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: addrName}, addr); err != nil {
+		t.Fatalf("get addr: %v", err)
+	}
+	addr.Status.Conditions[0].Status = "False"
+	if err := cli.Update(context.Background(), addr); err != nil {
+		t.Fatalf("update addr: %v", err)
+	}
+	ready, _, msg = p.checkReady(context.Background(), cli, pod, cfg, hcName, besName, tpName, addrName, frName, fwName)
+	if ready {
+		t.Fatalf("expected NotReady when address not ready; msg=%q", msg)
+	}
+}
+
+// withReady stamps generation/observedGeneration/Ready=True on any KCC object
+// in our scheme so checkReady sees it as healthy.
+func withReady(obj client.Object) client.Object {
+	switch o := obj.(type) {
+	case *gcpv1beta1.ComputeHealthCheck:
+		o.Generation = 1
+		o.Status.ObservedGeneration = int64Ptr2(1)
+		o.Status.Conditions = []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}}
+	case *gcpv1beta1.ComputeBackendService:
+		o.Generation = 1
+		o.Status.ObservedGeneration = int64Ptr2(1)
+		o.Status.Conditions = []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}}
+	case *gcpv1beta1.ComputeTargetTCPProxy:
+		o.Generation = 1
+		o.Status.ObservedGeneration = int64Ptr2(1)
+		o.Status.Conditions = []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}}
+	case *gcpv1beta1.ComputeFirewall:
+		o.Generation = 1
+		o.Status.ObservedGeneration = int64Ptr2(1)
+		o.Status.Conditions = []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}}
+	case *gcpv1beta1.ComputeForwardingRule:
+		o.Generation = 1
+		o.Status.ObservedGeneration = int64Ptr2(1)
+		o.Status.Conditions = []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}}
+	}
+	return obj
+}
+
+func withReadyAddress(o *gcpv1beta1.ComputeAddress, ip string) client.Object {
+	o.Generation = 1
+	o.Status.ObservedGeneration = int64Ptr2(1)
+	o.Status.Conditions = []gcpv1beta1.Condition{{Type: "Ready", Status: "True"}}
+	o.Status.ObservedState = &gcpv1beta1.ComputeAddressObservedState{Address: strPtr(ip)}
+	return o
+}

--- a/cloudprovider/googlecloud/googlecloud.go
+++ b/cloudprovider/googlecloud/googlecloud.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	log "k8s.io/klog/v2"
+
+	"github.com/openkruise/kruise-game/cloudprovider"
+)
+
+// GoogleCloud is the name of this cloud provider, returned by Provider.Name().
+const GoogleCloud = "GoogleCloud"
+
+var googleCloudProvider = &Provider{
+	plugins: make(map[string]cloudprovider.Plugin),
+}
+
+// Provider implements cloudprovider.CloudProvider for Google Cloud.
+type Provider struct {
+	plugins map[string]cloudprovider.Plugin
+}
+
+// Name returns the cloud provider name.
+func (p *Provider) Name() string { return GoogleCloud }
+
+// ListPlugins returns all registered Google Cloud network plugins.
+func (p *Provider) ListPlugins() (map[string]cloudprovider.Plugin, error) {
+	if p.plugins == nil {
+		return make(map[string]cloudprovider.Plugin), nil
+	}
+	return p.plugins, nil
+}
+
+// registerPlugin registers a plugin into the provider. Each plugin's init()
+// calls this to attach itself.
+func (p *Provider) registerPlugin(plugin cloudprovider.Plugin) {
+	name := plugin.Name()
+	if name == "" {
+		log.Fatal("empty google cloud plugin name")
+	}
+	p.plugins[name] = plugin
+}
+
+// NewGoogleCloudProvider returns the singleton Google Cloud provider for the
+// manager to register.
+func NewGoogleCloudProvider() (cloudprovider.CloudProvider, error) {
+	return googleCloudProvider, nil
+}

--- a/cloudprovider/googlecloud/naming.go
+++ b/cloudprovider/googlecloud/naming.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// dns1123 matches lower-case Kubernetes DNS-1123 label segments (we use it to
+// scrub names of disallowed characters before stuffing them into KCC metadata).
+var dns1123 = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// DeriveResourceID returns a deterministic, DNS-1123-safe GCP resource name
+// derived from a stable Kubernetes UID plus a short kind suffix.
+//
+// The same (uid, suffix) pair always yields the same ID, so a plugin restart
+// will adopt the existing KCC CR via spec.resourceID. The hash collapses the
+// UID into 10 hex characters, leaving plenty of room for the suffix and a
+// fixed "gs-" prefix while staying under the 63-character cap.
+func DeriveResourceID(uid types.UID, suffix string) string {
+	sum := sha1.Sum([]byte(string(uid)))
+	hash := hex.EncodeToString(sum[:5]) // 10 hex chars
+	suffix = sanitizeSuffix(suffix)
+	out := fmt.Sprintf("gs-%s-%s", suffix, hash)
+	if len(out) > 63 {
+		out = out[:63]
+	}
+	return strings.TrimRight(out, "-")
+}
+
+// DeriveServiceName returns the K8s Service name a plugin uses for a given pod.
+// Single Service per pod, suffixed by the plugin nickname so passthrough and
+// proxy plugins on the same pod do not collide.
+func DeriveServiceName(podName, pluginSuffix string) string {
+	pluginSuffix = sanitizeSuffix(pluginSuffix)
+	name := fmt.Sprintf("%s-%s", podName, pluginSuffix)
+	if len(name) > 63 {
+		// Hash the over-long suffix portion so the result is still deterministic.
+		sum := sha1.Sum([]byte(name))
+		name = fmt.Sprintf("%s-%s", podName, hex.EncodeToString(sum[:5]))
+		if len(name) > 63 {
+			name = name[:63]
+		}
+	}
+	return strings.TrimRight(name, "-")
+}
+
+func sanitizeSuffix(s string) string {
+	s = strings.ToLower(s)
+	s = dns1123.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "x"
+	}
+	return s
+}

--- a/cloudprovider/googlecloud/naming.go
+++ b/cloudprovider/googlecloud/naming.go
@@ -42,6 +42,28 @@ func DeriveResourceID(uid types.UID, suffix string) string {
 	return strings.TrimRight(out, "-")
 }
 
+// DeriveStableResourceID returns a deterministic GCP resource name that is
+// STABLE across Pod recreation. It is keyed on the owning GameServerSet UID
+// plus the replica ordinal rather than the Pod UID, so a Pod that is deleted
+// and recreated at the same ordinal (rolling update, eviction, manual delete)
+// re-adopts the identical GCP resource — keeping its reserved IP and avoiding
+// a multi-minute LB rebuild.
+//
+// GSS UID + ordinal is robust regardless of GameServerTemplate.ReclaimPolicy:
+// under Cascade the GameServer object is owner-ref'd to the Pod and churns on
+// recreate, so anchoring on it would not be stable; the GSS UID never changes
+// for the life of the workload.
+func DeriveStableResourceID(gssUID types.UID, ordinal int, suffix string) string {
+	sum := sha1.Sum([]byte(fmt.Sprintf("%s-%d", gssUID, ordinal)))
+	hash := hex.EncodeToString(sum[:5]) // 10 hex chars
+	suffix = sanitizeSuffix(suffix)
+	out := fmt.Sprintf("gs-%s-%s", suffix, hash)
+	if len(out) > 63 {
+		out = out[:63]
+	}
+	return strings.TrimRight(out, "-")
+}
+
 // DeriveServiceName returns the K8s Service name a plugin uses for a given pod.
 // Single Service per pod, suffixed by the plugin nickname so passthrough and
 // proxy plugins on the same pod do not collide.

--- a/cloudprovider/googlecloud/neg_watcher.go
+++ b/cloudprovider/googlecloud/neg_watcher.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NEGRef identifies one zonal Network Endpoint Group exposed by the in-cluster
+// GKE NEG controller in response to a cloud.google.com/neg Service annotation.
+type NEGRef struct {
+	Name string
+	Zone string
+}
+
+// SelfLink returns the GCP selfLink form used by ComputeBackendService backends.
+func (n NEGRef) SelfLink(projectID string) string {
+	return fmt.Sprintf("projects/%s/zones/%s/networkEndpointGroups/%s", projectID, n.Zone, n.Name)
+}
+
+// negStatusAnnotation matches the JSON written into Service annotations by the
+// GKE NEG controller. Shape:
+//   {
+//     "network_endpoint_groups": {"<port>":"<neg-name>"},
+//     "zones": ["us-central1-a","us-central1-b"]
+//   }
+type negStatusAnnotation struct {
+	NetworkEndpointGroups map[string]string `json:"network_endpoint_groups"`
+	Zones                 []string          `json:"zones"`
+}
+
+// ParseNEGStatusAnnotation extracts per-port NEG refs (one per zone) from the
+// cloud.google.com/neg-status annotation. Returns map[port -> []NEGRef].
+// Returns (nil, nil) when the annotation is absent or empty (not yet populated).
+func ParseNEGStatusAnnotation(svc *corev1.Service) (map[int32][]NEGRef, error) {
+	if svc == nil || svc.Annotations == nil {
+		return nil, nil
+	}
+	raw := svc.Annotations[NEGStatusAnnotationKey]
+	if raw == "" {
+		return nil, nil
+	}
+	var ann negStatusAnnotation
+	if err := json.Unmarshal([]byte(raw), &ann); err != nil {
+		return nil, fmt.Errorf("googlecloud: parse %s on Service %s/%s: %w", NEGStatusAnnotationKey, svc.Namespace, svc.Name, err)
+	}
+	if len(ann.NetworkEndpointGroups) == 0 || len(ann.Zones) == 0 {
+		return nil, nil
+	}
+	sort.Strings(ann.Zones)
+	out := make(map[int32][]NEGRef, len(ann.NetworkEndpointGroups))
+	for portStr, negName := range ann.NetworkEndpointGroups {
+		port, err := strconv.ParseInt(portStr, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("googlecloud: invalid port %q in %s on Service %s/%s", portStr, NEGStatusAnnotationKey, svc.Namespace, svc.Name)
+		}
+		refs := make([]NEGRef, 0, len(ann.Zones))
+		for _, z := range ann.Zones {
+			refs = append(refs, NEGRef{Name: negName, Zone: z})
+		}
+		out[int32(port)] = refs
+	}
+	return out, nil
+}
+

--- a/cloudprovider/googlecloud/neg_watcher.go
+++ b/cloudprovider/googlecloud/neg_watcher.go
@@ -33,10 +33,11 @@ func (n NEGRef) SelfLink(projectID string) string {
 
 // negStatusAnnotation matches the JSON written into Service annotations by the
 // GKE NEG controller. Shape:
-//   {
-//     "network_endpoint_groups": {"<port>":"<neg-name>"},
-//     "zones": ["us-central1-a","us-central1-b"]
-//   }
+//
+//	{
+//	  "network_endpoint_groups": {"<port>":"<neg-name>"},
+//	  "zones": ["us-central1-a","us-central1-b"]
+//	}
 type negStatusAnnotation struct {
 	NetworkEndpointGroups map[string]string `json:"network_endpoint_groups"`
 	Zones                 []string          `json:"zones"`
@@ -75,4 +76,3 @@ func ParseNEGStatusAnnotation(svc *corev1.Service) (map[int32][]NEGRef, error) {
 	}
 	return out, nil
 }
-

--- a/cloudprovider/googlecloud/ownership.go
+++ b/cloudprovider/googlecloud/ownership.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/pkg/util"
+)
+
+// gssOwnerRef returns an OwnerReference pointing at the GameServerSet. KCC CRs
+// (ComputeAddress, etc.) and the per-pod Service are anchored on the GSS — not
+// the Pod — so a Pod recreate at the same ordinal does NOT cascade-delete the
+// reserved IP or load balancer. Cleanup on scale-down / GSS deletion is handled
+// explicitly in OnPodDeleted (see shouldReleaseSlot).
+func gssOwnerRef(gss *gamekruiseiov1alpha1.GameServerSet) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         gss.APIVersion,
+		Kind:               gss.Kind,
+		Name:               gss.GetName(),
+		UID:                gss.GetUID(),
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+}
+
+// shouldReleaseSlot decides, during OnPodDeleted, whether the GCP resources for
+// this replica slot must be torn down (true) or preserved across a transient
+// Pod recreate (false).
+//
+// Release when EITHER:
+//   - the owning GameServerSet is gone or being deleted (whole-workload teardown), OR
+//   - the Pod's ordinal is >= the GameServerSet's desired replica count
+//     (a genuine scale-down — this slot will not come back).
+//
+// Otherwise the Pod is being recreated at an ordinal that is still in range
+// (rolling update, eviction, manual delete) and the reserved IP + LB are kept.
+func shouldReleaseSlot(ctx context.Context, c client.Client, namespace, gssName, podName string) bool {
+	gss := &gamekruiseiov1alpha1.GameServerSet{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: gssName}, gss)
+	if err != nil {
+		// GSS not found → workload deleted → release.
+		return true
+	}
+	if gss.DeletionTimestamp != nil {
+		return true
+	}
+	if gss.Spec.Replicas == nil {
+		// Defensive: without a replica count we cannot prove the slot is in
+		// range, so keep it (avoid destroying a live IP on ambiguous state).
+		return false
+	}
+	ordinal := util.GetIndexFromGsName(podName)
+	return ordinal >= int(*gss.Spec.Replicas)
+}

--- a/cloudprovider/googlecloud/ownership_test.go
+++ b/cloudprovider/googlecloud/ownership_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+// TestDeriveStableResourceID_StableAcrossPodRecreate is the core guarantee of
+// the IP-stability rework: the GCP resourceID depends only on (gssUID, ordinal),
+// so a Pod recreate (new Pod UID, same ordinal) yields the identical resourceID
+// and therefore re-adopts the same reserved IP.
+func TestDeriveStableResourceID_StableAcrossPodRecreate(t *testing.T) {
+	gssUID := types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	a := DeriveStableResourceID(gssUID, 0, "pnlb-addr")
+	b := DeriveStableResourceID(gssUID, 0, "pnlb-addr") // "after pod recreate"
+	if a != b {
+		t.Fatalf("resourceID not stable across recreate: %q vs %q", a, b)
+	}
+	if len(a) > 63 {
+		t.Fatalf("resourceID over 63 chars: %d / %q", len(a), a)
+	}
+}
+
+// TestDeriveStableResourceID_DistinctPerOrdinal ensures replicas don't collide.
+func TestDeriveStableResourceID_DistinctPerOrdinal(t *testing.T) {
+	gssUID := types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	seen := map[string]bool{}
+	for i := 0; i < 5; i++ {
+		id := DeriveStableResourceID(gssUID, i, "pnlb-addr")
+		if seen[id] {
+			t.Fatalf("ordinal %d collided: %q", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+// TestDeriveStableResourceID_DistinctPerGSS ensures two GameServerSets (even
+// same ordinal) don't share GCP resources.
+func TestDeriveStableResourceID_DistinctPerGSS(t *testing.T) {
+	a := DeriveStableResourceID(types.UID("11111111-1111-1111-1111-111111111111"), 0, "pnlb-addr")
+	b := DeriveStableResourceID(types.UID("22222222-2222-2222-2222-222222222222"), 0, "pnlb-addr")
+	if a == b {
+		t.Fatalf("different GSS UIDs collided: %q", a)
+	}
+}
+
+// TestDeriveStableResourceID_DistinctPerSuffix ensures the 6 proxy resources
+// for one slot get distinct names.
+func TestDeriveStableResourceID_DistinctPerSuffix(t *testing.T) {
+	gssUID := types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	suffixes := []string{"gpnlb-hc", "gpnlb-bes", "gpnlb-tp", "gpnlb-addr", "gpnlb-fr", "gpnlb-fw"}
+	seen := map[string]bool{}
+	for _, s := range suffixes {
+		id := DeriveStableResourceID(gssUID, 0, s)
+		if seen[id] {
+			t.Fatalf("suffix %q collided: %q", s, id)
+		}
+		seen[id] = true
+	}
+}
+
+func gssForTest(name, ns string, uid types.UID, replicas int32) *gamekruiseiov1alpha1.GameServerSet {
+	return &gamekruiseiov1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: uid},
+		Spec:       gamekruiseiov1alpha1.GameServerSetSpec{Replicas: ptr.To(replicas)},
+	}
+}
+
+func TestShouldReleaseSlot(t *testing.T) {
+	scheme := testScheme(t)
+
+	t.Run("in-range ordinal is preserved (pod recreate)", func(t *testing.T) {
+		gss := gssForTest("gs", "ns1", "u1", 3)
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss).Build()
+		// ordinal 0 < replicas 3 → keep
+		if shouldReleaseSlot(context.Background(), cli, "ns1", "gs", "gs-0") {
+			t.Fatal("ordinal 0 of replicas=3 should be preserved")
+		}
+	})
+
+	t.Run("out-of-range ordinal is released (scale-down)", func(t *testing.T) {
+		gss := gssForTest("gs", "ns1", "u1", 2)
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss).Build()
+		// ordinal 2 >= replicas 2 → release
+		if !shouldReleaseSlot(context.Background(), cli, "ns1", "gs", "gs-2") {
+			t.Fatal("ordinal 2 of replicas=2 should be released")
+		}
+	})
+
+	t.Run("missing GSS is released (workload deleted)", func(t *testing.T) {
+		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		if !shouldReleaseSlot(context.Background(), cli, "ns1", "gs", "gs-0") {
+			t.Fatal("missing GSS should release")
+		}
+	})
+
+	t.Run("GSS being deleted is released", func(t *testing.T) {
+		gss := gssForTest("gs", "ns1", "u1", 3)
+		now := metav1.Now()
+		gss.DeletionTimestamp = &now
+		gss.Finalizers = []string{"x"} // fake client requires a finalizer to accept a deletionTimestamp
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss).Build()
+		if !shouldReleaseSlot(context.Background(), cli, "ns1", "gs", "gs-0") {
+			t.Fatal("deleting GSS should release")
+		}
+	})
+}
+
+// TestOnPodDeleted_PreservesOnRecreate verifies that, for an in-range ordinal,
+// OnPodDeleted keeps the ComputeAddress + Service (so the new Pod keeps its IP)
+// and only removes the finalizer.
+func TestOnPodDeleted_PreservesOnRecreate(t *testing.T) {
+	scheme := testScheme(t)
+	gss := gssForTest("gs", "ns1", "u1", 3)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/TCP"),
+		confEntry("Region", "asia-east1"),
+	})
+	pod.Finalizers = []string{PodFinalizer}
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := &gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: "ns1"}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gss, pod, addr).Build()
+	p := newPlugin(t)
+	if perr := p.OnPodDeleted(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodDeleted: %v", perr)
+	}
+	// Address must still exist (preserved across recreate).
+	got := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: addrName}, got); err != nil {
+		t.Fatalf("ComputeAddress should be preserved on in-range pod recreate, got: %v", err)
+	}
+	// Finalizer should be removed so the Pod can complete deletion.
+	gotPod := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "gs-0"}, gotPod); err == nil {
+		if containsFinalizer(gotPod.Finalizers, PodFinalizer) {
+			t.Fatal("finalizer should be removed on recreate")
+		}
+	}
+}

--- a/cloudprovider/googlecloud/passthrough_nlb.go
+++ b/cloudprovider/googlecloud/passthrough_nlb.go
@@ -1,0 +1,576 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	log "k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/cloudprovider"
+	cperrors "github.com/openkruise/kruise-game/cloudprovider/errors"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+	provideroptions "github.com/openkruise/kruise-game/cloudprovider/options"
+	"github.com/openkruise/kruise-game/cloudprovider/utils"
+	"github.com/openkruise/kruise-game/pkg/util"
+)
+
+const (
+	// PassthroughNlbNetwork is the value users put in
+	// spec.network.networkType to select this plugin.
+	PassthroughNlbNetwork = "GoogleCloud-PassthroughNLB"
+	// AliasPassthroughNlb is the cross-cloud alias.
+	AliasPassthroughNlb = "NLB-Network"
+
+	// passthroughSuffix tags resources owned by this plugin in K8s metadata.
+	passthroughSuffix = "gcp-pnlb"
+
+	// maxPassthroughPorts mirrors the GCP Passthrough NLB forwarding-rule
+	// per-rule port cap. We reject configs above this limit at parse time.
+	maxPassthroughPorts = 5
+)
+
+// PassthroughNlbPlugin provisions a regional External or Internal Passthrough
+// Network Load Balancer per Pod. It uses the GKE in-cluster LB controller for
+// the FR/BES/HC stack (via Service of type=LoadBalancer + cloud.google.com/l4-rbs
+// annotation) and reconciles a KCC ComputeAddress separately for the static VIP.
+type PassthroughNlbPlugin struct {
+	projectID             string
+	defaultRegion         string
+	defaultNetwork        string
+	defaultSubnetwork     string
+	defaultNetworkTier    string
+	retainOnDeleteDefault bool
+	// apiClient is a non-caching client used for KCC CR operations. The
+	// caching client passed into On* would otherwise block waiting for
+	// informers that are never started for KCC types.
+	apiClient client.Client
+	mutex     sync.RWMutex
+}
+
+// Name implements cloudprovider.Plugin.
+func (p *PassthroughNlbPlugin) Name() string { return PassthroughNlbNetwork }
+
+// Alias implements cloudprovider.Plugin.
+func (p *PassthroughNlbPlugin) Alias() string { return AliasPassthroughNlb }
+
+// Init implements cloudprovider.Plugin. Refuses to start when KCC CRDs are
+// missing — the returned error is logged by provider_manager.Init and the
+// plugin is then absent from the registry.
+func (p *PassthroughNlbPlugin) Init(c client.Client, opts cloudprovider.CloudProviderOptions, ctx context.Context) error {
+	gcpOpts, ok := opts.(provideroptions.GoogleCloudOptions)
+	if !ok {
+		return fmt.Errorf("googlecloud passthrough: expected GoogleCloudOptions, got %T", opts)
+	}
+	if !gcpOpts.PassthroughNLB.Enable {
+		log.Infof("[%s] plugin disabled via PassthroughNLB.Enable=false", PassthroughNlbNetwork)
+		return nil
+	}
+
+	p.mutex.Lock()
+	p.projectID = gcpOpts.ProjectID
+	p.defaultRegion = gcpOpts.DefaultRegion
+	p.defaultNetwork = gcpOpts.DefaultNetwork
+	p.defaultSubnetwork = gcpOpts.DefaultSubnetwork
+	p.defaultNetworkTier = gcpOpts.PassthroughNLB.NetworkTier
+	if p.defaultNetworkTier == "" {
+		p.defaultNetworkTier = "PREMIUM"
+	}
+	p.retainOnDeleteDefault = gcpOpts.PassthroughNLB.RetainOnDeleteDefault
+	p.mutex.Unlock()
+
+	cfg := ctrl.GetConfigOrDie()
+	if err := VerifyKCCInstalled(cfg); err != nil {
+		// Refuse-to-start: the error message embeds the gcloud command.
+		return err
+	}
+	apiClient, err := client.New(cfg, client.Options{Scheme: c.Scheme(), Mapper: c.RESTMapper()})
+	if err != nil {
+		return fmt.Errorf("googlecloud passthrough: build non-caching client: %w", err)
+	}
+	p.mutex.Lock()
+	p.apiClient = apiClient
+	p.mutex.Unlock()
+	log.Infof("[%s] initialized (projectID=%s region=%s networkTier=%s)",
+		PassthroughNlbNetwork, p.projectID, p.defaultRegion, p.defaultNetworkTier)
+	return nil
+}
+
+// passthroughConfig is the parsed NetworkConfParams for this plugin.
+type passthroughConfig struct {
+	ProjectID         string
+	Region            string
+	Scheme            string // External | Internal
+	Network           string
+	Subnetwork        string
+	AllowGlobalAccess bool
+	NetworkTier       string
+	TargetPorts       []int
+	Protocols         []corev1.Protocol
+	Annotations       map[string]string
+	RetainOnDelete    bool
+}
+
+func (p *PassthroughNlbPlugin) parseConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) (*passthroughConfig, error) {
+	p.mutex.RLock()
+	out := &passthroughConfig{
+		ProjectID:      p.projectID,
+		Region:         p.defaultRegion,
+		Scheme:         SchemeExternal,
+		Network:        p.defaultNetwork,
+		Subnetwork:     p.defaultSubnetwork,
+		NetworkTier:    p.defaultNetworkTier,
+		RetainOnDelete: p.retainOnDeleteDefault,
+		Annotations:    map[string]string{},
+	}
+	p.mutex.RUnlock()
+
+	for _, c := range conf {
+		switch c.Name {
+		case ConfProjectID:
+			out.ProjectID = strings.TrimSpace(c.Value)
+		case ConfRegion:
+			out.Region = strings.TrimSpace(c.Value)
+		case ConfScheme:
+			v := strings.TrimSpace(c.Value)
+			if v != SchemeExternal && v != SchemeInternal {
+				return nil, fmt.Errorf("invalid Scheme %q (want External or Internal)", c.Value)
+			}
+			out.Scheme = v
+		case ConfNetwork:
+			out.Network = strings.TrimSpace(c.Value)
+		case ConfSubnetwork:
+			out.Subnetwork = strings.TrimSpace(c.Value)
+		case ConfAllowGlobalAccess:
+			v, err := strconv.ParseBool(strings.TrimSpace(c.Value))
+			if err != nil {
+				return nil, fmt.Errorf("invalid AllowGlobalAccess: %w", err)
+			}
+			out.AllowGlobalAccess = v
+		case ConfNetworkTier:
+			v := strings.TrimSpace(c.Value)
+			if v != "" && v != "PREMIUM" && v != "STANDARD" {
+				return nil, fmt.Errorf("invalid NetworkTier %q (want PREMIUM or STANDARD)", c.Value)
+			}
+			if v != "" {
+				out.NetworkTier = v
+			}
+		case ConfPortProtocols:
+			for _, pp := range strings.Split(c.Value, ",") {
+				pp = strings.TrimSpace(pp)
+				if pp == "" {
+					continue
+				}
+				parts := strings.Split(pp, "/")
+				port, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+				if err != nil {
+					return nil, fmt.Errorf("invalid PortProtocols port %q: %w", parts[0], err)
+				}
+				if port < 1 || port > 65535 {
+					return nil, fmt.Errorf("invalid PortProtocols port %d (1-65535)", port)
+				}
+				proto := corev1.ProtocolTCP
+				if len(parts) > 1 {
+					proto = corev1.Protocol(strings.ToUpper(strings.TrimSpace(parts[1])))
+					if proto != corev1.ProtocolTCP && proto != corev1.ProtocolUDP {
+						return nil, fmt.Errorf("invalid PortProtocols protocol %q (want TCP or UDP)", parts[1])
+					}
+				}
+				out.TargetPorts = append(out.TargetPorts, port)
+				out.Protocols = append(out.Protocols, proto)
+			}
+		case ConfAnnotations:
+			for _, kv := range strings.Split(c.Value, ",") {
+				kv = strings.TrimSpace(kv)
+				if kv == "" {
+					continue
+				}
+				eq := strings.Index(kv, "=")
+				if eq <= 0 || eq == len(kv)-1 {
+					return nil, fmt.Errorf("invalid Annotations entry %q (want key=value)", kv)
+				}
+				out.Annotations[kv[:eq]] = kv[eq+1:]
+			}
+		case ConfRetainOnDelete:
+			v, err := strconv.ParseBool(strings.TrimSpace(c.Value))
+			if err != nil {
+				return nil, fmt.Errorf("invalid RetainOnDelete: %w", err)
+			}
+			out.RetainOnDelete = v
+		}
+	}
+
+	if len(out.TargetPorts) == 0 {
+		return nil, fmt.Errorf("PortProtocols is required (e.g. PortProtocols=7777/UDP,7778/TCP)")
+	}
+	if len(out.TargetPorts) > maxPassthroughPorts {
+		return nil, fmt.Errorf("PortProtocols has %d entries, GCP Passthrough NLB allows at most %d per forwarding rule",
+			len(out.TargetPorts), maxPassthroughPorts)
+	}
+	if out.Region == "" {
+		return nil, fmt.Errorf("region is required (set per-GSS via NetworkConf Region= or set default_region in TOML)")
+	}
+	if out.Scheme == SchemeInternal {
+		if out.Network == "" {
+			return nil, fmt.Errorf("network is required for Scheme=Internal")
+		}
+		if out.Subnetwork == "" {
+			return nil, fmt.Errorf("subnetwork is required for Scheme=Internal")
+		}
+	}
+	return out, nil
+}
+
+// OnPodAdded ensures the Finalizer is present when RetainOnDelete=false. The
+// admission webhook persists the mutated Pod.
+func (p *PassthroughNlbPlugin) OnPodAdded(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	nm := utils.NewNetworkManager(pod, c)
+	if nm == nil {
+		return pod, nil
+	}
+	cfg, err := p.parseConfig(nm.GetNetworkConfig())
+	if err != nil {
+		return pod, cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+	if !cfg.RetainOnDelete {
+		if EnsurePodFinalizer(pod, PodFinalizer) {
+			log.Infof("[%s] added Finalizer to pod %s/%s", PassthroughNlbNetwork, pod.Namespace, pod.Name)
+		}
+	}
+	return pod, nil
+}
+
+// OnPodUpdated is the main reconcile.
+func (p *PassthroughNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	nm := utils.NewNetworkManager(pod, c)
+	if nm == nil {
+		return pod, nil
+	}
+	cfg, err := p.parseConfig(nm.GetNetworkConfig())
+	if err != nil {
+		return pod, cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+
+	netStatus, err := nm.GetNetworkStatus()
+	if err != nil {
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+	if netStatus == nil {
+		out, err := nm.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return out, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	// Track GSS-deleting on the Pod so OnPodDeleted has a non-racy signal.
+	gssName := pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+	if gssName != "" {
+		gss := &gamekruiseiov1alpha1.GameServerSet{}
+		gerr := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: gssName}, gss)
+		if gerr == nil && gss.DeletionTimestamp != nil {
+			if pod.Labels == nil {
+				pod.Labels = map[string]string{}
+			}
+			if _, ok := pod.Labels[GssDeletingLabelKey]; !ok {
+				pod.Labels[GssDeletingLabelKey] = "true"
+				return pod, nil
+			}
+		}
+	}
+
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix) // reuse short pod-anchored name
+	addrResourceID := DeriveResourceID(pod.UID, "pnlb-addr")
+	addrType := "EXTERNAL"
+	if cfg.Scheme == SchemeInternal {
+		addrType = "INTERNAL"
+	}
+	// Use non-caching client for KCC CRs (cached client would block on missing informer).
+	kccClient := p.kccClient(c)
+	addrOwners := []metav1.OwnerReference{podOwnerRef(pod)}
+	if cfg.RetainOnDelete {
+		// With Retain semantics, drop the Pod ownerRef so the reserved IP
+		// survives Pod tear-down and can be re-bound on re-create.
+		addrOwners = nil
+	}
+	if _, aerr := EnsureComputeAddress(ctx, kccClient, AddressSpec{
+		Name:          addrName,
+		Namespace:     pod.Namespace,
+		Location:      cfg.Region,
+		AddressType:   addrType,
+		NetworkTier:   cfg.NetworkTier,
+		ProjectID:     cfg.ProjectID,
+		NetworkRef:    cfg.Network,
+		SubnetworkRef: cfg.Subnetwork,
+		ResourceID:    addrResourceID,
+		OwnerRefs:     addrOwners,
+	}); aerr != nil {
+		return pod, cperrors.ToPluginError(aerr, cperrors.ApiCallError)
+	}
+
+	addrIP, addrReady, aerr := WaitForAddressReady(ctx, kccClient, types.NamespacedName{Namespace: pod.Namespace, Name: addrName})
+	if aerr != nil {
+		return pod, cperrors.ToPluginError(aerr, cperrors.ApiCallError)
+	}
+	if !addrReady {
+		log.V(1).Infof("[%s] ComputeAddress %s/%s not ready yet", PassthroughNlbNetwork, pod.Namespace, addrName)
+		out, err := nm.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return out, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	svcName := DeriveServiceName(pod.Name, passthroughSuffix)
+	// The GKE LB controller adopts a reserved IP by GCP resource name
+	// (ComputeAddress.spec.resourceID), not the K8s metadata.name.
+	// For Internal LB, GKE expects spec.loadBalancerIP to carry the actual IP.
+	// Pass the disable state in so ensureService doesn't re-assert
+	// Type=LoadBalancer on every reconcile and clobber a deliberate disable.
+	disabled := nm.GetNetworkDisabled()
+	svc, serr := p.ensureService(ctx, c, pod, cfg, svcName, addrResourceID, addrIP, disabled)
+	if serr != nil {
+		return pod, cperrors.ToPluginError(serr, cperrors.ApiCallError)
+	}
+	if disabled {
+		// Don't go further — when disabled the LB is intentionally torn down.
+		out, err := nm.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return out, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	if util.IsAllowNotReadyContainers(nm.GetNetworkConfig()) {
+		changed, perr := utils.AllowNotReadyContainers(c, ctx, pod, svc, false)
+		if perr != nil {
+			return pod, perr
+		}
+		if changed {
+			if uerr := c.Update(ctx, svc); uerr != nil {
+				return pod, cperrors.ToPluginError(uerr, cperrors.ApiCallError)
+			}
+		}
+	}
+
+	// Wait for the LB to settle. The reserved IP is authoritative once the
+	// Service ingress IP matches; until then mark NotReady.
+	if len(svc.Status.LoadBalancer.Ingress) == 0 || svc.Status.LoadBalancer.Ingress[0].IP == "" {
+		log.V(1).Infof("[%s] Service %s/%s LoadBalancer ingress not assigned yet", PassthroughNlbNetwork, pod.Namespace, svc.Name)
+		out, err := nm.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return out, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	// Build NetworkStatus from cfg.TargetPorts + the reserved IP.
+	internal := make([]gamekruiseiov1alpha1.NetworkAddress, 0, len(cfg.TargetPorts))
+	external := make([]gamekruiseiov1alpha1.NetworkAddress, 0, len(cfg.TargetPorts))
+	for i, tp := range cfg.TargetPorts {
+		intInternal := intstr.FromInt(tp)
+		intExternal := intstr.FromInt(tp) // passthrough preserves the wire port
+		internal = append(internal, gamekruiseiov1alpha1.NetworkAddress{
+			IP: pod.Status.PodIP,
+			Ports: []gamekruiseiov1alpha1.NetworkPort{{
+				Name:     strconv.Itoa(tp),
+				Port:     &intInternal,
+				Protocol: cfg.Protocols[i],
+			}},
+		})
+		external = append(external, gamekruiseiov1alpha1.NetworkAddress{
+			IP: addrIP,
+			Ports: []gamekruiseiov1alpha1.NetworkPort{{
+				Name:     strconv.Itoa(tp),
+				Port:     &intExternal,
+				Protocol: cfg.Protocols[i],
+			}},
+		})
+	}
+	netStatus.InternalAddresses = internal
+	netStatus.ExternalAddresses = external
+	netStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkReady
+	out, uerr := nm.UpdateNetworkStatus(*netStatus, pod)
+	return out, cperrors.ToPluginError(uerr, cperrors.InternalError)
+}
+
+// OnPodDeleted runs when the pod is being torn down. With RetainOnDelete=false
+// we remove the per-pod ComputeAddress and our Finalizer.
+func (p *PassthroughNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ctx context.Context) cperrors.PluginError {
+	nm := utils.NewNetworkManager(pod, c)
+	if nm == nil {
+		return nil
+	}
+	cfg, err := p.parseConfig(nm.GetNetworkConfig())
+	if err != nil {
+		// Still try to remove the Finalizer so we don't pin the pod.
+		_ = RemovePodFinalizer(ctx, c, pod, PodFinalizer)
+		return cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+	if cfg.RetainOnDelete {
+		return RemovePodFinalizerPlugin(ctx, c, pod)
+	}
+
+	// Delete the per-pod Service first (the GKE LB controller deletes the FR
+	// chain when the Service goes away), then the ComputeAddress.
+	svcName := DeriveServiceName(pod.Name, passthroughSuffix)
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: pod.Namespace}}
+	if derr := c.Delete(ctx, svc); derr != nil && !apierrors.IsNotFound(derr) {
+		log.Errorf("[%s] delete Service %s/%s: %v", PassthroughNlbNetwork, pod.Namespace, svcName, derr)
+		return cperrors.ToPluginError(derr, cperrors.ApiCallError)
+	}
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addrTyped := &gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: pod.Namespace}}
+	if derr := p.kccClient(c).Delete(ctx, addrTyped); derr != nil && !apierrors.IsNotFound(derr) {
+		log.Errorf("[%s] delete ComputeAddress %s/%s: %v", PassthroughNlbNetwork, pod.Namespace, addrName, derr)
+		return cperrors.ToPluginError(derr, cperrors.ApiCallError)
+	}
+	return RemovePodFinalizerPlugin(ctx, c, pod)
+}
+
+// ensureService creates or updates the per-pod Service. Type=LoadBalancer +
+// the right GKE annotations get the in-cluster controller to do the heavy
+// lifting (FR / BES / HC) while we own only the IP via ComputeAddress.
+//
+// addrGCPName is the ComputeAddress.spec.resourceID (the GCP-side name) used
+// to adopt the reserved External IP via annotation. addrIPValue is the actual
+// IP string used to adopt the reserved Internal IP via spec.loadBalancerIP
+// (GKE Internal LB controller ignores the External annotation).
+//
+// disabled=true sets the Service to ClusterIP (no LB), giving operators a way
+// to drain a pod's external traffic without deleting the GameServer.
+func (p *PassthroughNlbPlugin) ensureService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *passthroughConfig, svcName, addrGCPName, addrIPValue string, disabled bool) (*corev1.Service, error) {
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: pod.Namespace}}
+	mutate := func() error {
+		if svc.Labels == nil {
+			svc.Labels = map[string]string{}
+		}
+		svc.Labels[ResourceTagKey] = ResourceTagValue
+		svc.Labels[gamekruiseiov1alpha1.GameServerOwnerGssKey] =
+			pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+		if svc.Annotations == nil {
+			svc.Annotations = map[string]string{}
+		}
+		// IP adoption:
+		//   External LB → annotation carries the GCP Address name (the RBS path).
+		//   Internal LB → spec.loadBalancerIP carries the actual IP value.
+		if cfg.Scheme == SchemeExternal {
+			svc.Annotations[GKELoadBalancerIPAnnotationKey] = addrGCPName
+			svc.Annotations[L4RBSAnnotationKey] = "enabled"
+			svc.Annotations[NetworkTierAnnotationKey] = cfg.NetworkTier
+			delete(svc.Annotations, GKELoadBalancerTypeAnnotationKey)
+			delete(svc.Annotations, "networking.gke.io/internal-load-balancer-allow-global-access")
+		} else {
+			delete(svc.Annotations, GKELoadBalancerIPAnnotationKey)
+			delete(svc.Annotations, L4RBSAnnotationKey)
+			delete(svc.Annotations, NetworkTierAnnotationKey)
+			svc.Annotations[GKELoadBalancerTypeAnnotationKey] = "Internal"
+			if cfg.AllowGlobalAccess {
+				svc.Annotations["networking.gke.io/internal-load-balancer-allow-global-access"] = "true"
+			} else {
+				delete(svc.Annotations, "networking.gke.io/internal-load-balancer-allow-global-access")
+			}
+		}
+		// Drift detection.
+		svc.Annotations[ConfigHashKey] = util.GetHash(cfg)
+		// User-supplied passthrough Service annotations are layered last so they
+		// can override LB-class defaults if absolutely required.
+		for k, v := range cfg.Annotations {
+			svc.Annotations[k] = v
+		}
+
+		// Service spec.
+		if disabled {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+			svc.Spec.LoadBalancerIP = ""
+		} else {
+			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+			if cfg.Scheme == SchemeInternal && addrIPValue != "" {
+				// Internal LB adopts the reserved IP via spec.loadBalancerIP.
+				svc.Spec.LoadBalancerIP = addrIPValue
+			} else {
+				svc.Spec.LoadBalancerIP = ""
+			}
+		}
+		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
+		svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+		svc.Spec.Selector = map[string]string{SvcSelectorKey: pod.Name}
+
+		ports := make([]corev1.ServicePort, 0, len(cfg.TargetPorts))
+		for i, tp := range cfg.TargetPorts {
+			ports = append(ports, corev1.ServicePort{
+				Name:       fmt.Sprintf("p%d", tp),
+				Port:       int32(tp),
+				Protocol:   cfg.Protocols[i],
+				TargetPort: intstr.FromInt(tp),
+			})
+		}
+		svc.Spec.Ports = ports
+
+		// OwnerReference cascades the Service delete with the Pod when
+		// RetainOnDelete=false (typical case). For RetainOnDelete=true we drop
+		// the owner so the Service survives the Pod and the user manages it.
+		if !cfg.RetainOnDelete {
+			svc.OwnerReferences = []metav1.OwnerReference{podOwnerRef(pod)}
+		}
+		return nil
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, svc, mutate); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+// RemovePodFinalizerPlugin is a small wrapper that maps the controller-runtime
+// error onto a PluginError; the rest of the codebase consumes PluginError so
+// the Plugin contract is preserved.
+func RemovePodFinalizerPlugin(ctx context.Context, c client.Client, pod *corev1.Pod) cperrors.PluginError {
+	if err := RemovePodFinalizer(ctx, c, pod, PodFinalizer); err != nil {
+		return cperrors.ToPluginError(err, cperrors.ApiCallError)
+	}
+	return nil
+}
+
+func podOwnerRef(pod *corev1.Pod) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         pod.APIVersion,
+		Kind:               pod.Kind,
+		Name:               pod.Name,
+		UID:                pod.UID,
+		BlockOwnerDeletion: ptr.To(true),
+	}
+}
+
+// kccClient returns the non-caching API client when Init has populated it,
+// falling back to the cached client (only happens before Init, e.g. in unit
+// tests that bypass Init entirely).
+func (p *PassthroughNlbPlugin) kccClient(fallback client.Client) client.Client {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+	if p.apiClient != nil {
+		return p.apiClient
+	}
+	return fallback
+}
+
+func init() {
+	googleCloudProvider.registerPlugin(&PassthroughNlbPlugin{})
+}

--- a/cloudprovider/googlecloud/passthrough_nlb.go
+++ b/cloudprovider/googlecloud/passthrough_nlb.go
@@ -284,35 +284,39 @@ func (p *PassthroughNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ct
 		return out, cperrors.ToPluginError(err, cperrors.InternalError)
 	}
 
-	// Track GSS-deleting on the Pod so OnPodDeleted has a non-racy signal.
+	// Resolve the owning GameServerSet once. It is the stable anchor for both
+	// the resourceID (so the reserved IP survives Pod recreate) and the
+	// OwnerReference (so cleanup is tied to the workload, not the Pod).
 	gssName := pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
-	if gssName != "" {
-		gss := &gamekruiseiov1alpha1.GameServerSet{}
-		gerr := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: gssName}, gss)
-		if gerr == nil && gss.DeletionTimestamp != nil {
-			if pod.Labels == nil {
-				pod.Labels = map[string]string{}
-			}
-			if _, ok := pod.Labels[GssDeletingLabelKey]; !ok {
-				pod.Labels[GssDeletingLabelKey] = "true"
-				return pod, nil
-			}
+	gss := &gamekruiseiov1alpha1.GameServerSet{}
+	gssErr := c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: gssName}, gss)
+	if gssErr == nil && gss.DeletionTimestamp != nil {
+		// GSS being deleted — flag the Pod so OnPodDeleted has a non-racy signal.
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+		if _, ok := pod.Labels[GssDeletingLabelKey]; !ok {
+			pod.Labels[GssDeletingLabelKey] = "true"
+			return pod, nil
 		}
 	}
 
-	addrName := DeriveServiceName(pod.Name, passthroughSuffix) // reuse short pod-anchored name
-	addrResourceID := DeriveResourceID(pod.UID, "pnlb-addr")
+	ordinal := util.GetIndexFromGsName(pod.Name)
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix) // K8s metadata.name, stable per ordinal
+	// GCP-side resourceID is anchored on GSS UID + ordinal so a Pod recreate
+	// re-adopts the same reserved IP instead of allocating a fresh one.
+	addrResourceID := DeriveStableResourceID(gss.GetUID(), ordinal, "pnlb-addr")
 	addrType := "EXTERNAL"
 	if cfg.Scheme == SchemeInternal {
 		addrType = "INTERNAL"
 	}
 	// Use non-caching client for KCC CRs (cached client would block on missing informer).
 	kccClient := p.kccClient(c)
-	addrOwners := []metav1.OwnerReference{podOwnerRef(pod)}
-	if cfg.RetainOnDelete {
-		// With Retain semantics, drop the Pod ownerRef so the reserved IP
-		// survives Pod tear-down and can be re-bound on re-create.
-		addrOwners = nil
+	// Anchor ownership on the GSS (survives Pod recreate). With RetainOnDelete
+	// drop the owner entirely so the IP outlives even GSS deletion.
+	var addrOwners []metav1.OwnerReference
+	if !cfg.RetainOnDelete && gssErr == nil {
+		addrOwners = []metav1.OwnerReference{gssOwnerRef(gss)}
 	}
 	if _, aerr := EnsureComputeAddress(ctx, kccClient, AddressSpec{
 		Name:          addrName,
@@ -348,7 +352,12 @@ func (p *PassthroughNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ct
 	// Pass the disable state in so ensureService doesn't re-assert
 	// Type=LoadBalancer on every reconcile and clobber a deliberate disable.
 	disabled := nm.GetNetworkDisabled()
-	svc, serr := p.ensureService(ctx, c, pod, cfg, svcName, addrResourceID, addrIP, disabled)
+	var svcOwner *metav1.OwnerReference
+	if gssErr == nil {
+		o := gssOwnerRef(gss)
+		svcOwner = &o
+	}
+	svc, serr := p.ensureService(ctx, c, pod, cfg, svcName, addrResourceID, addrIP, disabled, svcOwner)
 	if serr != nil {
 		return pod, cperrors.ToPluginError(serr, cperrors.ApiCallError)
 	}
@@ -412,8 +421,9 @@ func (p *PassthroughNlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ct
 	return out, cperrors.ToPluginError(uerr, cperrors.InternalError)
 }
 
-// OnPodDeleted runs when the pod is being torn down. With RetainOnDelete=false
-// we remove the per-pod ComputeAddress and our Finalizer.
+// OnPodDeleted runs when the pod is being torn down. Resources are released
+// only on a genuine scale-down or GSS deletion; a transient Pod recreate at an
+// in-range ordinal keeps the reserved IP + LB so the new Pod re-adopts them.
 func (p *PassthroughNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ctx context.Context) cperrors.PluginError {
 	nm := utils.NewNetworkManager(pod, c)
 	if nm == nil {
@@ -429,8 +439,20 @@ func (p *PassthroughNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ct
 		return RemovePodFinalizerPlugin(ctx, c, pod)
 	}
 
-	// Delete the per-pod Service first (the GKE LB controller deletes the FR
-	// chain when the Service goes away), then the ComputeAddress.
+	gssName := pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+	// GssDeletingLabelKey is set by OnPodUpdated when the GSS entered deletion;
+	// treat it as an immediate release signal (avoids a GSS-get race here).
+	gssDeleting := pod.Labels[GssDeletingLabelKey] == "true"
+	if !gssDeleting && !shouldReleaseSlot(ctx, c, pod.Namespace, gssName, pod.Name) {
+		// Transient recreate at an in-range ordinal — keep resources, just let
+		// the Pod finish deleting.
+		log.Infof("[%s] pod %s/%s recreating at in-range ordinal; preserving reserved IP + LB",
+			PassthroughNlbNetwork, pod.Namespace, pod.Name)
+		return RemovePodFinalizerPlugin(ctx, c, pod)
+	}
+
+	// Genuine release: delete the per-pod Service first (the GKE LB controller
+	// tears down the FR chain when the Service goes away), then the ComputeAddress.
 	svcName := DeriveServiceName(pod.Name, passthroughSuffix)
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: pod.Namespace}}
 	if derr := c.Delete(ctx, svc); derr != nil && !apierrors.IsNotFound(derr) {
@@ -443,6 +465,8 @@ func (p *PassthroughNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ct
 		log.Errorf("[%s] delete ComputeAddress %s/%s: %v", PassthroughNlbNetwork, pod.Namespace, addrName, derr)
 		return cperrors.ToPluginError(derr, cperrors.ApiCallError)
 	}
+	log.Infof("[%s] released GCP resources for pod %s/%s (scale-down or GSS deletion)",
+		PassthroughNlbNetwork, pod.Namespace, pod.Name)
 	return RemovePodFinalizerPlugin(ctx, c, pod)
 }
 
@@ -457,7 +481,7 @@ func (p *PassthroughNlbPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ct
 //
 // disabled=true sets the Service to ClusterIP (no LB), giving operators a way
 // to drain a pod's external traffic without deleting the GameServer.
-func (p *PassthroughNlbPlugin) ensureService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *passthroughConfig, svcName, addrGCPName, addrIPValue string, disabled bool) (*corev1.Service, error) {
+func (p *PassthroughNlbPlugin) ensureService(ctx context.Context, c client.Client, pod *corev1.Pod, cfg *passthroughConfig, svcName, addrGCPName, addrIPValue string, disabled bool, svcOwner *metav1.OwnerReference) (*corev1.Service, error) {
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: pod.Namespace}}
 	mutate := func() error {
 		if svc.Labels == nil {
@@ -525,11 +549,12 @@ func (p *PassthroughNlbPlugin) ensureService(ctx context.Context, c client.Clien
 		}
 		svc.Spec.Ports = ports
 
-		// OwnerReference cascades the Service delete with the Pod when
-		// RetainOnDelete=false (typical case). For RetainOnDelete=true we drop
-		// the owner so the Service survives the Pod and the user manages it.
-		if !cfg.RetainOnDelete {
-			svc.OwnerReferences = []metav1.OwnerReference{podOwnerRef(pod)}
+		// OwnerReference is anchored on the GameServerSet (not the Pod) so the
+		// Service — and the GKE-managed LB behind it — survives a Pod recreate.
+		// Cleanup on scale-down / GSS deletion is explicit (OnPodDeleted).
+		// RetainOnDelete=true drops the owner so the Service outlives even the GSS.
+		if !cfg.RetainOnDelete && svcOwner != nil {
+			svc.OwnerReferences = []metav1.OwnerReference{*svcOwner}
 		}
 		return nil
 	}
@@ -547,16 +572,6 @@ func RemovePodFinalizerPlugin(ctx context.Context, c client.Client, pod *corev1.
 		return cperrors.ToPluginError(err, cperrors.ApiCallError)
 	}
 	return nil
-}
-
-func podOwnerRef(pod *corev1.Pod) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion:         pod.APIVersion,
-		Kind:               pod.Kind,
-		Name:               pod.Name,
-		UID:                pod.UID,
-		BlockOwnerDeletion: ptr.To(true),
-	}
 }
 
 // kccClient returns the non-caching API client when Init has populated it,

--- a/cloudprovider/googlecloud/passthrough_nlb_test.go
+++ b/cloudprovider/googlecloud/passthrough_nlb_test.go
@@ -470,7 +470,7 @@ func containsFinalizer(list []string, name string) bool {
 	return false
 }
 
-func strPtr(s string) *string { return &s }
+func strPtr(s string) *string  { return &s }
 func int64Ptr2(v int64) *int64 { return &v }
 
 // silence "unused import" if test file is the only consumer of ctrlclient.

--- a/cloudprovider/googlecloud/passthrough_nlb_test.go
+++ b/cloudprovider/googlecloud/passthrough_nlb_test.go
@@ -310,7 +310,7 @@ func TestEnsureService_ExternalAnnotations(t *testing.T) {
 		t.Fatalf("parseConfig: %v", err)
 	}
 	pod := newGamePod("gs-0", "ns1", nil)
-	svc, err := plugin.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc", "gs-0-addr", "", false)
+	svc, err := plugin.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc", "gs-0-addr", "", false, nil)
 	if err != nil {
 		t.Fatalf("ensureService: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestEnsureService_InternalAnnotations(t *testing.T) {
 		t.Fatalf("parseConfig: %v", err)
 	}
 	pod := newGamePod("gs-0", "ns1", nil)
-	svc, err := plugin.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc", "gs-0-addr", "", false)
+	svc, err := plugin.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc", "gs-0-addr", "", false, nil)
 	if err != nil {
 		t.Fatalf("ensureService: %v", err)
 	}

--- a/cloudprovider/googlecloud/passthrough_nlb_test.go
+++ b/cloudprovider/googlecloud/passthrough_nlb_test.go
@@ -1,0 +1,477 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("client-go scheme: %v", err)
+	}
+	if err := gcpv1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("gcp scheme: %v", err)
+	}
+	if err := gamekruiseiov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("kruise-game scheme: %v", err)
+	}
+	return s
+}
+
+func newPlugin(t *testing.T) *PassthroughNlbPlugin {
+	t.Helper()
+	return &PassthroughNlbPlugin{
+		projectID:             "demo-project",
+		defaultRegion:         "us-central1",
+		defaultNetwork:        "default",
+		defaultSubnetwork:     "default-us-central1",
+		defaultNetworkTier:    "PREMIUM",
+		retainOnDeleteDefault: false,
+	}
+}
+
+func confEntry(name, value string) gamekruiseiov1alpha1.NetworkConfParams {
+	return gamekruiseiov1alpha1.NetworkConfParams{Name: name, Value: value}
+}
+
+func TestParseConfig_Defaults(t *testing.T) {
+	p := newPlugin(t)
+	cfg, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Scheme != SchemeExternal {
+		t.Errorf("Scheme: want External, got %q", cfg.Scheme)
+	}
+	if cfg.Region != "us-central1" {
+		t.Errorf("Region: want us-central1, got %q", cfg.Region)
+	}
+	if cfg.NetworkTier != "PREMIUM" {
+		t.Errorf("NetworkTier: want PREMIUM, got %q", cfg.NetworkTier)
+	}
+	if len(cfg.TargetPorts) != 1 || cfg.TargetPorts[0] != 7777 {
+		t.Errorf("TargetPorts: want [7777], got %v", cfg.TargetPorts)
+	}
+	if cfg.Protocols[0] != corev1.ProtocolUDP {
+		t.Errorf("Protocols[0]: want UDP, got %q", cfg.Protocols[0])
+	}
+	if cfg.RetainOnDelete != false {
+		t.Errorf("RetainOnDelete: want false (default), got true")
+	}
+}
+
+func TestParseConfig_AllFields(t *testing.T) {
+	p := newPlugin(t)
+	cfg, err := p.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("ProjectId", "override-proj"),
+		confEntry("Region", "europe-west1"),
+		confEntry("Scheme", "Internal"),
+		confEntry("Network", "vpc-1"),
+		confEntry("Subnetwork", "sub-1"),
+		confEntry("AllowGlobalAccess", "true"),
+		confEntry("NetworkTier", "STANDARD"),
+		confEntry("PortProtocols", "7777/UDP,8000/TCP"),
+		confEntry("Annotations", "foo=bar,baz=qux"),
+		confEntry("RetainOnDelete", "true"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ProjectID != "override-proj" || cfg.Region != "europe-west1" || cfg.Scheme != SchemeInternal {
+		t.Errorf("overrides not applied: %+v", cfg)
+	}
+	if !cfg.AllowGlobalAccess || cfg.NetworkTier != "STANDARD" || !cfg.RetainOnDelete {
+		t.Errorf("bool/enum overrides not applied: %+v", cfg)
+	}
+	if len(cfg.TargetPorts) != 2 || cfg.Protocols[0] != corev1.ProtocolUDP || cfg.Protocols[1] != corev1.ProtocolTCP {
+		t.Errorf("PortProtocols parse wrong: %+v", cfg)
+	}
+	if cfg.Annotations["foo"] != "bar" || cfg.Annotations["baz"] != "qux" {
+		t.Errorf("Annotations parse wrong: %+v", cfg.Annotations)
+	}
+}
+
+func TestParseConfig_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []gamekruiseiov1alpha1.NetworkConfParams
+		want    string
+	}{
+		{"missing PortProtocols", nil, "PortProtocols is required"},
+		{"invalid Scheme", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("Scheme", "Whatever"), confEntry("PortProtocols", "7777"),
+		}, "invalid Scheme"},
+		{"too many ports", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("PortProtocols", "1,2,3,4,5,6"),
+		}, "at most 5"},
+		{"invalid port number", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("PortProtocols", "70000/UDP"),
+		}, "invalid PortProtocols port 70000"},
+		{"invalid protocol", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("PortProtocols", "7777/SCTP"),
+		}, "invalid PortProtocols protocol"},
+		{"internal needs network", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("Scheme", "Internal"),
+			confEntry("Network", ""),
+			confEntry("PortProtocols", "7777"),
+		}, "network is required"},
+		{"bad annotation entry", []gamekruiseiov1alpha1.NetworkConfParams{
+			confEntry("PortProtocols", "7777"),
+			confEntry("Annotations", "novalue"),
+		}, "invalid Annotations entry"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Special case: clear defaults that the test relies on.
+			plugin := newPlugin(t)
+			if tc.name == "internal needs network" {
+				plugin.defaultNetwork = ""
+			}
+			_, err := plugin.parseConfig(tc.entries)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveResourceID_StableAndCapped(t *testing.T) {
+	uid := types.UID("11111111-2222-3333-4444-555555555555")
+	a := DeriveResourceID(uid, "pnlb-addr")
+	b := DeriveResourceID(uid, "pnlb-addr")
+	if a != b {
+		t.Fatalf("DeriveResourceID not deterministic: %q vs %q", a, b)
+	}
+	if len(a) > 63 {
+		t.Fatalf("DeriveResourceID over 63 chars: %d / %q", len(a), a)
+	}
+	other := DeriveResourceID(types.UID("99999999-2222-3333-4444-555555555555"), "pnlb-addr")
+	if other == a {
+		t.Fatalf("different UIDs collided: %q", a)
+	}
+}
+
+func TestDeriveServiceName_StableAndCapped(t *testing.T) {
+	a := DeriveServiceName("very-long-game-server-pod-name-that-may-exceed-the-limit-zzzzz", "gcp-pnlb")
+	if len(a) > 63 {
+		t.Fatalf("DeriveServiceName over 63 chars: %d / %q", len(a), a)
+	}
+	b := DeriveServiceName("very-long-game-server-pod-name-that-may-exceed-the-limit-zzzzz", "gcp-pnlb")
+	if a != b {
+		t.Fatalf("not deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestEnsureComputeAddress_Idempotent(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	spec := AddressSpec{
+		Name:        "gs-addr",
+		Namespace:   "ns1",
+		Location:    "us-central1",
+		AddressType: "EXTERNAL",
+		NetworkTier: "PREMIUM",
+		ProjectID:   "proj-1",
+		ResourceID:  "gs-addr-abc1234567",
+	}
+	if _, err := EnsureComputeAddress(context.Background(), cli, spec); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	if _, err := EnsureComputeAddress(context.Background(), cli, spec); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	got := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns1", Name: "gs-addr"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Annotations[ProjectIDAnnotation] != "proj-1" {
+		t.Errorf("project-id annotation missing: %v", got.Annotations)
+	}
+	if got.Labels[ResourceTagKey] != ResourceTagValue {
+		t.Errorf("managed-by label missing: %v", got.Labels)
+	}
+	if got.Spec.ResourceID == nil || *got.Spec.ResourceID != spec.ResourceID {
+		t.Errorf("ResourceID not set: %+v", got.Spec.ResourceID)
+	}
+	if got.Spec.NetworkTier == nil || *got.Spec.NetworkTier != "PREMIUM" {
+		t.Errorf("NetworkTier not set: %+v", got.Spec.NetworkTier)
+	}
+}
+
+func TestWaitForAddressReady_StatusGated(t *testing.T) {
+	scheme := testScheme(t)
+	addr := &gcpv1beta1.ComputeAddress{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs-addr", Namespace: "ns1", Generation: 1},
+		Status: gcpv1beta1.ComputeAddressStatus{
+			ObservedGeneration: int64Ptr2(1),
+			Conditions: []gcpv1beta1.Condition{{
+				Type: "Ready", Status: "True",
+			}},
+			ObservedState: &gcpv1beta1.ComputeAddressObservedState{
+				Address: strPtr("203.0.113.42"),
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(addr).Build()
+	ip, ready, err := WaitForAddressReady(context.Background(), cli, types.NamespacedName{Namespace: "ns1", Name: "gs-addr"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ready || ip != "203.0.113.42" {
+		t.Fatalf("want (203.0.113.42, true), got (%q, %v)", ip, ready)
+	}
+
+	// Status not Ready -> ip="", ready=false.
+	addr2 := addr.DeepCopy()
+	addr2.Status.Conditions[0].Status = "False"
+	if err := cli.Update(context.Background(), addr2); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	ip, ready, err = WaitForAddressReady(context.Background(), cli, types.NamespacedName{Namespace: "ns1", Name: "gs-addr"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ready || ip != "" {
+		t.Fatalf("want ('', false), got (%q, %v)", ip, ready)
+	}
+}
+
+func TestOnPodAdded_AddsFinalizerWhenNotRetained(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	plugin := newPlugin(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+	})
+	out, perr := plugin.OnPodAdded(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodAdded: %v", perr)
+	}
+	if !containsFinalizer(out.Finalizers, PodFinalizer) {
+		t.Fatalf("Finalizer not added; finalizers=%v", out.Finalizers)
+	}
+}
+
+func TestOnPodAdded_SkipsFinalizerWhenRetained(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	plugin := newPlugin(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+		confEntry("RetainOnDelete", "true"),
+	})
+	out, perr := plugin.OnPodAdded(cli, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodAdded: %v", perr)
+	}
+	if containsFinalizer(out.Finalizers, PodFinalizer) {
+		t.Fatalf("Finalizer should not have been added; finalizers=%v", out.Finalizers)
+	}
+}
+
+func TestEnsureService_ExternalAnnotations(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	plugin := newPlugin(t)
+	cfg, err := plugin.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP,7778/TCP"),
+	})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	pod := newGamePod("gs-0", "ns1", nil)
+	svc, err := plugin.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc", "gs-0-addr", "", false)
+	if err != nil {
+		t.Fatalf("ensureService: %v", err)
+	}
+	if svc.Annotations[L4RBSAnnotationKey] != "enabled" {
+		t.Errorf("missing l4-rbs annotation: %v", svc.Annotations)
+	}
+	if svc.Annotations[GKELoadBalancerIPAnnotationKey] != "gs-0-addr" {
+		t.Errorf("missing IP-adoption annotation: %v", svc.Annotations)
+	}
+	if _, has := svc.Annotations[GKELoadBalancerTypeAnnotationKey]; has {
+		t.Errorf("Internal LB annotation should not be set for External Scheme: %v", svc.Annotations)
+	}
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Errorf("Service type want LoadBalancer, got %q", svc.Spec.Type)
+	}
+	if svc.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyTypeLocal {
+		t.Errorf("ExternalTrafficPolicy must be Local for client-IP preservation")
+	}
+	if len(svc.Spec.Ports) != 2 {
+		t.Errorf("want 2 ports, got %d", len(svc.Spec.Ports))
+	}
+}
+
+func TestEnsureService_InternalAnnotations(t *testing.T) {
+	scheme := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	plugin := newPlugin(t)
+	cfg, err := plugin.parseConfig([]gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("Scheme", "Internal"),
+		confEntry("AllowGlobalAccess", "true"),
+		confEntry("PortProtocols", "7777/UDP"),
+	})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	pod := newGamePod("gs-0", "ns1", nil)
+	svc, err := plugin.ensureService(context.Background(), cli, pod, cfg, "gs-0-svc", "gs-0-addr", "", false)
+	if err != nil {
+		t.Fatalf("ensureService: %v", err)
+	}
+	if svc.Annotations[GKELoadBalancerTypeAnnotationKey] != "Internal" {
+		t.Errorf("missing Internal LB annotation: %v", svc.Annotations)
+	}
+	if svc.Annotations["networking.gke.io/internal-load-balancer-allow-global-access"] != "true" {
+		t.Errorf("missing AllowGlobalAccess annotation: %v", svc.Annotations)
+	}
+	if _, has := svc.Annotations[L4RBSAnnotationKey]; has {
+		t.Errorf("l4-rbs annotation should not be set on Internal Scheme: %v", svc.Annotations)
+	}
+}
+
+func TestOnPodDeleted_RetainedSkipsCleanup(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+		confEntry("RetainOnDelete", "true"),
+	})
+	// Pre-create an Address so we can verify it survives.
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := &gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: pod.Namespace}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(addr, pod).Build()
+	plugin := newPlugin(t)
+	if perr := plugin.OnPodDeleted(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodDeleted: %v", perr)
+	}
+	got := &gcpv1beta1.ComputeAddress{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: pod.Namespace, Name: addrName}, got); err != nil {
+		t.Fatalf("Address should still exist with RetainOnDelete=true, got error: %v", err)
+	}
+}
+
+func TestOnPodDeleted_DeletesAddressWhenNotRetained(t *testing.T) {
+	scheme := testScheme(t)
+	pod := newGamePod("gs-0", "ns1", []gamekruiseiov1alpha1.NetworkConfParams{
+		confEntry("PortProtocols", "7777/UDP"),
+	})
+	pod.Finalizers = []string{PodFinalizer}
+	addrName := DeriveServiceName(pod.Name, passthroughSuffix)
+	addr := &gcpv1beta1.ComputeAddress{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: pod.Namespace}}
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: addrName, Namespace: pod.Namespace}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(addr, svc, pod).Build()
+	plugin := newPlugin(t)
+	if perr := plugin.OnPodDeleted(cli, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodDeleted: %v", perr)
+	}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: pod.Namespace, Name: addrName}, &gcpv1beta1.ComputeAddress{}); err == nil {
+		t.Fatalf("Address should be deleted")
+	}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: pod.Namespace, Name: addrName}, &corev1.Service{}); err == nil {
+		t.Fatalf("Service should be deleted")
+	}
+	// Pod Finalizer should have been removed.
+	got := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, got); err == nil {
+		if containsFinalizer(got.Finalizers, PodFinalizer) {
+			t.Fatalf("Finalizer should have been removed; got %v", got.Finalizers)
+		}
+	}
+}
+
+// --- test helpers ------------------------------------------------------------
+
+func newGamePod(name, ns string, conf []gamekruiseiov1alpha1.NetworkConfParams) *corev1.Pod {
+	confJSON := "[]"
+	if conf != nil {
+		b, _ := encodeConfJSON(conf)
+		confJSON = string(b)
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			UID:       types.UID("uid-" + name),
+			Labels: map[string]string{
+				gamekruiseiov1alpha1.GameServerOwnerGssKey: "gs",
+				SvcSelectorKey: name,
+			},
+			Annotations: map[string]string{
+				gamekruiseiov1alpha1.GameServerNetworkType: PassthroughNlbNetwork,
+				gamekruiseiov1alpha1.GameServerNetworkConf: confJSON,
+			},
+		},
+	}
+}
+
+func encodeConfJSON(conf []gamekruiseiov1alpha1.NetworkConfParams) ([]byte, error) {
+	// Inlined to keep the test self-contained; matches NetworkManager's parser.
+	type kv = gamekruiseiov1alpha1.NetworkConfParams
+	_ = kv{}
+	return []byte(toJSON(conf)), nil
+}
+
+func toJSON(conf []gamekruiseiov1alpha1.NetworkConfParams) string {
+	// Manual minimal JSON to avoid importing encoding/json into the test helper twice.
+	var b strings.Builder
+	b.WriteString("[")
+	for i, c := range conf {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"name":"`)
+		b.WriteString(c.Name)
+		b.WriteString(`","value":"`)
+		b.WriteString(strings.ReplaceAll(c.Value, `"`, `\"`))
+		b.WriteString(`"}`)
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func containsFinalizer(list []string, name string) bool {
+	for _, f := range list {
+		if f == name {
+			return true
+		}
+	}
+	return false
+}
+
+func strPtr(s string) *string { return &s }
+func int64Ptr2(v int64) *int64 { return &v }
+
+// silence "unused import" if test file is the only consumer of ctrlclient.
+var _ = ctrlclient.Object(&corev1.Pod{})

--- a/cloudprovider/googlecloud/prereq.go
+++ b/cloudprovider/googlecloud/prereq.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+// VerifyKCCInstalled probes the discovery API for the Config Connector compute
+// CRDs we depend on. On miss it returns a wrapped error whose message embeds
+// the gcloud commands required to install KCC. Plugins call this from Init()
+// and refuse to start when it fails (per-plugin failure — does not crash the
+// manager).
+func VerifyKCCInstalled(restConfig *rest.Config) error {
+	if restConfig == nil {
+		return fmt.Errorf("googlecloud: nil rest.Config passed to VerifyKCCInstalled")
+	}
+	dc, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("googlecloud: build discovery client: %w", err)
+	}
+	resources, err := dc.ServerResourcesForGroupVersion(gcpv1beta1.SchemeGroupVersion.String())
+	if err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || discovery.IsGroupDiscoveryFailedError(err) {
+			return notInstalledError()
+		}
+		return fmt.Errorf("googlecloud: probe %s: %w", gcpv1beta1.SchemeGroupVersion.String(), err)
+	}
+	required := map[string]bool{
+		"ComputeAddress":        false,
+		"ComputeForwardingRule": false,
+		"ComputeBackendService": false,
+		"ComputeHealthCheck":    false,
+		"ComputeTargetTCPProxy": false,
+		"ComputeFirewall":       false,
+	}
+	for _, r := range resources.APIResources {
+		if _, want := required[r.Kind]; want {
+			required[r.Kind] = true
+		}
+	}
+	missing := []string{}
+	for k, present := range required {
+		if !present {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"googlecloud: Config Connector compute CRDs missing in cluster (%v). "+
+				"Install KCC via the GKE add-on then wait for the cnrm-system controller-manager to settle:\n"+
+				"  gcloud container clusters update <CLUSTER> --update-addons=ConfigConnector=ENABLED --region <REGION>\n"+
+				"  kubectl wait --for=condition=Available deploy -n cnrm-system --all --timeout=300s",
+			missing,
+		)
+	}
+	return nil
+}
+
+func notInstalledError() error {
+	return fmt.Errorf(
+		"googlecloud: Config Connector API group %s not installed. "+
+			"Install KCC via the GKE add-on:\n"+
+			"  gcloud container clusters update <CLUSTER> --update-addons=ConfigConnector=ENABLED --region <REGION>\n"+
+			"  kubectl wait --for=condition=Available deploy -n cnrm-system --all --timeout=300s\n"+
+			"Alternatively, for non-GKE clusters install the standalone Config Connector operator: "+
+			"https://docs.cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall",
+		gcpv1beta1.SchemeGroupVersion.String(),
+	)
+}

--- a/cloudprovider/googlecloud/rbac.go
+++ b/cloudprovider/googlecloud/rbac.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Package-level RBAC markers for the Google Cloud network plugins. Picked up
+// by controller-gen when `make manifests` regenerates config/rbac/role.yaml so
+// the contents of role.yaml stay in sync with what the plugins actually call.
+
+// +kubebuilder:rbac:groups=compute.cnrm.cloud.google.com,resources=computeaddresses;computeforwardingrules;computebackendservices;computehealthchecks;computetargettcpproxies;computefirewalls,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=compute.cnrm.cloud.google.com,resources=computeaddresses/status;computeforwardingrules/status;computebackendservices/status;computehealthchecks/status;computetargettcpproxies/status;computefirewalls/status,verbs=get
+
+package googlecloud

--- a/cloudprovider/googlecloud/readiness.go
+++ b/cloudprovider/googlecloud/readiness.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package googlecloud
+
+import (
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
+)
+
+// IsKCCReady returns true when a KCC object reports Ready=True AND has caught
+// up with the current generation. Both checks are needed: a stale "Ready" on a
+// just-updated spec would otherwise look fresh when it is not.
+func IsKCCReady(conditions []gcpv1beta1.Condition, observedGeneration, generation int64) bool {
+	if observedGeneration < generation {
+		return false
+	}
+	for _, c := range conditions {
+		if c.Type == "Ready" {
+			return c.Status == "True"
+		}
+	}
+	return false
+}
+
+// CondReason extracts the Reason of the Ready condition, useful for log lines.
+func CondReason(conditions []gcpv1beta1.Condition) string {
+	for _, c := range conditions {
+		if c.Type == "Ready" {
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+// CondMessage extracts the Message of the Ready condition.
+func CondMessage(conditions []gcpv1beta1.Condition) string {
+	for _, c := range conditions {
+		if c.Type == "Ready" {
+			return c.Message
+		}
+	}
+	return ""
+}
+
+// derefInt64 collapses *int64 to int64 with a zero default.
+func derefInt64(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/cloudprovider/manager/provider_manager.go
+++ b/cloudprovider/manager/provider_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openkruise/kruise-game/cloudprovider"
 	"github.com/openkruise/kruise-game/cloudprovider/alibabacloud"
 	aws "github.com/openkruise/kruise-game/cloudprovider/amazonswebservices"
+	"github.com/openkruise/kruise-game/cloudprovider/googlecloud"
 	"github.com/openkruise/kruise-game/cloudprovider/kubernetes"
 	"github.com/openkruise/kruise-game/cloudprovider/tencentcloud"
 	volcengine "github.com/openkruise/kruise-game/cloudprovider/volcengine"
@@ -173,6 +174,16 @@ func NewProviderManager() (*ProviderManager, error) {
 		}
 	} else {
 		log.Warningf("HwCloudProvider is not enabled, enable flag is %v, config valid flag is %v", configs.HwCloudOptions.Enabled(), configs.HwCloudOptions.Valid())
+	}
+
+	if configs.GoogleCloudOptions.Valid() && configs.GoogleCloudOptions.Enabled() {
+		// build and register google cloud provider
+		gp, err := googlecloud.NewGoogleCloudProvider()
+		if err != nil {
+			log.Errorf("Failed to initialize googlecloud provider, because of %s", err.Error())
+		} else {
+			pm.RegisterCloudProvider(gp, configs.GoogleCloudOptions)
+		}
 	}
 
 	return pm, nil

--- a/cloudprovider/options/googlecloud_options.go
+++ b/cloudprovider/options/googlecloud_options.go
@@ -21,27 +21,27 @@ var gcpRegionRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
 //   - GoogleCloud-PassthroughNLB
 //   - GoogleCloud-GlobalProxyNLB
 type GoogleCloudOptions struct {
-	Enable            bool                     `toml:"enable"`
-	ProjectID         string                   `toml:"project_id"`
-	DefaultRegion     string                   `toml:"default_region"`
-	DefaultNetwork    string                   `toml:"default_network"`
-	DefaultSubnetwork string                   `toml:"default_subnetwork"`
-	PassthroughNLB    PassthroughNLBOptions    `toml:"passthrough_nlb"`
-	GlobalProxyNLB    GlobalProxyNLBOptions    `toml:"global_proxy_nlb"`
+	Enable            bool                  `toml:"enable"`
+	ProjectID         string                `toml:"project_id"`
+	DefaultRegion     string                `toml:"default_region"`
+	DefaultNetwork    string                `toml:"default_network"`
+	DefaultSubnetwork string                `toml:"default_subnetwork"`
+	PassthroughNLB    PassthroughNLBOptions `toml:"passthrough_nlb"`
+	GlobalProxyNLB    GlobalProxyNLBOptions `toml:"global_proxy_nlb"`
 }
 
 // PassthroughNLBOptions configures the GoogleCloud-PassthroughNLB plugin.
 type PassthroughNLBOptions struct {
-	Enable                bool   `toml:"enable"`
-	RetainOnDeleteDefault bool   `toml:"retain_on_delete_default"`
+	Enable                bool `toml:"enable"`
+	RetainOnDeleteDefault bool `toml:"retain_on_delete_default"`
 	// NetworkTier is PREMIUM (default) or STANDARD.
 	NetworkTier string `toml:"network_tier"`
 }
 
 // GlobalProxyNLBOptions configures the GoogleCloud-GlobalProxyNLB plugin.
 type GlobalProxyNLBOptions struct {
-	Enable                bool   `toml:"enable"`
-	RetainOnDeleteDefault bool   `toml:"retain_on_delete_default"`
+	Enable                bool `toml:"enable"`
+	RetainOnDeleteDefault bool `toml:"retain_on_delete_default"`
 	// FirewallNetworkRef is the KCC ComputeNetwork name used as networkRef on
 	// the per-pod ComputeFirewall opening up GFE/HC ranges to backend ports.
 	// Empty falls back to DefaultNetwork on the parent struct.

--- a/cloudprovider/options/googlecloud_options.go
+++ b/cloudprovider/options/googlecloud_options.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package options
+
+import "regexp"
+
+// gcpRegionRegex is a loose validator for GCP region/zone names (lowercase
+// letters, digits, dashes; cannot start/end with dash).
+var gcpRegionRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
+
+// GoogleCloudOptions captures the Google Cloud provider's TOML configuration.
+// Two plugins live under this provider and share project/network defaults:
+//   - GoogleCloud-PassthroughNLB
+//   - GoogleCloud-GlobalProxyNLB
+type GoogleCloudOptions struct {
+	Enable            bool                     `toml:"enable"`
+	ProjectID         string                   `toml:"project_id"`
+	DefaultRegion     string                   `toml:"default_region"`
+	DefaultNetwork    string                   `toml:"default_network"`
+	DefaultSubnetwork string                   `toml:"default_subnetwork"`
+	PassthroughNLB    PassthroughNLBOptions    `toml:"passthrough_nlb"`
+	GlobalProxyNLB    GlobalProxyNLBOptions    `toml:"global_proxy_nlb"`
+}
+
+// PassthroughNLBOptions configures the GoogleCloud-PassthroughNLB plugin.
+type PassthroughNLBOptions struct {
+	Enable                bool   `toml:"enable"`
+	RetainOnDeleteDefault bool   `toml:"retain_on_delete_default"`
+	// NetworkTier is PREMIUM (default) or STANDARD.
+	NetworkTier string `toml:"network_tier"`
+}
+
+// GlobalProxyNLBOptions configures the GoogleCloud-GlobalProxyNLB plugin.
+type GlobalProxyNLBOptions struct {
+	Enable                bool   `toml:"enable"`
+	RetainOnDeleteDefault bool   `toml:"retain_on_delete_default"`
+	// FirewallNetworkRef is the KCC ComputeNetwork name used as networkRef on
+	// the per-pod ComputeFirewall opening up GFE/HC ranges to backend ports.
+	// Empty falls back to DefaultNetwork on the parent struct.
+	FirewallNetworkRef string `toml:"firewall_network_ref"`
+}
+
+// Enabled returns whether the provider is on at all. The per-plugin Enable
+// flags further gate plugin registration.
+func (o GoogleCloudOptions) Enabled() bool { return o.Enable }
+
+// Valid sanity-checks the TOML. Called once at startup; on false the provider
+// is skipped with a log line.
+func (o GoogleCloudOptions) Valid() bool {
+	if !o.Enable {
+		// Disabled providers don't need to be valid.
+		return true
+	}
+	if o.ProjectID == "" {
+		return false
+	}
+	if o.PassthroughNLB.Enable && o.DefaultRegion != "" && !gcpRegionRegex.MatchString(o.DefaultRegion) {
+		return false
+	}
+	switch o.PassthroughNLB.NetworkTier {
+	case "", "PREMIUM", "STANDARD":
+	default:
+		return false
+	}
+	return true
+}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,29 +111,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - elbv2.k8s.aws
-  resources:
-  - targetgroupbindings
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - elbv2.services.k8s.aws
-  resources:
-  - listeners
-  - targetgroups
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - compute.cnrm.cloud.google.com
   resources:
   - computeaddresses
@@ -161,6 +138,29 @@ rules:
   - computetargettcpproxies/status
   verbs:
   - get
+- apiGroups:
+  - elbv2.k8s.aws
+  resources:
+  - targetgroupbindings
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - listeners
+  - targetgroups
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - game.kruise.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -134,6 +134,34 @@ rules:
   - update
   - watch
 - apiGroups:
+  - compute.cnrm.cloud.google.com
+  resources:
+  - computeaddresses
+  - computebackendservices
+  - computefirewalls
+  - computeforwardingrules
+  - computehealthchecks
+  - computetargettcpproxies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - compute.cnrm.cloud.google.com
+  resources:
+  - computeaddresses/status
+  - computebackendservices/status
+  - computefirewalls/status
+  - computeforwardingrules/status
+  - computehealthchecks/status
+  - computetargettcpproxies/status
+  verbs:
+  - get
+- apiGroups:
   - game.kruise.io
   resources:
   - gameservers

--- a/config/samples/google_global_proxy_nlb_gss.yaml
+++ b/config/samples/google_global_proxy_nlb_gss.yaml
@@ -1,0 +1,64 @@
+# Sample: GameServerSet using the GoogleCloud-GlobalProxyNLB plugin.
+#
+# Best for TCP-only games with globally distributed players (MMO, SLG, card,
+# casual). The pod gets an anycast IPv4 IP fronted by Google Front Ends, with
+# automatic cross-region failover and Cloud Armor compatibility. Real client
+# IP is delivered via PROXY-protocol v1 when ProxyHeader=PROXY_V1.
+#
+# Prerequisites (one-time, cluster-admin):
+#   1. VPC-native GKE cluster (alias IPs).
+#   2. Config Connector add-on enabled and healthy.
+#   3. cnrm-system SA bound (Workload Identity) to a GCP SA with
+#      roles/compute.networkAdmin.
+#   4. A default VPC network exists; the plugin authors a per-pod
+#      ComputeFirewall opening 35.191.0.0/16 + 130.211.0.0/22 to the game port.
+#   5. (Production) Request GCP quota increases for ForwardingRules / BackendServices
+#      / NetworkEndpointGroups / Addresses ahead of scaling.
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  name: mmo-global
+  namespace: default
+spec:
+  replicas: 3
+  gameServerTemplate:
+    spec:
+      containers:
+      - name: server
+        image: example.com/mmo-server:latest
+        ports:
+        - containerPort: 7777
+          protocol: TCP
+  network:
+    networkType: GoogleCloud-GlobalProxyNLB
+    networkConf:
+    # Required: single TCP port 1-65535. Global Proxy NLB is one port per pod.
+    - name: Port
+      value: "7777"
+    # Optional: NONE (default) gives the backend no client IP. PROXY_V1 prepends
+    # one PROXY-protocol line; the game container MUST be PROXY-aware.
+    - name: ProxyHeader
+      value: PROXY_V1
+    # Optional: balancing mode for the backend service. CONNECTION is the
+    # default; RATE or UTILIZATION are also valid.
+    - name: BalancingMode
+      value: CONNECTION
+    - name: MaxConnectionsPerEndpoint
+      value: "1000"
+    # Optional health-check tuning.
+    - name: HealthCheckIntervalSec
+      value: "5"
+    - name: HealthCheckTimeoutSec
+      value: "5"
+    - name: HealthyThreshold
+      value: "2"
+    - name: UnhealthyThreshold
+      value: "3"
+    # Optional: VPC network for the per-pod ComputeFirewall. Defaults to the
+    # googlecloud.firewall_network_ref (then default_network) from the operator
+    # TOML.
+    - name: Network
+      value: default
+    # Optional: false (default) drops the GCP stack when the pod is removed.
+    - name: RetainOnDelete
+      value: "false"

--- a/config/samples/google_passthrough_nlb_gss.yaml
+++ b/config/samples/google_passthrough_nlb_gss.yaml
@@ -1,0 +1,56 @@
+# Sample: GameServerSet using the GoogleCloud-PassthroughNLB plugin.
+#
+# Best for UDP-heavy realtime games (FPS, MOBA, action) or TCP workloads that
+# need lowest possible latency and native client-IP preservation. Each pod gets
+# a per-pod static external IP (KCC ComputeAddress) and a per-pod LoadBalancer
+# Service backed by GKE's container-native L4 RBS pipeline.
+#
+# Prerequisites (one-time, cluster-admin):
+#   1. VPC-native GKE cluster (alias IPs).
+#   2. Config Connector add-on enabled and healthy:
+#        gcloud container clusters update <CLUSTER> --update-addons=ConfigConnector=ENABLED --region <REGION>
+#        kubectl wait --for=condition=Available deploy -n cnrm-system --all --timeout=300s
+#   3. The cnrm-system service account bound (via Workload Identity) to a GCP
+#      service account that holds roles/compute.networkAdmin (or a narrower
+#      custom role over forwardingRules/backendServices/healthChecks/addresses/firewalls).
+#   4. A firewall rule that admits Google health-check probe ranges
+#      (35.191.0.0/16 + 130.211.0.0/22) to your game-server container ports.
+#
+# Minimum GKE version for the cloud.google.com/l4-rbs annotation path: 1.32.2-gke.1652000.
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  name: minecraft-passthrough
+  namespace: default
+spec:
+  replicas: 3
+  gameServerTemplate:
+    spec:
+      containers:
+      - name: server
+        image: itzg/minecraft-server:latest
+        env:
+        - name: EULA
+          value: "TRUE"
+        ports:
+        - containerPort: 25565
+          protocol: TCP
+  network:
+    networkType: GoogleCloud-PassthroughNLB
+    networkConf:
+    # Required: at least one port (max 5 per pod).
+    - name: PortProtocols
+      value: "25565/TCP"
+    # Optional. External (default) for public traffic; Internal for VPC-only.
+    - name: Scheme
+      value: External
+    # Required when Scheme=Internal; defaults to googlecloud.default_region.
+    - name: Region
+      value: us-central1
+    # Optional: PREMIUM (default) or STANDARD.
+    - name: NetworkTier
+      value: PREMIUM
+    # Optional: false (default per plugin) keeps the per-pod IP on pod tear-down.
+    #          true retains the ComputeAddress + Service across pod restarts.
+    - name: RetainOnDelete
+      value: "false"

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ import (
 	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
 	"github.com/openkruise/kruise-game/cloudprovider"
 	aliv1beta1 "github.com/openkruise/kruise-game/cloudprovider/alibabacloud/apis/v1beta1"
+	gcpv1beta1 "github.com/openkruise/kruise-game/cloudprovider/googlecloud/apis/compute/v1beta1"
 	cpmanager "github.com/openkruise/kruise-game/cloudprovider/manager"
 	kruisegameclientset "github.com/openkruise/kruise-game/pkg/client/clientset/versioned"
 	kruisegamevisions "github.com/openkruise/kruise-game/pkg/client/informers/externalversions"
@@ -88,6 +89,10 @@ func init() {
 	// Register NLB and EIP CRD schemes for AutoNLBs-V2
 	utilruntime.Must(nlbv1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(eipv1.AddToScheme(scheme))
+
+	// Register Google Cloud Config Connector compute v1beta1 CRD scheme for the
+	// GoogleCloud-PassthroughNLB and GoogleCloud-GlobalProxyNLB plugins.
+	utilruntime.Must(gcpv1beta1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
## What this PR does

Adds a new **GoogleCloud** cloud-provider with two per-Pod network plugins, following the existing `cloudprovider/` plugin contract (`OnPodAdded/OnPodUpdated/OnPodDeleted`):

- **`GoogleCloud-PassthroughNLB`** (alias `NLB-Network`) — provisions a regional External/Internal Passthrough Network Load Balancer per Pod. Uses the in-cluster GKE L4 controller (`Service type=LoadBalancer` + `cloud.google.com/l4-rbs`) for the FR/BES/HC stack and reconciles a KCC `ComputeAddress` for a stable static VIP.
- **`GoogleCloud-GlobalProxyNLB`** (alias `GlobalProxyNLB-Network`) — provisions a per-Pod Global External Proxy NLB (anycast IP, GFE-backed) via the KCC graph: Service+NEG → HealthCheck → BackendService → TargetTCPProxy → Address → ForwardingRule → Firewall, with a three-stage readiness gate.

Both plugins rely on [Config Connector (KCC)](https://cloud.google.com/config-connector) `compute.cnrm.cloud.google.com/v1beta1` CRDs; `Init` refuses to start (per-plugin, non-fatal) with an actionable message if KCC is absent.

### Highlights
- Reserved IP / LB stays **stable across Pod recreate** — GCP resource IDs are anchored on `GSS UID + ordinal`, not the Pod UID, so a rolling update / eviction re-adopts the same IP and avoids a multi-minute LB rebuild. OwnerReferences are anchored on the GameServerSet; cleanup on scale-down / GSS deletion is explicit.
- `RetainOnDelete` lets the underlying cloud resources outlive the Pod (and even the GSS).
- Wired through `cloudprovider/config.go`, `provider_manager.go`, options, `main.go` scheme, and RBAC markers (`make manifests` regenerates `config/rbac/role.yaml`).
- Sample GameServerSets under `config/samples/`.

## Tests
- Statement coverage of `cloudprovider/googlecloud` is **98.9%**.
- Pure unit tests (fake client + `interceptor.Funcs` for error paths) cover config parsing, the full reconcile happy/not-ready/disabled/recreate paths, readiness gating, and resource cleanup.
- envtest-backed tests cover `VerifyKCCInstalled` discovery (missing / partial / present) and the full `Init` bootstrap; they skip automatically when `KUBEBUILDER_ASSETS` is unset.
- `make test` and `golangci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)