### PR TITLE
fix(cloudprovider): unique ServicePort name for same port with TCP and UDP

### DIFF
--- a/cloudprovider/kubernetes/nodeport.go
+++ b/cloudprovider/kubernetes/nodeport.go
@@ -561,10 +561,24 @@ func parsePortProtocols(value string) ([]int, []corev1.Protocol) {
 }
 
 func consNodePortSvc(npc *nodePortConfig, pod *corev1.Pod, c client.Client, ctx context.Context) *corev1.Service {
+	// Detect duplicate port numbers (e.g. the same port exposed for both TCP and
+	// UDP). Kubernetes requires every ServicePort in a multi-port Service to have
+	// a unique Name, so when a port number repeats we disambiguate the Name by
+	// appending the protocol. For unique port numbers we keep the legacy
+	// numeric-only name to stay backward compatible.
+	portCount := make(map[int]int)
+	for i := 0; i < len(npc.ports); i++ {
+		portCount[npc.ports[i]]++
+	}
+
 	svcPorts := make([]corev1.ServicePort, 0)
 	for i := 0; i < len(npc.ports); i++ {
+		name := strconv.Itoa(npc.ports[i])
+		if portCount[npc.ports[i]] > 1 {
+			name = name + "-" + strings.ToLower(string(npc.protocols[i]))
+		}
 		svcPorts = append(svcPorts, corev1.ServicePort{
-			Name:       strconv.Itoa(npc.ports[i]),
+			Name:       name,
 			Port:       int32(npc.ports[i]),
 			Protocol:   npc.protocols[i],
 			TargetPort: intstr.FromInt(npc.ports[i]),


### PR DESCRIPTION
## What this PR does / why we need it

  Kubernetes requires every ServicePort in a multi-port Service to have a unique
  `name`. The `Kubernetes-NodePort` plugin used the bare port number as the name,
  so exposing the same port for both TCP and UDP — e.g. `PortProtocols: "9000/TCP,9000/UDP"` —
  produced two ServicePorts both named `"9000"`, which is an invalid Service and is
  rejected by the API server.

  ## Fix
  
  Append the lowercased protocol to the name **only when a port number repeats**
  (e.g. `9000-tcp` / `9000-udp`); ports that appear once keep the numeric-only name,
  so existing single-protocol Services are unaffected (backward compatible).
  
  ## Testing
  
  `9000/TCP,9000/UDP` now yields ServicePorts `9000-tcp` and `9000-udp` and the
  Service is accepted, while a single `9000/TCP` keeps the name `9000`. 