### PR TITLE
feat(cloudprovider): add GCP-NLB network plugin for GKE

### DIFF
--- a/cloudprovider/kubernetes/gcp_nlb.go
+++ b/cloudprovider/kubernetes/gcp_nlb.go
@@ -1,0 +1,451 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/cloudprovider"
+	cperrors "github.com/openkruise/kruise-game/cloudprovider/errors"
+	"github.com/openkruise/kruise-game/cloudprovider/utils"
+	"github.com/openkruise/kruise-game/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// GcpNLBNetwork is the network type name for the GCP passthrough Network Load Balancer plugin.
+	GcpNLBNetwork = "GCP-NLB"
+
+	// GcpNLBLoadBalancerClass is the GKE L4 regional external passthrough NLB load balancer class.
+	// Using this class enables backend-service based NLB which supports mixed TCP/UDP protocols
+	// on the same port.
+	GcpNLBLoadBalancerClass = "networking.gke.io/l4-regional-external"
+
+	// GcpNLBExternalTrafficPolicyConfigName lets users override the externalTrafficPolicy.
+	// Defaults to Local so the client source IP is preserved and traffic is sent only to the
+	// node that hosts the GameServer pod.
+	GcpNLBExternalTrafficPolicyConfigName = "ExternalTrafficPolicy"
+
+	// GcpNLBLoadBalancerIPsConfigName optionally pins one reserved static IP to the
+	// Service. When multiple per-pod Services share one IP this enables the
+	// "single NLB IP, multiple ports" pattern.
+	GcpNLBLoadBalancerIPsConfigName = "LoadBalancerIP"
+
+	// GcpNLBMinPortConfigName, when set, enables "port offset" mode: every pod shares
+	// the same LoadBalancerIP but receives a distinct external port computed from its
+	// ordinal index, while the container targetPort stays fixed. For example with
+	// MinPort=9000 and a single container port:
+	//   NLB_IP:9000 -> pod-0:<containerPort>
+	//   NLB_IP:9001 -> pod-1:<containerPort>
+	// Each external port carries every protocol configured for that container port
+	// (so TCP+UDP on the same external port is supported).
+	// When MinPort is unset the plugin keeps the legacy behaviour: the external port
+	// equals the container port (one dedicated IP per pod).
+	GcpNLBMinPortConfigName = "MinPort"
+)
+
+// GcpNLBPlugin implements the OKG network Plugin interface using a GKE managed
+// type=LoadBalancer Service (backend-service based passthrough NLB).
+//
+// Design (Option A): the plugin does NOT call the GCP Compute API directly.
+// Instead it creates a per-pod Service whose OwnerReference points to the pod
+// (or the GameServerSet when Fixed). The GKE loadbalancer-controller turns the
+// Service into a GCP forwarding rule + NEG and writes back the external IP.
+// When the pod is recycled, Kubernetes garbage-collects the owned Service via the
+// OwnerReference, and the GKE controller then deletes the underlying forwarding
+// rule automatically. This gives us "create forwarding rule bound to pod" plus
+// "delete forwarding rule when pod is recycled" with no extra credentials.
+type GcpNLBPlugin struct {
+}
+
+func (g *GcpNLBPlugin) Name() string {
+	return GcpNLBNetwork
+}
+
+func (g *GcpNLBPlugin) Alias() string {
+	return ""
+}
+
+func (g *GcpNLBPlugin) Init(client client.Client, options cloudprovider.CloudProviderOptions, ctx context.Context) error {
+	return nil
+}
+
+func (g *GcpNLBPlugin) OnPodAdded(client client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	return pod, nil
+}
+
+func (g *GcpNLBPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	networkManager := utils.NewNetworkManager(pod, c)
+
+	networkStatus, _ := networkManager.GetNetworkStatus()
+	networkConfig := networkManager.GetNetworkConfig()
+	conf, err := parseGcpNLBConfig(networkConfig)
+	if err != nil {
+		return pod, cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+	// Port-offset mode needs the pod ordinal to compute its external port block.
+	conf.podIndex = util.GetIndexFromGsName(pod.GetName())
+
+	if networkStatus == nil {
+		pod, err := networkManager.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	// get svc
+	svc := &corev1.Service{}
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      pod.GetName(),
+		Namespace: pod.GetNamespace(),
+	}, svc)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Service does not exist yet, create it. OwnerReference handles cascade delete.
+			return pod, cperrors.ToPluginError(c.Create(ctx, consGcpNLBSvc(conf, pod, c, ctx)), cperrors.ApiCallError)
+		}
+		return pod, cperrors.NewPluginError(cperrors.ApiCallError, err.Error())
+	}
+
+	// config changed, update svc
+	if util.GetHash(conf) != svc.GetAnnotations()[ServiceHashKey] {
+		networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+		pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+		if err != nil {
+			return pod, cperrors.NewPluginError(cperrors.InternalError, err.Error())
+		}
+		newSvc := consGcpNLBSvc(conf, pod, c, ctx)
+		newSvc.ResourceVersion = svc.ResourceVersion
+		newSvc.Spec.ClusterIP = svc.Spec.ClusterIP
+		return pod, cperrors.ToPluginError(c.Update(ctx, newSvc), cperrors.ApiCallError)
+	}
+
+	// disable network: drop the selector so traffic stops reaching the pod, keep the IP.
+	if networkManager.GetNetworkDisabled() && svc.Spec.Selector[SvcSelectorKey] == pod.GetName() {
+		newSelector := svc.Spec.Selector
+		newSelector[SvcSelectorDisabledKey] = pod.GetName()
+		delete(newSelector, SvcSelectorKey)
+		svc.Spec.Selector = newSelector
+		return pod, cperrors.ToPluginError(c.Update(ctx, svc), cperrors.ApiCallError)
+	}
+
+	// enable network
+	if !networkManager.GetNetworkDisabled() && svc.Spec.Selector[SvcSelectorDisabledKey] == pod.GetName() {
+		newSelector := svc.Spec.Selector
+		newSelector[SvcSelectorKey] = pod.GetName()
+		delete(newSelector, SvcSelectorDisabledKey)
+		svc.Spec.Selector = newSelector
+		return pod, cperrors.ToPluginError(c.Update(ctx, svc), cperrors.ApiCallError)
+	}
+
+	// network not ready until the GKE controller assigns an external IP
+	if len(svc.Status.LoadBalancer.Ingress) == 0 || svc.Status.LoadBalancer.Ingress[0].IP == "" {
+		networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+		pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	if pod.Status.PodIP == "" {
+		networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+		pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	// network ready: build internal/external addresses from the Service.
+	lbIP := svc.Status.LoadBalancer.Ingress[0].IP
+	internalAddresses := make([]gamekruiseiov1alpha1.NetworkAddress, 0)
+	externalAddresses := make([]gamekruiseiov1alpha1.NetworkAddress, 0)
+	for _, port := range svc.Spec.Ports {
+		instrIPort := port.TargetPort
+		instrEPort := intstr.FromInt(int(port.Port))
+		internalAddresses = append(internalAddresses, gamekruiseiov1alpha1.NetworkAddress{
+			IP: pod.Status.PodIP,
+			Ports: []gamekruiseiov1alpha1.NetworkPort{
+				{
+					Name:     instrIPort.String(),
+					Port:     &instrIPort,
+					Protocol: port.Protocol,
+				},
+			},
+		})
+		externalAddresses = append(externalAddresses, gamekruiseiov1alpha1.NetworkAddress{
+			IP: lbIP,
+			Ports: []gamekruiseiov1alpha1.NetworkPort{
+				{
+					Name:     instrIPort.String(),
+					Port:     &instrEPort,
+					Protocol: port.Protocol,
+				},
+			},
+		})
+	}
+	networkStatus.InternalAddresses = internalAddresses
+	networkStatus.ExternalAddresses = externalAddresses
+	networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkReady
+	pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+	return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+}
+
+// OnPodDeleted cleans up the Service (and therefore the GCP forwarding rule).
+//
+//   - Fixed=false: the Service is owned by the Pod, so Kubernetes garbage-collects
+//     it automatically via the OwnerReference whenever the pod is deleted. This gives
+//     immediate cleanup on scale-down, at the cost of a LB teardown+rebuild on update.
+//   - Fixed=true: the Service is owned by the GameServerSet so it survives pod
+//     recreation (smooth, zero-downtime updates) and also persists across scale-down
+//     so a replica that comes back keeps the same IP:port (stable address semantics,
+//     consistent with other OKG cloud plugins). The Service is only removed once the
+//     whole GameServerSet is deleted, which we handle explicitly here because the
+//     OwnerReference cascade does not fire until then.
+func (g *GcpNLBPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ctx context.Context) cperrors.PluginError {
+	networkManager := utils.NewNetworkManager(pod, c)
+	conf, err := parseGcpNLBConfig(networkManager.GetNetworkConfig())
+	if err != nil {
+		return cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+
+	// Non-fixed: the Service is owned by the GameServer CR. On scale-down the
+	// GameServer is deleted and the Service is cascade garbage-collected; on update
+	// the GameServer persists so the Service survives. Nothing to do here.
+	if !conf.isFixed {
+		return nil
+	}
+
+	// Fixed: keep the Service while the GameServerSet still exists (update or
+	// scale-down where the index may return). Only delete once the GSS is gone.
+	gss, err := util.GetGameServerSetOfPod(pod, c, ctx)
+	if err == nil && gss.GetDeletionTimestamp() == nil {
+		return nil
+	}
+	if err != nil && !errors.IsNotFound(err) {
+		return cperrors.ToPluginError(err, cperrors.ApiCallError)
+	}
+
+	// GameServerSet gone: delete the Service so GKE removes the forwarding rule.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.GetName(),
+			Namespace: pod.GetNamespace(),
+		},
+	}
+	err = c.Delete(ctx, svc)
+	if err != nil && !errors.IsNotFound(err) {
+		return cperrors.ToPluginError(err, cperrors.ApiCallError)
+	}
+	return nil
+}
+
+func init() {
+	kubernetesProvider.registerPlugin(&GcpNLBPlugin{})
+}
+
+type gcpNLBConfig struct {
+	ports                 []int
+	protocols             []corev1.Protocol
+	isFixed               bool
+	externalTrafficPolicy corev1.ServiceExternalTrafficPolicyType
+	loadBalancerIP        string
+	// minPort > 0 enables port-offset mode (shared IP, per-pod external port).
+	minPort int
+	// podIndex is the ordinal of the pod, used to compute the external port offset.
+	podIndex int
+}
+
+func parseGcpNLBConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) (*gcpNLBConfig, error) {
+	var ports []int
+	var protocols []corev1.Protocol
+	isFixed := false
+	etp := corev1.ServiceExternalTrafficPolicyTypeLocal
+	loadBalancerIP := ""
+	minPort := 0
+
+	for _, c := range conf {
+		switch c.Name {
+		case PortProtocolsConfigName:
+			ports, protocols = parsePortProtocols(c.Value)
+		case FixedKey:
+			v, err := strconv.ParseBool(c.Value)
+			if err != nil {
+				return nil, err
+			}
+			isFixed = v
+		case GcpNLBExternalTrafficPolicyConfigName:
+			if strings.EqualFold(c.Value, string(corev1.ServiceExternalTrafficPolicyTypeCluster)) {
+				etp = corev1.ServiceExternalTrafficPolicyTypeCluster
+			}
+		case GcpNLBLoadBalancerIPsConfigName:
+			loadBalancerIP = strings.TrimSpace(c.Value)
+		case GcpNLBMinPortConfigName:
+			v, err := strconv.Atoi(strings.TrimSpace(c.Value))
+			if err != nil {
+				return nil, err
+			}
+			minPort = v
+		}
+	}
+	return &gcpNLBConfig{
+		ports:                 ports,
+		protocols:             protocols,
+		isFixed:               isFixed,
+		externalTrafficPolicy: etp,
+		loadBalancerIP:        loadBalancerIP,
+		minPort:               minPort,
+	}, nil
+}
+
+// uniquePorts returns the distinct container port numbers preserving first-seen order.
+// TCP+UDP on the same container port collapse to a single entry so they share one
+// external port.
+func uniquePorts(ports []int) []int {
+	seen := make(map[int]bool)
+	out := make([]int, 0, len(ports))
+	for _, p := range ports {
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func consGcpNLBSvc(conf *gcpNLBConfig, pod *corev1.Pod, c client.Client, ctx context.Context) *corev1.Service {
+	// Detect duplicate port numbers (e.g. the same container port exposed for both
+	// TCP and UDP). Kubernetes requires every ServicePort in a multi-port Service to
+	// have a unique Name, so when a port number repeats we disambiguate the Name by
+	// appending the protocol.
+	portCount := make(map[int]int)
+	for i := 0; i < len(conf.ports); i++ {
+		portCount[conf.ports[i]]++
+	}
+
+	// In port-offset mode every pod shares one LoadBalancerIP, so each pod must get
+	// a distinct external port. We allocate a contiguous block per pod based on its
+	// ordinal: blockBase = MinPort + podIndex * (number of distinct container ports).
+	// The k-th distinct container port maps to external port blockBase + k, and every
+	// protocol on that container port reuses the same external port (TCP+UDP share it).
+	externalPortOf := func(containerPort int) int32 { return int32(containerPort) }
+	if conf.minPort > 0 {
+		distinct := uniquePorts(conf.ports)
+		blockBase := conf.minPort + conf.podIndex*len(distinct)
+		extPortByContainerPort := make(map[int]int32, len(distinct))
+		for k, cp := range distinct {
+			extPortByContainerPort[cp] = int32(blockBase + k)
+		}
+		externalPortOf = func(containerPort int) int32 { return extPortByContainerPort[containerPort] }
+	}
+
+	svcPorts := make([]corev1.ServicePort, 0)
+	for i := 0; i < len(conf.ports); i++ {
+		extPort := externalPortOf(conf.ports[i])
+		name := strconv.Itoa(int(extPort))
+		if portCount[conf.ports[i]] > 1 {
+			name = name + "-" + strings.ToLower(string(conf.protocols[i]))
+		}
+		svcPorts = append(svcPorts, corev1.ServicePort{
+			Name:       name,
+			Port:       extPort,                          // external port on the NLB IP
+			Protocol:   conf.protocols[i],
+			TargetPort: intstr.FromInt(conf.ports[i]),    // fixed container port
+		})
+	}
+
+	// OwnerReference selection drives the Service lifecycle:
+	//   - Fixed=false (default): owned by the GameServer CR. The GameServer persists
+	//     across pod recreation (OnDelete update) but is deleted on scale-down, so the
+	//     Service (and its forwarding rule) survives updates yet is auto-cleaned on
+	//     scale-down — exactly "keep on update, delete on scale-down".
+	//   - Fixed=true: owned by the GameServerSet, so the address persists even across
+	//     scale-down and is only removed when the whole GameServerSet is deleted.
+	var ownerRefs []metav1.OwnerReference
+	if conf.isFixed {
+		ownerRefs = consOwnerReference(c, ctx, pod, true)
+	} else {
+		ownerRefs = consGameServerOwnerReference(c, ctx, pod)
+	}
+
+	loadBalancerClass := GcpNLBLoadBalancerClass
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.GetName(),
+			Namespace: pod.GetNamespace(),
+			Annotations: map[string]string{
+				ServiceHashKey: util.GetHash(conf),
+			},
+			OwnerReferences: ownerRefs,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                  corev1.ServiceTypeLoadBalancer,
+			LoadBalancerClass:     &loadBalancerClass,
+			ExternalTrafficPolicy: conf.externalTrafficPolicy,
+			Selector: map[string]string{
+				SvcSelectorKey: pod.GetName(),
+			},
+			Ports: svcPorts,
+		},
+	}
+	if conf.loadBalancerIP != "" {
+		svc.Spec.LoadBalancerIP = conf.loadBalancerIP
+	}
+	return svc
+}
+
+// consGameServerOwnerReference returns an OwnerReference pointing at the GameServer
+// CR with the same name as the pod. The GameServer is the stable identity of a
+// replica: it survives pod recreation during an OnDelete update, but is deleted on
+// scale-down. Owning the Service by it therefore yields "keep on update, delete on
+// scale-down" purely through Kubernetes garbage collection.
+//
+// If the client is nil (unit tests) or the GameServer cannot be fetched, it falls
+// back to owning the Service by the pod.
+func consGameServerOwnerReference(c client.Client, ctx context.Context, pod *corev1.Pod) []metav1.OwnerReference {
+	podOwner := []metav1.OwnerReference{
+		{
+			APIVersion:         pod.APIVersion,
+			Kind:               pod.Kind,
+			Name:               pod.GetName(),
+			UID:                pod.GetUID(),
+			Controller:         ptr.To[bool](true),
+			BlockOwnerDeletion: ptr.To[bool](true),
+		},
+	}
+	if c == nil {
+		return podOwner
+	}
+	gs := &gamekruiseiov1alpha1.GameServer{}
+	if err := c.Get(ctx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, gs); err != nil {
+		return podOwner
+	}
+	return []metav1.OwnerReference{
+		{
+			APIVersion:         gamekruiseiov1alpha1.GroupVersion.String(),
+			Kind:               "GameServer",
+			Name:               gs.GetName(),
+			UID:                gs.GetUID(),
+			Controller:         ptr.To[bool](true),
+			BlockOwnerDeletion: ptr.To[bool](true),
+		},
+	}
+}

--- a/cloudprovider/kubernetes/gcp_nlb_test.go
+++ b/cloudprovider/kubernetes/gcp_nlb_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+)
+
+func TestParseGcpNLBConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		conf []gamekruiseiov1alpha1.NetworkConfParams
+		want *gcpNLBConfig
+	}{
+		{
+			name: "single tcp port, defaults",
+			conf: []gamekruiseiov1alpha1.NetworkConfParams{
+				{Name: PortProtocolsConfigName, Value: "9000"},
+			},
+			want: &gcpNLBConfig{
+				ports:                 []int{9000},
+				protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+				isFixed:               false,
+				externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				loadBalancerIP:        "",
+				minPort:               0,
+			},
+		},
+		{
+			name: "dual protocol same port + shared IP + offset + fixed",
+			conf: []gamekruiseiov1alpha1.NetworkConfParams{
+				{Name: PortProtocolsConfigName, Value: "9000/TCP,9000/UDP"},
+				{Name: GcpNLBLoadBalancerIPsConfigName, Value: "34.80.242.156"},
+				{Name: GcpNLBMinPortConfigName, Value: "9000"},
+				{Name: FixedKey, Value: "true"},
+				{Name: GcpNLBExternalTrafficPolicyConfigName, Value: "Cluster"},
+			},
+			want: &gcpNLBConfig{
+				ports:                 []int{9000, 9000},
+				protocols:             []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolUDP},
+				isFixed:               true,
+				externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+				loadBalancerIP:        "34.80.242.156",
+				minPort:               9000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGcpNLBConfig(tt.conf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseGcpNLBConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUniquePorts(t *testing.T) {
+	tests := []struct {
+		in   []int
+		want []int
+	}{
+		{in: []int{9000, 9000}, want: []int{9000}},                   // TCP+UDP same port collapse
+		{in: []int{9000, 7777}, want: []int{9000, 7777}},             // distinct, order preserved
+		{in: []int{9000, 7777, 9000}, want: []int{9000, 7777}},       // dedup keep first-seen order
+		{in: []int{}, want: []int{}},                                 // empty
+	}
+	for _, tt := range tests {
+		got := uniquePorts(tt.in)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("uniquePorts(%v) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func newPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns", UID: types.UID("uid-" + name)},
+	}
+}
+
+// TestConsGcpNLBSvcDualProtocol verifies that exposing the same container port for
+// both TCP and UDP produces unique ServicePort names (the bug that breaks the
+// upstream Kubernetes-NodePort plugin) and a LoadBalancer Service with the GKE
+// regional external load balancer class.
+func TestConsGcpNLBSvcDualProtocol(t *testing.T) {
+	conf := &gcpNLBConfig{
+		ports:                 []int{9000, 9000},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolUDP},
+		isFixed:               false,
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+	}
+	svc := consGcpNLBSvc(conf, newPod("game-0"), nil, nil)
+
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Errorf("expected type LoadBalancer, got %v", svc.Spec.Type)
+	}
+	if svc.Spec.LoadBalancerClass == nil || *svc.Spec.LoadBalancerClass != GcpNLBLoadBalancerClass {
+		t.Errorf("expected loadBalancerClass %q, got %v", GcpNLBLoadBalancerClass, svc.Spec.LoadBalancerClass)
+	}
+	if len(svc.Spec.Ports) != 2 {
+		t.Fatalf("expected 2 ports, got %d", len(svc.Spec.Ports))
+	}
+	// Names must be unique, otherwise Kubernetes rejects the multi-port Service.
+	if svc.Spec.Ports[0].Name == svc.Spec.Ports[1].Name {
+		t.Errorf("duplicate port name %q — Service would be rejected", svc.Spec.Ports[0].Name)
+	}
+	wantNames := map[string]corev1.Protocol{"9000-tcp": corev1.ProtocolTCP, "9000-udp": corev1.ProtocolUDP}
+	for _, p := range svc.Spec.Ports {
+		proto, ok := wantNames[p.Name]
+		if !ok {
+			t.Errorf("unexpected port name %q", p.Name)
+		}
+		if p.Protocol != proto {
+			t.Errorf("port %q expected protocol %v, got %v", p.Name, proto, p.Protocol)
+		}
+		if p.Port != 9000 || p.TargetPort != intstr.FromInt(9000) {
+			t.Errorf("port %q expected external/target 9000, got port=%d target=%v", p.Name, p.Port, p.TargetPort)
+		}
+	}
+}
+
+// TestConsGcpNLBSvcPortOffset verifies that with MinPort set, each pod ordinal gets a
+// distinct external port while the container targetPort stays fixed, and that TCP+UDP
+// on the same container port share one external port.
+func TestConsGcpNLBSvcPortOffset(t *testing.T) {
+	mkConf := func() *gcpNLBConfig {
+		return &gcpNLBConfig{
+			ports:                 []int{9000, 9000},
+			protocols:             []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolUDP},
+			minPort:               9000,
+			loadBalancerIP:        "34.80.242.156",
+			externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		}
+	}
+
+	cases := []struct {
+		podName      string
+		wantExtPort  int32
+	}{
+		{"game-0", 9000},
+		{"game-1", 9001},
+		{"game-2", 9002},
+	}
+
+	for _, c := range cases {
+		conf := mkConf()
+		conf.podIndex = indexFromName(c.podName)
+		svc := consGcpNLBSvc(conf, newPod(c.podName), nil, nil)
+
+		if svc.Spec.LoadBalancerIP != "34.80.242.156" {
+			t.Errorf("%s: expected shared loadBalancerIP, got %q", c.podName, svc.Spec.LoadBalancerIP)
+		}
+		for _, p := range svc.Spec.Ports {
+			if p.Port != c.wantExtPort {
+				t.Errorf("%s: expected external port %d, got %d", c.podName, c.wantExtPort, p.Port)
+			}
+			if p.TargetPort != intstr.FromInt(9000) {
+				t.Errorf("%s: expected targetPort 9000, got %v", c.podName, p.TargetPort)
+			}
+		}
+		// TCP and UDP must share the SAME external port for the same container port.
+		if svc.Spec.Ports[0].Port != svc.Spec.Ports[1].Port {
+			t.Errorf("%s: TCP and UDP should share the same external port, got %d and %d",
+				c.podName, svc.Spec.Ports[0].Port, svc.Spec.Ports[1].Port)
+		}
+	}
+}
+
+// indexFromName mirrors util.GetIndexFromGsName for the test without importing it,
+// keeping the test focused on the plugin's own logic.
+func indexFromName(name string) int {
+	switch name {
+	case "game-0":
+		return 0
+	case "game-1":
+		return 1
+	case "game-2":
+		return 2
+	}
+	return 0
+}


### PR DESCRIPTION
  ## What this PR does / why we need it

  OKG ships cloud network plugins for Alibaba Cloud, Tencent Cloud, AWS, Huawei
  Cloud, Volcengine and JD Cloud, but **none for Google Cloud (GKE)**. On GKE users
  are limited to the generic `Kubernetes-NodePort` / `HostPort` / `Ingress` plugins,
  which have drawbacks for game servers:

  1. Exposing a stable public address means hand-creating `type=LoadBalancer`
     Services that OKG does not manage, so they don't follow scaling.
  2. On scale-down the leftover Service / forwarding rule is not cleaned up
     (port + billing leak).
  3. NodePort/HostPort tie the public IP to a node, which breaks under node
     autoscaling and does not work on GKE Autopilot (nodes have no external IP).

  This PR adds a `GCP-NLB` plugin: OKG automatically creates and recycles a GCP
  passthrough Network Load Balancer per GameServer by managing GKE-native
  `type=LoadBalancer` Services (loadBalancerClass `networking.gke.io/l4-regional-external`).
  The GKE controller turns each Service into a forwarding rule + NEG and assigns the
  external IP; OKG writes the address back to `GameServer.status.networkStatus`.
  Because it only manages standard Services (no privileged pods, no DaemonSet) it
  works on GKE Autopilot and is decoupled from node lifecycle.

  ## Features

  - **Single shared LB IP + per-pod port offset**: with `LoadBalancerIP` + `MinPort`,
    every pod shares one IP and gets a distinct external port (`MinPort + ordinal`)
    while the container `targetPort` stays fixed — e.g. `IP:9000→pod-0`, `IP:9001→pod-1`.
  - **Mixed TCP+UDP on the same port**: unique ServicePort names are generated by
    appending the protocol (`9000-tcp` / `9000-udp`).
    - `Fixed=false` (default): Service owned by the **GameServer CR** — survives pod
      recreation (OnDelete update, zero downtime) but is auto-cleaned on scale-down.
      Requires `reclaimPolicy: Delete` so the GameServer CR is owned by the GSS
      rather than the pod.
    - `Fixed=true`: Service owned by the GameServerSet → stable address that also
      survives scale-down; cleaned up when the GSS is deleted (`OnPodDeleted`).
  - **Autopilot-compatible** — no privileged workloads required.

  ## Configuration

  ```yaml
  network:
    networkType: GCP-NLB
    networkConf: 
      - name: PortProtocols
        value: "9000/TCP,9000/UDP"
      - name: LoadBalancerIP         # optional, shared static IP
        value: "34.80.242.156"       
      - name: MinPort                # optional, enables port-offset mode
        value: "9000"
      - name: Fixed                  # optional, default false
        value: "true"
      - name: ExternalTrafficPolicy  # optional, default Local
        value: "Local"

  Testing

  Unit tests (gcp_nlb_test.go): config parsing, port dedup, dual-protocol naming,
  port-offset allocation — all pass.

  Manually verified on GKE Standard 1.36 and GKE Autopilot 1.36 (asia-east1):
  - single IP 34.80.242.156 → ports 9000/9001/9002 routed to 3 different pods, each carrying both TCP and UDP;
  - Fixed=false scale-down: deleting a pod removed its Service and both forwarding rules, no residue; 
  - Fixed=true update: deleting/recreating a pod kept the same Service (UID unchanged), no LB rebuild;
  - Fixed=true GSS deletion: all Services and forwarding rules removed;
  - Autopilot: same results.

  Notes

  - A direct GCP Compute API variant (no dependency on the GKE Service controller)
  is possible but intentionally not implemented here to keep the plugin credential-free.

  Related: #344  (NodePort same-port naming fix, split out separately)

  ---