### PR TITLE
feat(autoscaler): add wtdbThreshold parameter to prioritize scale-dow…

### DIFF
--- a/docs/proposals/20260609-autoscaler-scale-down-priority.md
+++ b/docs/proposals/20260609-autoscaler-scale-down-priority.md
@@ -49,7 +49,7 @@ The OKG External Scaler currently uses a mutually exclusive two-branch logic in 
 
 In large-scale clusters, this design causes a problem: the None count frequently drops below `minAvailable` due to slow pod startup, game server allocation, or frequent state changes. As a result, the scaler consistently enters the scale-up branch, the overall `spec.Replicas` keeps growing, and WTBD game servers are never deleted.
 
-This proposal introduces a configurable threshold parameter (`wtdbThreshold`) to the ScaledObject metadata. When the WTBD count (or WTBD ratio) exceeds this threshold, the scaler prioritizes scale-down to clear the WTBD backlog before considering scale-up. When WTBD is below the threshold, the existing scale-up-first behavior is preserved for backward compatibility.
+This proposal introduces a configurable threshold parameter (`scaleDownThreshold`) to the ScaledObject metadata. When the WTBD count (or WTBD ratio) exceeds this threshold, the scaler prioritizes scale-down to clear the WTBD backlog before considering scale-up. When WTBD is below the threshold, the existing scale-up-first behavior is preserved for backward compatibility.
 
 ## Motivation
 
@@ -77,7 +77,7 @@ A game operator runs a cluster with 500 game servers. The `minAvailable` is set 
 
 **Current behavior**: The scaler always sees `noneNum < minAvailable`, keeps scaling up, and `spec.Replicas` grows from 500 to 600+. The 50+ WTBD servers are never deleted.
 
-**Expected behavior**: The operator sets `wtdbThreshold: "10"`. When WTBD count exceeds 10, the scaler returns a `desiredReplicas` lower than the current pod count, triggering scale-down. The controller deletes the WTBD servers. Once WTBD drops below 10, the scaler resumes normal scale-up-first behavior.
+**Expected behavior**: The operator sets `scaleDownThreshold: "10"`. When WTBD count exceeds 10, the scaler returns a `desiredReplicas` lower than the current pod count, triggering scale-down. The controller deletes the WTBD servers. Once WTBD drops below 10, the scaler resumes normal scale-up-first behavior.
 
 #### Story 2: Small-Scale Cluster with Normal WTBD Flow
 
@@ -85,7 +85,7 @@ A game operator runs a cluster with 10 game servers and `minAvailable: 3`. WTBD 
 
 **Current behavior**: Works correctly. The None count is usually sufficient, and the scaler reaches the scale-down branch to delete WTBD servers.
 
-**Expected behavior**: The operator does not set `wtdbThreshold` (or sets it high). The behavior remains identical to the current implementation. No disruption.
+**Expected behavior**: The operator does not set `scaleDownThreshold` (or sets it high). The behavior remains identical to the current implementation. No disruption.
 
 ### Implementation Details/Notes/Constraints
 
@@ -111,7 +111,7 @@ The problem: the scale-up branch has an early return. When `noneNum < minNum` (f
 
 #### Proposed Solution: Threshold-Based Priority Control
 
-Introduce a new ScaledObject metadata parameter `wtdbThreshold` that controls when scale-down takes priority over scale-up.
+Introduce a new ScaledObject metadata parameter `scaleDownThreshold` that controls when scale-down takes priority over scale-up.
 
 **Decision logic**:
 
@@ -129,13 +129,13 @@ The key insight: when WTBD exceeds the threshold, the scaler deliberately allows
 
 #### Threshold Parameter Design
 
-The `wtdbThreshold` parameter supports two formats:
+The `scaleDownThreshold` parameter supports two formats:
 
 **Absolute value** (integer >= 1):
 
 ```yaml
 metadata:
-  wtdbThreshold: "10"   # Trigger scale-down priority when WTBD count > 10
+  scaleDownThreshold: "10"   # Trigger scale-down priority when WTBD count > 10
 ```
 
 - Simple and intuitive for small to medium clusters.
@@ -145,7 +145,7 @@ metadata:
 
 ```yaml
 metadata:
-  wtdbThreshold: "0.1"  # Trigger scale-down priority when WTBD ratio > 10%
+  scaleDownThreshold: "0.1"  # Trigger scale-down priority when WTBD ratio > 10%
 ```
 
 - The WTBD ratio is calculated as: `numWaitToBeDeleted / totalNum`.
@@ -154,7 +154,7 @@ metadata:
 
 **Default behavior** (parameter not set):
 
-- When `wtdbThreshold` is not specified, the scaler behaves identically to the current implementation (scale-up always takes priority when `noneNum < minNum`).
+- When `scaleDownThreshold` is not specified, the scaler behaves identically to the current implementation (scale-up always takes priority when `noneNum < minNum`).
 - This ensures full backward compatibility.
 
 The parameter is parsed using the same approach as `minAvailable` (via `strconv.ParseFloat`), distinguishing between integer and percentage values.
@@ -166,7 +166,7 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
     // ... existing code: get GSS, list pods, count totalNum, noneNum, numWaitToBeDeleted ...
 
     // --- NEW: WTBD threshold check ---
-    thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[WTBDThresholdKey]
+    thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[ScaleDownThresholdKey]
     if thresholdStr != "" {
         threshold, isPercentage := parseThreshold(thresholdStr)
         exceeded := false
@@ -202,7 +202,7 @@ Note on the `minAvailable` floor: when prioritizing scale-down, we still apply `
 
 #### Behavior Walkthrough
 
-Consider: `minAvailable: 3`, `wtdbThreshold: "5"`, cluster with 100 pods (noneNum=2, WTBD=20).
+Consider: `minAvailable: 3`, `scaleDownThreshold: "5"`, cluster with 100 pods (noneNum=2, WTBD=20).
 
 | Cycle | totalNum | noneNum | WTBD | WTBD > threshold? | desireReplicas | Action |
 |-------|----------|---------|------|-------------------|----------------|--------|
@@ -225,13 +225,13 @@ If WTBD does not exceed threshold (e.g., WTBD=3):
 | Users may misconfigure the threshold | Provide clear documentation with recommended values for different cluster sizes. Default behavior (no threshold set) preserves current behavior. |
 | Percentage threshold may cause instability near the boundary | The threshold comparison uses `>` (strict greater than), so values exactly at the boundary do not trigger scale-down. HPA/KEDA stabilization windows also dampen oscillation. |
 | Scale-down and scale-up oscillation when WTBD hovers around the threshold | KEDA's built-in `stabilizationWindowSeconds` and `cooldownPeriod` naturally mitigate this. The threshold is a coarse-grained control, not a real-time PID controller. |
-| Backward compatibility breakage | When `wtdbThreshold` is not set, the scaler behaves identically to the current implementation. No breaking changes. |
+| Backward compatibility breakage | When `scaleDownThreshold` is not set, the scaler behaves identically to the current implementation. No breaking changes. |
 
 ## Upgrade Strategy
 
-- No changes to CRD or API types. The `wtdbThreshold` parameter is added to the ScaledObject metadata, which is already a free-form `map[string]string`.
+- No changes to CRD or API types. The `scaleDownThreshold` parameter is added to the ScaledObject metadata, which is already a free-form `map[string]string`.
 - Existing ScaledObject configurations work without any modification.
-- Users who want to enable the new behavior add `wtdbThreshold` to their ScaledObject metadata.
+- Users who want to enable the new behavior add `scaleDownThreshold` to their ScaledObject metadata.
 - No controller restart or rolling update is required. The External Scaler reads the parameter on each `GetMetrics` call.
 
 ## Implementation History
@@ -262,7 +262,7 @@ OKG External Scaler 当前在 `GetMetrics` 中使用互斥的双分支逻辑：�
 
 在大规模集群中，这个设计会导致问题：由于 Pod 启动慢、游戏服被分配、状态频繁变化等原因，None 数量经常低于 `minAvailable`。Scaler 持续进入扩容分支，`spec.Replicas` 不断上涨，WTBD 游戏服永远无法被删除。
 
-本方案引入一个可配置的阈值参数 `wtdbThreshold` 到 ScaledObject 元数据中。当 WTBD 数量（或比例）超过此阈值时，Scaler 优先缩容以清理 WTBD 积压；当 WTBD 低于阈值时，保留现有的扩容优先行为，确保向后兼容。
+本方案引入一个可配置的阈值参数 `scaleDownThreshold` 到 ScaledObject 元数据中。当 WTBD 数量（或比例）超过此阈值时，Scaler 优先缩容以清理 WTBD 积压；当 WTBD 低于阈值时，保留现有的扩容优先行为，确保向后兼容。
 
 ## 动机
 
@@ -290,7 +290,7 @@ OKG External Scaler 当前在 `GetMetrics` 中使用互斥的双分支逻辑：�
 
 **当前行为**：Scaler 始终看到 `noneNum < minAvailable`，持续扩容，`spec.Replicas` 从 500 涨到 600+。50+ 个 WTBD 游戏服永远无法被删除。
 
-**预期行为**：运营商设置 `wtdbThreshold: "10"`。当 WTBD 数量超过 10 时，Scaler 返回一个小于当前 Pod 数量的 `desiredReplicas`，触发缩容。Controller 删除 WTBD 游戏服。一旦 WTBD 降至 10 以下，Scaler 恢复正常的扩容优先行为。
+**预期行为**：运营商设置 `scaleDownThreshold: "10"`。当 WTBD 数量超过 10 时，Scaler 返回一个小于当前 Pod 数量的 `desiredReplicas`，触发缩容。Controller 删除 WTBD 游戏服。一旦 WTBD 降至 10 以下，Scaler 恢复正常的扩容优先行为。
 
 #### 场景 2：小规模集群的正常 WTBD 流转
 
@@ -298,7 +298,7 @@ OKG External Scaler 当前在 `GetMetrics` 中使用互斥的双分支逻辑：�
 
 **当前行为**：正常工作。None 数量通常充足，Scaler 能走到缩容分支删除 WTBD 游戏服。
 
-**预期行为**：运营商不设置 `wtdbThreshold`（或设置较高值）。行为与现有实现完全一致。无影响。
+**预期行为**：运营商不设置 `scaleDownThreshold`（或设置较高值）。行为与现有实现完全一致。无影响。
 
 ### 实现细节/注意事项/约束
 
@@ -324,7 +324,7 @@ return desireReplicas
 
 #### 方案：基于阈值的优先级控制
 
-在 ScaledObject 元数据中新增 `wtdbThreshold` 参数，控制缩容何时优先于扩容。
+在 ScaledObject 元数据中新增 `scaleDownThreshold` 参数，控制缩容何时优先于扩容。
 
 **决策逻辑**：
 
@@ -342,13 +342,13 @@ return desireReplicas
 
 #### 阈值参数设计
 
-`wtdbThreshold` 参数支持两种格式：
+`scaleDownThreshold` 参数支持两种格式：
 
 **绝对值**（整数 >= 1）：
 
 ```yaml
 metadata:
-  wtdbThreshold: "10"   # 当 WTBD 数量 > 10 时触发缩容优先
+  scaleDownThreshold: "10"   # 当 WTBD 数量 > 10 时触发缩容优先
 ```
 
 - 对小到中型集群简单直观。
@@ -358,7 +358,7 @@ metadata:
 
 ```yaml
 metadata:
-  wtdbThreshold: "0.1"  # 当 WTBD 占比 > 10% 时触发缩容优先
+  scaleDownThreshold: "0.1"  # 当 WTBD 占比 > 10% 时触发缩容优先
 ```
 
 - WTBD 占比计算公式：`numWaitToBeDeleted / totalNum`。
@@ -367,7 +367,7 @@ metadata:
 
 **默认行为**（参数未设置时）：
 
-- 当未指定 `wtdbThreshold` 时，Scaler 行为与现有实现完全一致（当 `noneNum < minNum` 时始终扩容优先）。
+- 当未指定 `scaleDownThreshold` 时，Scaler 行为与现有实现完全一致（当 `noneNum < minNum` 时始终扩容优先）。
 - 确保完全向后兼容。
 
 参数解析方式与 `minAvailable` 相同（通过 `strconv.ParseFloat`），区分整数和百分比值。
@@ -379,7 +379,7 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
     // ... 现有代码：获取 GSS、列出 Pod、统计 totalNum、noneNum、numWaitToBeDeleted ...
 
     // --- 新增：WTBD 阈值检查 ---
-    thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[WTBDThresholdKey]
+    thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[ScaleDownThresholdKey]
     if thresholdStr != "" {
         threshold, isPercentage := parseThreshold(thresholdStr)
         exceeded := false
@@ -415,7 +415,7 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
 
 #### 行为推演
 
-场景：`minAvailable: 3`，`wtdbThreshold: "5"`，集群 100 个 Pod（noneNum=2，WTBD=20）。
+场景：`minAvailable: 3`，`scaleDownThreshold: "5"`，集群 100 个 Pod（noneNum=2，WTBD=20）。
 
 | 轮次 | totalNum | noneNum | WTBD | WTBD > 阈值? | desireReplicas | 动作 |
 |------|----------|---------|------|-------------|----------------|------|
@@ -438,13 +438,13 @@ WTBD 未超过阈值的场景（如 WTBD=3）：
 | 用户可能错误配置阈值 | 提供清晰的文档，包含不同集群规模的推荐值。默认行为（不设置阈值）保留当前行为。 |
 | 百分比阈值在边界附近可能导致不稳定 | 阈值比较使用 `>`（严格大于），恰好在边界上的值不会触发缩容。HPA/KEDA 的稳定窗口也会抑制振荡。 |
 | WTBD 在阈值附近波动时可能导致扩缩振荡 | KEDA 内置的 `stabilizationWindowSeconds` 和 `cooldownPeriod` 自然会缓解此问题。阈值是粗粒度的控制，不是实时的 PID 控制器。 |
-| 向后兼容性破坏 | 未设置 `wtdbThreshold` 时，Scaler 行为与现有实现完全一致。无破坏性变更。 |
+| 向后兼容性破坏 | 未设置 `scaleDownThreshold` 时，Scaler 行为与现有实现完全一致。无破坏性变更。 |
 
 ## 升级策略
 
-- 无需修改 CRD 或 API 类型。`wtdbThreshold` 参数添加到 ScaledObject 元数据中，该字段已经是自由格式的 `map[string]string`。
+- 无需修改 CRD 或 API 类型。`scaleDownThreshold` 参数添加到 ScaledObject 元数据中，该字段已经是自由格式的 `map[string]string`。
 - 现有的 ScaledObject 配置无需任何修改即可继续使用。
-- 需要启用新行为的用户只需在 ScaledObject 元数据中添加 `wtdbThreshold`。
+- 需要启用新行为的用户只需在 ScaledObject 元数据中添加 `scaleDownThreshold`。
 - 不需要 Controller 重启或滚动更新。External Scaler 在每次 `GetMetrics` 调用时读取该参数。
 
 ## 实施历史

--- a/docs/proposals/20260609-autoscaler-scale-down-priority.md
+++ b/docs/proposals/20260609-autoscaler-scale-down-priority.md
@@ -1,0 +1,455 @@
+---
+title: External Scaler Scale-Down Priority Control via Threshold Parameter
+authors:
+  - "@ChrisLiu"
+reviewers:
+  - "@openkruise/kruise-game-maintainers"
+creation-date: 2026-06-09
+last-updated: 2026-06-09
+status: provisional
+---
+
+# External Scaler Scale-Down Priority Control via Threshold Parameter
+
+## Table of Contents
+
+- [External Scaler Scale-Down Priority Control via Threshold Parameter](#external-scaler-scale-down-priority-control-via-threshold-parameter)
+  - [Table of Contents](#table-of-contents)
+  - [Glossary](#glossary)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals/Future Work](#non-goalsfuture-work)
+  - [Proposal](#proposal)
+    - [User Stories](#user-stories)
+      - [Story 1: Large-Scale Cluster with WTBD Accumulation](#story-1-large-scale-cluster-with-wtbd-accumulation)
+      - [Story 2: Small-Scale Cluster with Normal WTBD Flow](#story-2-small-scale-cluster-with-normal-wtbd-flow)
+    - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
+      - [Current Architecture and Problem Analysis](#current-architecture-and-problem-analysis)
+      - [Proposed Solution: Threshold-Based Priority Control](#proposed-solution-threshold-based-priority-control)
+      - [Threshold Parameter Design](#threshold-parameter-design)
+      - [Pseudocode](#pseudocode)
+      - [Behavior Walkthrough](#behavior-walkthrough)
+    - [Risks and Mitigations](#risks-and-mitigations)
+  - [Upgrade Strategy](#upgrade-strategy)
+  - [Implementation History](#implementation-history)
+
+## Glossary
+
+- **GSS**: GameServerSet, the workload type in OpenKruiseGame.
+- **GS**: GameServer, the individual game server instance managed by GSS.
+- **WTBD**: WaitToBeDeleted, the opsState of a GS that indicates it is ready to be removed during scale-down.
+- **External Scaler**: The gRPC-based scaler in OKG that integrates with KEDA to provide game-server-aware autoscaling decisions.
+- **minAvailable**: A ScaledObject metadata parameter specifying the minimum number of GS with opsState=None.
+- **KEDA**: Kubernetes Event-driven Autoscaling, an external autoscaler framework used by OKG.
+
+## Summary
+
+The OKG External Scaler currently uses a mutually exclusive two-branch logic in `GetMetrics`: when the number of None-opState game servers is below `minAvailable`, it prioritizes scale-up and returns early without considering scale-down; when None count is sufficient, it proceeds to scale down WTBD game servers.
+
+In large-scale clusters, this design causes a problem: the None count frequently drops below `minAvailable` due to slow pod startup, game server allocation, or frequent state changes. As a result, the scaler consistently enters the scale-up branch, the overall `spec.Replicas` keeps growing, and WTBD game servers are never deleted.
+
+This proposal introduces a configurable threshold parameter (`wtdbThreshold`) to the ScaledObject metadata. When the WTBD count (or WTBD ratio) exceeds this threshold, the scaler prioritizes scale-down to clear the WTBD backlog before considering scale-up. When WTBD is below the threshold, the existing scale-up-first behavior is preserved for backward compatibility.
+
+## Motivation
+
+### Goals
+
+- Fix the issue where WTBD game servers accumulate and are never deleted in large-scale clusters.
+- Prevent unbounded growth of `spec.Replicas` caused by the mutually exclusive scale-up/scale-down logic.
+- Provide users with a configurable parameter to control the trade-off between scale-up priority and scale-down urgency.
+- Maintain backward compatibility: existing clusters without the new parameter should behave identically to the current implementation.
+
+### Non-Goals/Future Work
+
+- Changing the GameServerSet controller's pod deletion priority logic. The controller's behavior (WTBD first, then None, then Allocated, etc.) remains unchanged.
+- Modifying KEDA or HPA behavior. The proposal only changes the `desiredReplicas` calculation within the OKG External Scaler.
+- Implementing a fully dynamic or predictive autoscaling algorithm. This proposal is a pragmatic, incremental improvement.
+- Supporting complex multi-trigger scaling scenarios beyond the external scaler trigger.
+
+## Proposal
+
+### User Stories
+
+#### Story 1: Large-Scale Cluster with WTBD Accumulation
+
+A game operator runs a cluster with 500 game servers. The `minAvailable` is set to 10. During off-peak hours, many game servers finish their sessions and transition to WTBD via ServiceQuality auto-detection. However, the None count also drops because active servers are being allocated to players.
+
+**Current behavior**: The scaler always sees `noneNum < minAvailable`, keeps scaling up, and `spec.Replicas` grows from 500 to 600+. The 50+ WTBD servers are never deleted.
+
+**Expected behavior**: The operator sets `wtdbThreshold: "10"`. When WTBD count exceeds 10, the scaler returns a `desiredReplicas` lower than the current pod count, triggering scale-down. The controller deletes the WTBD servers. Once WTBD drops below 10, the scaler resumes normal scale-up-first behavior.
+
+#### Story 2: Small-Scale Cluster with Normal WTBD Flow
+
+A game operator runs a cluster with 10 game servers and `minAvailable: 3`. WTBD servers appear occasionally (1-2 at a time) and are deleted quickly during normal scaling cycles.
+
+**Current behavior**: Works correctly. The None count is usually sufficient, and the scaler reaches the scale-down branch to delete WTBD servers.
+
+**Expected behavior**: The operator does not set `wtdbThreshold` (or sets it high). The behavior remains identical to the current implementation. No disruption.
+
+### Implementation Details/Notes/Constraints
+
+#### Current Architecture and Problem Analysis
+
+The OKG External Scaler's responsibility is limited to computing a `desiredReplicas` value and returning it to KEDA via the `GetMetrics` gRPC call. KEDA then adjusts `gss.Spec.Replicas` accordingly. The GameServerSet controller reconciles the actual state:
+- If `spec.Replicas > current pods` -> scale up (create new pods).
+- If `spec.Replicas < current pods` -> scale down (delete pods by priority: WTBD first).
+
+The current `GetMetrics` logic (in `pkg/externalscaler/externalscaler.go`):
+
+```
+if noneNum < minNum:
+    desireReplicas = spec.Replicas + (minNum - noneNum)  // Scale up
+    return desireReplicas  // EARLY RETURN: scale-down branch never reached
+
+// Scale down WTBD
+desireReplicas = spec.Replicas - numWaitToBeDeleted
+return desireReplicas
+```
+
+The problem: the scale-up branch has an early return. When `noneNum < minNum` (frequent in large-scale clusters), the scaler always returns a value >= current pod count, so KEDA never triggers scale-down. The `spec.Replicas` grows monotonically.
+
+#### Proposed Solution: Threshold-Based Priority Control
+
+Introduce a new ScaledObject metadata parameter `wtdbThreshold` that controls when scale-down takes priority over scale-up.
+
+**Decision logic**:
+
+```
+1. Count totalNum, noneNum, numWaitToBeDeleted (same as current)
+2. Check if WTBD exceeds threshold
+3. If WTBD exceeds threshold:
+   - Prioritize scale-down: return totalNum - numWaitToBeDeleted
+   - This ensures all WTBD pods are deleted by the controller
+4. If WTBD does not exceed threshold:
+   - Use existing logic (scale-up-first when noneNum < minNum)
+```
+
+The key insight: when WTBD exceeds the threshold, the scaler deliberately allows the None count to temporarily drop below `minAvailable` in order to clear the WTBD backlog. In the next scaling cycle, once WTBD is cleared, the scaler will naturally enter the scale-up branch and restore the None count.
+
+#### Threshold Parameter Design
+
+The `wtdbThreshold` parameter supports two formats:
+
+**Absolute value** (integer >= 1):
+
+```yaml
+metadata:
+  wtdbThreshold: "10"   # Trigger scale-down priority when WTBD count > 10
+```
+
+- Simple and intuitive for small to medium clusters.
+- The scaler triggers scale-down when `numWaitToBeDeleted > threshold`.
+
+**Percentage** (float between 0 and 1, expressed as string):
+
+```yaml
+metadata:
+  wtdbThreshold: "0.1"  # Trigger scale-down priority when WTBD ratio > 10%
+```
+
+- The WTBD ratio is calculated as: `numWaitToBeDeleted / totalNum`.
+- More suitable for clusters of varying sizes. 10 WTBD in a 20-pod cluster (50%) is very different from 10 WTBD in a 1000-pod cluster (1%).
+- The denominator uses `totalNum` (current actual pod count), not `spec.Replicas`, because `totalNum` reflects the real cluster state while `spec.Replicas` may lag behind KEDA's reconciliation.
+
+**Default behavior** (parameter not set):
+
+- When `wtdbThreshold` is not specified, the scaler behaves identically to the current implementation (scale-up always takes priority when `noneNum < minNum`).
+- This ensures full backward compatibility.
+
+The parameter is parsed using the same approach as `minAvailable` (via `strconv.ParseFloat`), distinguishing between integer and percentage values.
+
+#### Pseudocode
+
+```go
+func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetricsRequest) (*GetMetricsResponse, error) {
+    // ... existing code: get GSS, list pods, count totalNum, noneNum, numWaitToBeDeleted ...
+
+    // --- NEW: WTBD threshold check ---
+    thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[WTBDThresholdKey]
+    if thresholdStr != "" {
+        threshold, isPercentage := parseThreshold(thresholdStr)
+        exceeded := false
+        if isPercentage {
+            // Percentage mode: compare ratio
+            if totalNum > 0 {
+                ratio := float64(numWaitToBeDeleted) / float64(totalNum)
+                exceeded = ratio > threshold
+            }
+        } else {
+            // Absolute mode: compare count
+            exceeded = numWaitToBeDeleted > int(threshold)
+        }
+
+        if exceeded {
+            // Prioritize scale-down: delete all WTBD first
+            desireReplicas := totalNum - numWaitToBeDeleted
+            // Apply minAvailable floor to avoid scaling down too aggressively
+            minNum, _ := handleMinNum(totalNum, noneNum, minNumStr)
+            if minNum > 0 && desireReplicas < minNum {
+                desireReplicas = minNum
+            }
+            return desireReplicas
+        }
+    }
+    // --- END NEW ---
+
+    // ... existing logic: scale-up-first when noneNum < minNum, then scale-down WTBD ...
+}
+```
+
+Note on the `minAvailable` floor: when prioritizing scale-down, we still apply `minNum` as a lower bound to prevent the cluster from scaling down below the minimum required capacity in a single step. This means not all WTBD pods may be deleted in one cycle, but the replicas count will decrease, and subsequent cycles will continue to reduce it until WTBD is cleared.
+
+#### Behavior Walkthrough
+
+Consider: `minAvailable: 3`, `wtdbThreshold: "5"`, cluster with 100 pods (noneNum=2, WTBD=20).
+
+| Cycle | totalNum | noneNum | WTBD | WTBD > threshold? | desireReplicas | Action |
+|-------|----------|---------|------|-------------------|----------------|--------|
+| T0 | 100 | 2 | 20 | Yes (20 > 5) | max(100-20, 3) = 80 | Scale down: delete 20 WTBD |
+| T1 | 80 | 5 | 0 | No (0 <= 5) | Check noneNum >= minNum: 5 >= 3, scale-down branch: 80-0 = 80 | No action |
+| T2 | 80 | 5 | 0 | No | 80 | Stable |
+
+If WTBD does not exceed threshold (e.g., WTBD=3):
+
+| Cycle | totalNum | noneNum | WTBD | WTBD > threshold? | desireReplicas | Action |
+|-------|----------|---------|------|-------------------|----------------|--------|
+| T0 | 100 | 2 | 3 | No (3 <= 5) | noneNum(2) < minNum(3): 100+3-2 = 101 | Scale up |
+| T1 | 101 | 2 | 3 | No | 101+3-2 = 102 | Scale up (existing behavior) |
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Aggressive scale-down may temporarily drop None count below `minAvailable` | Apply `minNum` as a floor in the scale-down branch. The cluster will recover None count in subsequent cycles. |
+| Users may misconfigure the threshold | Provide clear documentation with recommended values for different cluster sizes. Default behavior (no threshold set) preserves current behavior. |
+| Percentage threshold may cause instability near the boundary | The threshold comparison uses `>` (strict greater than), so values exactly at the boundary do not trigger scale-down. HPA/KEDA stabilization windows also dampen oscillation. |
+| Scale-down and scale-up oscillation when WTBD hovers around the threshold | KEDA's built-in `stabilizationWindowSeconds` and `cooldownPeriod` naturally mitigate this. The threshold is a coarse-grained control, not a real-time PID controller. |
+| Backward compatibility breakage | When `wtdbThreshold` is not set, the scaler behaves identically to the current implementation. No breaking changes. |
+
+## Upgrade Strategy
+
+- No changes to CRD or API types. The `wtdbThreshold` parameter is added to the ScaledObject metadata, which is already a free-form `map[string]string`.
+- Existing ScaledObject configurations work without any modification.
+- Users who want to enable the new behavior add `wtdbThreshold` to their ScaledObject metadata.
+- No controller restart or rolling update is required. The External Scaler reads the parameter on each `GetMetrics` call.
+
+## Implementation History
+
+- [ ] 06/09/2026: Proposed idea in design document
+- [ ] TBD: Community review and feedback
+- [ ] TBD: Implementation and testing
+- [ ] TBD: Open PR
+
+---
+
+# 中文版
+
+# External Scaler 缩容优先级控制：基于阈值参数的方案
+
+## 术语表
+
+- **GSS**: GameServerSet，OpenKruiseGame 中的工作负载类型。
+- **GS**: GameServer，由 GSS 管理的单个游戏服实例。
+- **WTBD**: WaitToBeDeleted，表示游戏服处于等待被删除的运维状态。
+- **External Scaler**: OKG 中基于 gRPC 的扩缩器，与 KEDA 集成，提供感知游戏服状态的自动扩缩决策。
+- **minAvailable**: ScaledObject 元数据参数，指定 opsState 为 None 的游戏服的最小数量。
+- **KEDA**: Kubernetes Event-driven Autoscaling，OKG 使用的外部自动扩缩框架。
+
+## 概述
+
+OKG External Scaler 当前在 `GetMetrics` 中使用互斥的双分支逻辑：当 None 状态的游戏服数量低于 `minAvailable` 时，优先扩容并直接返回，不考虑缩容；当 None 数量充足时，才执行缩容 WTBD 游戏服的逻辑。
+
+在大规模集群中，这个设计会导致问题：由于 Pod 启动慢、游戏服被分配、状态频繁变化等原因，None 数量经常低于 `minAvailable`。Scaler 持续进入扩容分支，`spec.Replicas` 不断上涨，WTBD 游戏服永远无法被删除。
+
+本方案引入一个可配置的阈值参数 `wtdbThreshold` 到 ScaledObject 元数据中。当 WTBD 数量（或比例）超过此阈值时，Scaler 优先缩容以清理 WTBD 积压；当 WTBD 低于阈值时，保留现有的扩容优先行为，确保向后兼容。
+
+## 动机
+
+### 目标
+
+- 修复大规模集群中 WTBD 游戏服堆积无法删除的问题。
+- 防止 `spec.Replicas` 因互斥的扩缩逻辑而无限增长。
+- 为用户提供可配置参数，控制扩容优先与缩容紧急度之间的权衡。
+- 保持向后兼容：未设置新参数的集群行为与现有实现完全一致。
+
+### 非目标/未来工作
+
+- 不改变 GameServerSet Controller 的 Pod 删除优先级逻辑。Controller 的行为（WTBD 优先，然后 None，然后 Allocated 等）保持不变。
+- 不修改 KEDA 或 HPA 的行为。本方案仅修改 OKG External Scaler 中 `desiredReplicas` 的计算逻辑。
+- 不实现完全动态或预测性的自动扩缩算法。本方案是务实的增量改进。
+- 不支持 External Scaler trigger 之外的复杂多触发器伸缩场景。
+
+## 方案设计
+
+### 用户场景
+
+#### 场景 1：大规模集群的 WTBD 堆积
+
+游戏运营商运行一个 500 个游戏服的集群，`minAvailable` 设为 10。低峰时段，大量游戏服结束会话后通过 ServiceQuality 自动检测转为 WTBD 状态。但 None 数量也在下降，因为活跃的游戏服正在被分配给玩家。
+
+**当前行为**：Scaler 始终看到 `noneNum < minAvailable`，持续扩容，`spec.Replicas` 从 500 涨到 600+。50+ 个 WTBD 游戏服永远无法被删除。
+
+**预期行为**：运营商设置 `wtdbThreshold: "10"`。当 WTBD 数量超过 10 时，Scaler 返回一个小于当前 Pod 数量的 `desiredReplicas`，触发缩容。Controller 删除 WTBD 游戏服。一旦 WTBD 降至 10 以下，Scaler 恢复正常的扩容优先行为。
+
+#### 场景 2：小规模集群的正常 WTBD 流转
+
+游戏运营商运行一个 10 个游戏服的集群，`minAvailable: 3`。WTBD 游戏服偶尔出现（每次 1-2 个），在正常扩缩周期中很快被删除。
+
+**当前行为**：正常工作。None 数量通常充足，Scaler 能走到缩容分支删除 WTBD 游戏服。
+
+**预期行为**：运营商不设置 `wtdbThreshold`（或设置较高值）。行为与现有实现完全一致。无影响。
+
+### 实现细节/注意事项/约束
+
+#### 当前架构与问题分析
+
+OKG External Scaler 的职责仅限于计算 `desiredReplicas` 值并通过 `GetMetrics` gRPC 调用返回给 KEDA。KEDA 据此调整 `gss.Spec.Replicas`。GameServerSet Controller 负责实际的调和：
+- `spec.Replicas > 当前 Pod 数` -> 扩容（创建新 Pod）。
+- `spec.Replicas < 当前 Pod 数` -> 缩容（按优先级删除 Pod：WTBD 优先）。
+
+当前 `GetMetrics` 逻辑（位于 `pkg/externalscaler/externalscaler.go`）：
+
+```
+if noneNum < minNum:
+    desireReplicas = spec.Replicas + (minNum - noneNum)  // 扩容
+    return desireReplicas  // 直接返回：缩容分支永远不会执行
+
+// 缩容 WTBD
+desireReplicas = spec.Replicas - numWaitToBeDeleted
+return desireReplicas
+```
+
+问题：扩容分支有直接返回（early return）。当 `noneNum < minNum`（大规模集群中经常出现）时，Scaler 始终返回一个 >= 当前 Pod 数量的值，KEDA 永远不会触发缩容。`spec.Replicas` 单调递增。
+
+#### 方案：基于阈值的优先级控制
+
+在 ScaledObject 元数据中新增 `wtdbThreshold` 参数，控制缩容何时优先于扩容。
+
+**决策逻辑**：
+
+```
+1. 统计 totalNum、noneNum、numWaitToBeDeleted（与现有逻辑相同）
+2. 判断 WTBD 是否超过阈值
+3. 如果 WTBD 超过阈值：
+   - 优先缩容：返回 totalNum - numWaitToBeDeleted
+   - 确保 Controller 能删除所有 WTBD Pod
+4. 如果 WTBD 未超过阈值：
+   - 使用现有逻辑（noneNum < minNum 时扩容优先）
+```
+
+核心思路：当 WTBD 超过阈值时，Scaler 有意允许 None 数量暂时低于 `minAvailable`，以清理 WTBD 积压。在下一轮扩缩周期中，一旦 WTBD 被清理，Scaler 自然会进入扩容分支补充 None 数量。
+
+#### 阈值参数设计
+
+`wtdbThreshold` 参数支持两种格式：
+
+**绝对值**（整数 >= 1）：
+
+```yaml
+metadata:
+  wtdbThreshold: "10"   # 当 WTBD 数量 > 10 时触发缩容优先
+```
+
+- 对小到中型集群简单直观。
+- 当 `numWaitToBeDeleted > threshold` 时触发缩容。
+
+**百分比**（0 到 1 之间的浮点数，以字符串形式表示）：
+
+```yaml
+metadata:
+  wtdbThreshold: "0.1"  # 当 WTBD 占比 > 10% 时触发缩容优先
+```
+
+- WTBD 占比计算公式：`numWaitToBeDeleted / totalNum`。
+- 更适合不同规模的集群。20 个 Pod 的集群中 10 个 WTBD（50%）与 1000 个 Pod 的集群中 10 个 WTBD（1%）严重程度完全不同。
+- 分母使用 `totalNum`（当前实际 Pod 数），而非 `spec.Replicas`，因为 `totalNum` 反映真实的集群状态，而 `spec.Replicas` 可能因 KEDA 尚未调和而滞后。
+
+**默认行为**（参数未设置时）：
+
+- 当未指定 `wtdbThreshold` 时，Scaler 行为与现有实现完全一致（当 `noneNum < minNum` 时始终扩容优先）。
+- 确保完全向后兼容。
+
+参数解析方式与 `minAvailable` 相同（通过 `strconv.ParseFloat`），区分整数和百分比值。
+
+#### 伪代码
+
+```go
+func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetricsRequest) (*GetMetricsResponse, error) {
+    // ... 现有代码：获取 GSS、列出 Pod、统计 totalNum、noneNum、numWaitToBeDeleted ...
+
+    // --- 新增：WTBD 阈值检查 ---
+    thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[WTBDThresholdKey]
+    if thresholdStr != "" {
+        threshold, isPercentage := parseThreshold(thresholdStr)
+        exceeded := false
+        if isPercentage {
+            // 百分比模式：比较占比
+            if totalNum > 0 {
+                ratio := float64(numWaitToBeDeleted) / float64(totalNum)
+                exceeded = ratio > threshold
+            }
+        } else {
+            // 绝对值模式：比较数量
+            exceeded = numWaitToBeDeleted > int(threshold)
+        }
+
+        if exceeded {
+            // 优先缩容：先删除所有 WTBD
+            desireReplicas := totalNum - numWaitToBeDeleted
+            // 应用 minAvailable 下限，避免缩容过于激进
+            minNum, _ := handleMinNum(totalNum, noneNum, minNumStr)
+            if minNum > 0 && desireReplicas < minNum {
+                desireReplicas = minNum
+            }
+            return desireReplicas
+        }
+    }
+    // --- 新增结束 ---
+
+    // ... 现有逻辑：noneNum < minNum 时扩容优先，然后缩容 WTBD ...
+}
+```
+
+关于 `minAvailable` 下限的说明：在优先缩容时，仍然将 `minNum` 作为下限，防止集群在单次缩容中降至最低要求容量以下。这意味着可能无法在一个周期内删除所有 WTBD Pod，但副本数会下降，后续周期会继续减少，直到 WTBD 被清理完毕。
+
+#### 行为推演
+
+场景：`minAvailable: 3`，`wtdbThreshold: "5"`，集群 100 个 Pod（noneNum=2，WTBD=20）。
+
+| 轮次 | totalNum | noneNum | WTBD | WTBD > 阈值? | desireReplicas | 动作 |
+|------|----------|---------|------|-------------|----------------|------|
+| T0 | 100 | 2 | 20 | 是 (20 > 5) | max(100-20, 3) = 80 | 缩容：删除 20 个 WTBD |
+| T1 | 80 | 5 | 0 | 否 (0 <= 5) | noneNum(5) >= minNum(3)，缩容分支：80-0 = 80 | 无动作 |
+| T2 | 80 | 5 | 0 | 否 | 80 | 稳定 |
+
+WTBD 未超过阈值的场景（如 WTBD=3）：
+
+| 轮次 | totalNum | noneNum | WTBD | WTBD > 阈值? | desireReplicas | 动作 |
+|------|----------|---------|------|-------------|----------------|------|
+| T0 | 100 | 2 | 3 | 否 (3 <= 5) | noneNum(2) < minNum(3)：100+3-2 = 101 | 扩容 |
+| T1 | 101 | 2 | 3 | 否 | 101+3-2 = 102 | 扩容（现有行为） |
+
+### 风险与缓解措施
+
+| 风险 | 缓解措施 |
+|------|----------|
+| 激进的缩容可能导致 None 数量暂时低于 `minAvailable` | 在缩容分支中应用 `minNum` 作为下限。集群会在后续周期中恢复 None 数量。 |
+| 用户可能错误配置阈值 | 提供清晰的文档，包含不同集群规模的推荐值。默认行为（不设置阈值）保留当前行为。 |
+| 百分比阈值在边界附近可能导致不稳定 | 阈值比较使用 `>`（严格大于），恰好在边界上的值不会触发缩容。HPA/KEDA 的稳定窗口也会抑制振荡。 |
+| WTBD 在阈值附近波动时可能导致扩缩振荡 | KEDA 内置的 `stabilizationWindowSeconds` 和 `cooldownPeriod` 自然会缓解此问题。阈值是粗粒度的控制，不是实时的 PID 控制器。 |
+| 向后兼容性破坏 | 未设置 `wtdbThreshold` 时，Scaler 行为与现有实现完全一致。无破坏性变更。 |
+
+## 升级策略
+
+- 无需修改 CRD 或 API 类型。`wtdbThreshold` 参数添加到 ScaledObject 元数据中，该字段已经是自由格式的 `map[string]string`。
+- 现有的 ScaledObject 配置无需任何修改即可继续使用。
+- 需要启用新行为的用户只需在 ScaledObject 元数据中添加 `wtdbThreshold`。
+- 不需要 Controller 重启或滚动更新。External Scaler 在每次 `GetMetrics` 调用时读取该参数。
+
+## 实施历史
+
+- [ ] 2026/06/09：提出设计方案
+- [ ] 待定：社区评审与反馈
+- [ ] 待定：实现与测试
+- [ ] 待定：提交 PR

--- a/pkg/externalscaler/externalscaler.go
+++ b/pkg/externalscaler/externalscaler.go
@@ -19,7 +19,7 @@ import (
 const (
 	NoneGameServerMinNumberKey = "minAvailable"
 	NoneGameServerMaxNumberKey = "maxAvailable"
-	WTBDThresholdKey           = "wtdbThreshold"
+	ScaleDownThresholdKey      = "scaleDownThreshold"
 )
 
 type ExternalScaler struct {
@@ -151,11 +151,11 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
 	}
 
 	// Check if WTBD count exceeds the threshold, if so prioritize scale-down
-	thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[WTBDThresholdKey]
+	thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[ScaleDownThresholdKey]
 	if thresholdStr != "" && numWaitToBeDeleted > 0 {
-		threshold, isPercentage, parseErr := parseWTBDThreshold(thresholdStr)
+		threshold, isPercentage, parseErr := parseScaleDownThreshold(thresholdStr)
 		if parseErr != nil {
-			klog.Errorf("invalid wtdbThreshold value %q: %v", thresholdStr, parseErr)
+			klog.Errorf("invalid scaleDownThreshold value %q: %v", thresholdStr, parseErr)
 		} else {
 			exceeded := false
 			if isPercentage {
@@ -223,14 +223,14 @@ func NewExternalScaler(client client.Client) *ExternalScaler {
 	}
 }
 
-// parseWTBDThreshold parses the wtdbThreshold value from ScaledObject metadata.
+// parseScaleDownThreshold parses the scaleDownThreshold value from ScaledObject metadata.
 // Supported formats:
 //   - integer >= 1 (e.g. "10"): absolute count threshold, isPercentage=false
 //   - float between 0 and 1 exclusive (e.g. "0.1"): percentage threshold, isPercentage=true
-func parseWTBDThreshold(s string) (threshold float64, isPercentage bool, err error) {
+func parseScaleDownThreshold(s string) (threshold float64, isPercentage bool, err error) {
 	n, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0, false, fmt.Errorf("invalid wtdbThreshold %q: %v", s, err)
+		return 0, false, fmt.Errorf("invalid scaleDownThreshold %q: %v", s, err)
 	}
 	if n > 0 && n < 1 {
 		return n, true, nil
@@ -238,7 +238,7 @@ func parseWTBDThreshold(s string) (threshold float64, isPercentage bool, err err
 	if n >= 1 {
 		return math.Ceil(n), false, nil
 	}
-	return 0, false, fmt.Errorf("invalid wtdbThreshold %q: must be >= 1 (absolute) or between 0 and 1 exclusive (percentage)", s)
+	return 0, false, fmt.Errorf("invalid scaleDownThreshold %q: must be >= 1 (absolute) or between 0 and 1 exclusive (percentage)", s)
 }
 
 // handleMinNum calculate the expected min number of GameServers from the give minNumStr,

--- a/pkg/externalscaler/externalscaler.go
+++ b/pkg/externalscaler/externalscaler.go
@@ -19,6 +19,7 @@ import (
 const (
 	NoneGameServerMinNumberKey = "minAvailable"
 	NoneGameServerMaxNumberKey = "maxAvailable"
+	WTBDThresholdKey           = "wtdbThreshold"
 )
 
 type ExternalScaler struct {
@@ -109,6 +110,24 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
 		}
 	}
 
+	// Count WaitToBeDeleted GameServers (not yet in Deleting state)
+	isWaitToDelete, _ := labels.NewRequirement(gamekruiseiov1alpha1.GameServerOpsStateKey, selection.Equals, []string{string(gamekruiseiov1alpha1.WaitToDelete)})
+	notDeleting, _ := labels.NewRequirement(gamekruiseiov1alpha1.GameServerStateKey, selection.NotEquals, []string{string(gamekruiseiov1alpha1.Deleting)})
+	wtbdPodList := &corev1.PodList{}
+	err = e.client.List(ctx, wtbdPodList, &client.ListOptions{
+		Namespace: ns,
+		LabelSelector: labels.NewSelector().Add(
+			*isWaitToDelete,
+			*notDeleting,
+			*isGssOwner,
+		),
+	})
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	numWaitToBeDeleted := len(wtbdPodList.Items)
+
 	maxNumStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[NoneGameServerMaxNumberKey]
 	var maxNumP *int
 	if maxNumStr != "" {
@@ -120,7 +139,8 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
 		}
 	}
 
-	minNum, err := handleMinNum(totalNum, noneNum, metricRequest.ScaledObjectRef.GetScalerMetadata()[NoneGameServerMinNumberKey])
+	minNumStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[NoneGameServerMinNumberKey]
+	minNum, err := handleMinNum(totalNum, noneNum, minNumStr)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -128,6 +148,42 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
 
 	if maxNumP != nil && minNum > *maxNumP {
 		minNum = *maxNumP
+	}
+
+	// Check if WTBD count exceeds the threshold, if so prioritize scale-down
+	thresholdStr := metricRequest.ScaledObjectRef.GetScalerMetadata()[WTBDThresholdKey]
+	if thresholdStr != "" && numWaitToBeDeleted > 0 {
+		threshold, isPercentage, parseErr := parseWTBDThreshold(thresholdStr)
+		if parseErr != nil {
+			klog.Errorf("invalid wtdbThreshold value %q: %v", thresholdStr, parseErr)
+		} else {
+			exceeded := false
+			if isPercentage {
+				if totalNum > 0 {
+					ratio := float64(numWaitToBeDeleted) / float64(totalNum)
+					exceeded = ratio > threshold
+				}
+			} else {
+				exceeded = float64(numWaitToBeDeleted) > threshold
+			}
+
+			if exceeded {
+				// Prioritize scale-down: set desiredReplicas below totalNum so that
+				// the controller will delete all WTBD pods.
+				desireReplicas := totalNum - numWaitToBeDeleted
+				// Apply minAvailable as a floor to avoid scaling down too aggressively.
+				if minNum > 0 && desireReplicas < minNum {
+					desireReplicas = minNum
+				}
+				klog.Infof("GameServerSet %s/%s WTBD count %d exceeds threshold, prioritize scale-down, desire replicas is %d", ns, name, numWaitToBeDeleted, desireReplicas)
+				return &GetMetricsResponse{
+					MetricValues: []*MetricValue{{
+						MetricName:  "gssReplicas",
+						MetricValue: int64(desireReplicas),
+					}},
+				}, nil
+			}
+		}
 	}
 
 	if noneNum < minNum {
@@ -142,24 +198,7 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
 	}
 
 	//  scale down those GameServers with WaitToBeDeleted opsState
-	isWaitToDelete, _ := labels.NewRequirement(gamekruiseiov1alpha1.GameServerOpsStateKey, selection.Equals, []string{string(gamekruiseiov1alpha1.WaitToDelete)})
-	notDeleting, _ := labels.NewRequirement(gamekruiseiov1alpha1.GameServerStateKey, selection.NotEquals, []string{string(gamekruiseiov1alpha1.Deleting)})
-	podList = &corev1.PodList{}
-	err = e.client.List(ctx, podList, &client.ListOptions{
-		Namespace: ns,
-		LabelSelector: labels.NewSelector().Add(
-			*isWaitToDelete,
-			*notDeleting,
-			*isGssOwner,
-		),
-	})
-	if err != nil {
-		klog.Error(err)
-		return nil, err
-	}
-
 	desireReplicas := int(*gss.Spec.Replicas)
-	numWaitToBeDeleted := len(podList.Items)
 	if numWaitToBeDeleted != 0 {
 		desireReplicas = desireReplicas - numWaitToBeDeleted
 	} else {
@@ -182,6 +221,24 @@ func NewExternalScaler(client client.Client) *ExternalScaler {
 	return &ExternalScaler{
 		client: client,
 	}
+}
+
+// parseWTBDThreshold parses the wtdbThreshold value from ScaledObject metadata.
+// Supported formats:
+//   - integer >= 1 (e.g. "10"): absolute count threshold, isPercentage=false
+//   - float between 0 and 1 exclusive (e.g. "0.1"): percentage threshold, isPercentage=true
+func parseWTBDThreshold(s string) (threshold float64, isPercentage bool, err error) {
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid wtdbThreshold %q: %v", s, err)
+	}
+	if n > 0 && n < 1 {
+		return n, true, nil
+	}
+	if n >= 1 {
+		return math.Ceil(n), false, nil
+	}
+	return 0, false, fmt.Errorf("invalid wtdbThreshold %q: must be >= 1 (absolute) or between 0 and 1 exclusive (percentage)", s)
 }
 
 // handleMinNum calculate the expected min number of GameServers from the give minNumStr,

--- a/pkg/externalscaler/externalscaler_test.go
+++ b/pkg/externalscaler/externalscaler_test.go
@@ -64,14 +64,14 @@ func TestGetMetrics(t *testing.T) {
 	const ns = "default"
 
 	tests := []struct {
-		name             string
-		replicas         int32
-		pods             []*corev1.Pod
-		metadata         map[string]string
-		wantReplicas     int64
-		wantErr          bool
+		name         string
+		replicas     int32
+		pods         []*corev1.Pod
+		metadata     map[string]string
+		wantReplicas int64
+		wantErr      bool
 	}{
-		// --- wtdbThreshold: absolute mode, exceeded ---
+		// --- scaleDownThreshold: absolute mode, exceeded ---
 		{
 			name:     "threshold exceeded (absolute): scale-down prioritized",
 			replicas: 100,
@@ -84,13 +84,13 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "3",
-				"wtdbThreshold": "10",
+				"scaleDownThreshold": "10",
 			},
 			// totalNum=100, noneNum=2, WTBD=20, threshold=10, exceeded
 			// desireReplicas = max(100-20, 3) = 80
 			wantReplicas: 80,
 		},
-		// --- wtdbThreshold: percentage mode, exceeded ---
+		// --- scaleDownThreshold: percentage mode, exceeded ---
 		{
 			name:     "threshold exceeded (percentage): scale-down prioritized",
 			replicas: 100,
@@ -103,13 +103,13 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "3",
-				"wtdbThreshold": "0.1",
+				"scaleDownThreshold": "0.1",
 			},
 			// ratio = 20/100 = 0.2 > 0.1, exceeded
 			// desireReplicas = max(100-20, 3) = 80
 			wantReplicas: 80,
 		},
-		// --- wtdbThreshold: not exceeded, falls through to existing logic ---
+		// --- scaleDownThreshold: not exceeded, falls through to existing logic ---
 		{
 			name:     "threshold not exceeded (absolute): existing scale-up logic",
 			replicas: 100,
@@ -122,13 +122,13 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "5",
-				"wtdbThreshold": "10",
+				"scaleDownThreshold": "10",
 			},
 			// WTBD=3 <= 10, not exceeded. noneNum(2) < minNum(5)
 			// desireReplicas = 100 + 5 - 2 = 103
 			wantReplicas: 103,
 		},
-		// --- wtdbThreshold: not exceeded, falls through to scale-down WTBD ---
+		// --- scaleDownThreshold: not exceeded, falls through to scale-down WTBD ---
 		{
 			name:     "threshold not exceeded, noneNum >= minNum: scale-down WTBD",
 			replicas: 100,
@@ -141,13 +141,13 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "3",
-				"wtdbThreshold": "10",
+				"scaleDownThreshold": "10",
 			},
 			// WTBD=5 <= 10, not exceeded. noneNum(10) >= minNum(3)
 			// desireReplicas = 100 - 5 = 95
 			wantReplicas: 95,
 		},
-		// --- wtdbThreshold: not set, existing behavior preserved ---
+		// --- scaleDownThreshold: not set, existing behavior preserved ---
 		{
 			name:     "no threshold set, existing scale-up behavior",
 			replicas: 10,
@@ -161,7 +161,7 @@ func TestGetMetrics(t *testing.T) {
 			// noneNum(2) < minNum(5), desireReplicas = 10 + 5 - 2 = 13
 			wantReplicas: 13,
 		},
-		// --- wtdbThreshold: not set, existing scale-down behavior ---
+		// --- scaleDownThreshold: not set, existing scale-down behavior ---
 		{
 			name:     "no threshold set, existing scale-down WTBD behavior",
 			replicas: 10,
@@ -175,7 +175,7 @@ func TestGetMetrics(t *testing.T) {
 			// noneNum(5) >= minNum(3), WTBD=3, desireReplicas = 10 - 3 = 7
 			wantReplicas: 7,
 		},
-		// --- wtdbThreshold: invalid string, falls through gracefully ---
+		// --- scaleDownThreshold: invalid string, falls through gracefully ---
 		{
 			name:     "invalid threshold string: falls through to existing logic",
 			replicas: 10,
@@ -185,13 +185,13 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "5",
-				"wtdbThreshold": "invalid",
+				"scaleDownThreshold": "invalid",
 			},
 			// invalid threshold, falls through. noneNum(2) < minNum(5)
 			// desireReplicas = 10 + 5 - 2 = 13
 			wantReplicas: 13,
 		},
-		// --- wtdbThreshold: exceeded but minNum floor kicks in ---
+		// --- scaleDownThreshold: exceeded but minNum floor kicks in ---
 		{
 			name:     "threshold exceeded but minAvailable floor applied",
 			replicas: 10,
@@ -201,26 +201,26 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "5",
-				"wtdbThreshold": "5",
+				"scaleDownThreshold": "5",
 			},
 			// totalNum=10, WTBD=8, threshold=5, exceeded
 			// desireReplicas = max(10-8, 5) = max(2, 5) = 5
 			wantReplicas: 5,
 		},
-		// --- wtdbThreshold: zero WTBD, threshold check skipped ---
+		// --- scaleDownThreshold: zero WTBD, threshold check skipped ---
 		{
 			name:     "zero WTBD pods: threshold check skipped",
 			replicas: 10,
 			pods:     makePods(gssName, ns, 10, string(gamekruiseiov1alpha1.None), ""),
 			metadata: map[string]string{
 				"minAvailable":  "3",
-				"wtdbThreshold": "5",
+				"scaleDownThreshold": "5",
 			},
 			// WTBD=0, threshold skipped. noneNum(10) >= minNum(3), WTBD=0
 			// no maxAvailable, desireReplicas = 10
 			wantReplicas: 10,
 		},
-		// --- wtdbThreshold: percentage mode, not exceeded ---
+		// --- scaleDownThreshold: percentage mode, not exceeded ---
 		{
 			name:     "threshold not exceeded (percentage): existing logic",
 			replicas: 100,
@@ -233,7 +233,7 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "5",
-				"wtdbThreshold": "0.1",
+				"scaleDownThreshold": "0.1",
 			},
 			// ratio = 3/100 = 0.03 < 0.1, not exceeded. noneNum(10) >= minNum(5)
 			// WTBD=3, desireReplicas = 100 - 3 = 97
@@ -255,7 +255,7 @@ func TestGetMetrics(t *testing.T) {
 			),
 			metadata: map[string]string{
 				"minAvailable":  "3",
-				"wtdbThreshold": "8",
+				"scaleDownThreshold": "8",
 			},
 			// WTBD (non-Deleting) = 5, threshold=8, 5 <= 8, not exceeded
 			// noneNum(5) >= minNum(3), WTBD=5, desireReplicas = 100 - 5 = 95
@@ -316,7 +316,7 @@ func makePodsPrefix(gssName, ns, prefix string, count int, opsState, state strin
 	return pods
 }
 
-func TestParseWTBDThreshold(t *testing.T) {
+func TestParseScaleDownThreshold(t *testing.T) {
 	tests := []struct {
 		name       string
 		input      string
@@ -404,19 +404,19 @@ func TestParseWTBDThreshold(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotThresh, gotPct, err := parseWTBDThreshold(tt.input)
+			gotThresh, gotPct, err := parseScaleDownThreshold(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseWTBDThreshold(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Errorf("parseScaleDownThreshold(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 				return
 			}
 			if tt.wantErr {
 				return
 			}
 			if gotPct != tt.wantPct {
-				t.Errorf("parseWTBDThreshold(%q) isPercentage = %v, want %v", tt.input, gotPct, tt.wantPct)
+				t.Errorf("parseScaleDownThreshold(%q) isPercentage = %v, want %v", tt.input, gotPct, tt.wantPct)
 			}
 			if math.Abs(gotThresh-tt.wantThresh) > 1e-9 {
-				t.Errorf("parseWTBDThreshold(%q) threshold = %v, want %v", tt.input, gotThresh, tt.wantThresh)
+				t.Errorf("parseScaleDownThreshold(%q) threshold = %v, want %v", tt.input, gotThresh, tt.wantThresh)
 			}
 		})
 	}

--- a/pkg/externalscaler/externalscaler_test.go
+++ b/pkg/externalscaler/externalscaler_test.go
@@ -7,6 +7,112 @@ import (
 	"testing"
 )
 
+func TestParseWTBDThreshold(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantThresh float64
+		wantPct    bool
+		wantErr    bool
+	}{
+		{
+			name:       "valid absolute integer",
+			input:      "10",
+			wantThresh: 10,
+			wantPct:    false,
+			wantErr:    false,
+		},
+		{
+			name:       "valid absolute integer 1",
+			input:      "1",
+			wantThresh: 1,
+			wantPct:    false,
+			wantErr:    false,
+		},
+		{
+			name:       "valid percentage 0.1",
+			input:      "0.1",
+			wantThresh: 0.1,
+			wantPct:    true,
+			wantErr:    false,
+		},
+		{
+			name:       "valid percentage 0.5",
+			input:      "0.5",
+			wantThresh: 0.5,
+			wantPct:    true,
+			wantErr:    false,
+		},
+		{
+			name:       "valid percentage 0.99",
+			input:      "0.99",
+			wantThresh: 0.99,
+			wantPct:    true,
+			wantErr:    false,
+		},
+		{
+			name:    "invalid - zero",
+			input:   "0",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - negative",
+			input:   "-5",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - not a number",
+			input:   "abc",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:       "float >= 1 treated as absolute",
+			input:      "3.7",
+			wantThresh: 4, // math.Ceil(3.7)
+			wantPct:    false,
+			wantErr:    false,
+		},
+		{
+			name:       "1.0 treated as absolute 1",
+			input:      "1.0",
+			wantThresh: 1,
+			wantPct:    false,
+			wantErr:    false,
+		},
+		{
+			name:       "large absolute value",
+			input:      "100",
+			wantThresh: 100,
+			wantPct:    false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotThresh, gotPct, err := parseWTBDThreshold(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseWTBDThreshold(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if gotPct != tt.wantPct {
+				t.Errorf("parseWTBDThreshold(%q) isPercentage = %v, want %v", tt.input, gotPct, tt.wantPct)
+			}
+			if math.Abs(gotThresh-tt.wantThresh) > 1e-9 {
+				t.Errorf("parseWTBDThreshold(%q) threshold = %v, want %v", tt.input, gotThresh, tt.wantThresh)
+			}
+		})
+	}
+}
+
 func TestHandleMinNum(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/externalscaler/externalscaler_test.go
+++ b/pkg/externalscaler/externalscaler_test.go
@@ -1,11 +1,320 @@
 package externalscaler
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
 	"testing"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = gamekruiseiov1alpha1.AddToScheme(s)
+	return s
+}
+
+func makeGSS(name, ns string, replicas int32) *gamekruiseiov1alpha1.GameServerSet {
+	return &gamekruiseiov1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: gamekruiseiov1alpha1.GameServerSetSpec{
+			Replicas: ptr.To(replicas),
+		},
+	}
+}
+
+func makePod(name, ns, gssName, opsState, state string) *corev1.Pod {
+	labels := map[string]string{
+		gamekruiseiov1alpha1.GameServerOwnerGssKey: gssName,
+		gamekruiseiov1alpha1.GameServerOpsStateKey: opsState,
+	}
+	if state != "" {
+		labels[gamekruiseiov1alpha1.GameServerStateKey] = state
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    labels,
+		},
+	}
+}
+
+func newFakeClient(s *runtime.Scheme, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		Build()
+}
+
+func TestGetMetrics(t *testing.T) {
+	const gssName = "test-gss"
+	const ns = "default"
+
+	tests := []struct {
+		name             string
+		replicas         int32
+		pods             []*corev1.Pod
+		metadata         map[string]string
+		wantReplicas     int64
+		wantErr          bool
+	}{
+		// --- wtdbThreshold: absolute mode, exceeded ---
+		{
+			name:     "threshold exceeded (absolute): scale-down prioritized",
+			replicas: 100,
+			pods: append(
+				makePods(gssName, ns, 2, string(gamekruiseiov1alpha1.None), ""),
+				append(
+					makePodsPrefix(gssName, ns, "w", 20, string(gamekruiseiov1alpha1.WaitToDelete), ""),
+					makePodsPrefix(gssName, ns, "a", 78, string(gamekruiseiov1alpha1.Allocated), "")...,
+				)...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "3",
+				"wtdbThreshold": "10",
+			},
+			// totalNum=100, noneNum=2, WTBD=20, threshold=10, exceeded
+			// desireReplicas = max(100-20, 3) = 80
+			wantReplicas: 80,
+		},
+		// --- wtdbThreshold: percentage mode, exceeded ---
+		{
+			name:     "threshold exceeded (percentage): scale-down prioritized",
+			replicas: 100,
+			pods: append(
+				makePods(gssName, ns, 5, string(gamekruiseiov1alpha1.None), ""),
+				append(
+					makePodsPrefix(gssName, ns, "w", 20, string(gamekruiseiov1alpha1.WaitToDelete), ""),
+					makePodsPrefix(gssName, ns, "a", 75, string(gamekruiseiov1alpha1.Allocated), "")...,
+				)...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "3",
+				"wtdbThreshold": "0.1",
+			},
+			// ratio = 20/100 = 0.2 > 0.1, exceeded
+			// desireReplicas = max(100-20, 3) = 80
+			wantReplicas: 80,
+		},
+		// --- wtdbThreshold: not exceeded, falls through to existing logic ---
+		{
+			name:     "threshold not exceeded (absolute): existing scale-up logic",
+			replicas: 100,
+			pods: append(
+				makePods(gssName, ns, 2, string(gamekruiseiov1alpha1.None), ""),
+				append(
+					makePodsPrefix(gssName, ns, "w", 3, string(gamekruiseiov1alpha1.WaitToDelete), ""),
+					makePodsPrefix(gssName, ns, "a", 95, string(gamekruiseiov1alpha1.Allocated), "")...,
+				)...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "5",
+				"wtdbThreshold": "10",
+			},
+			// WTBD=3 <= 10, not exceeded. noneNum(2) < minNum(5)
+			// desireReplicas = 100 + 5 - 2 = 103
+			wantReplicas: 103,
+		},
+		// --- wtdbThreshold: not exceeded, falls through to scale-down WTBD ---
+		{
+			name:     "threshold not exceeded, noneNum >= minNum: scale-down WTBD",
+			replicas: 100,
+			pods: append(
+				makePods(gssName, ns, 10, string(gamekruiseiov1alpha1.None), ""),
+				append(
+					makePodsPrefix(gssName, ns, "w", 5, string(gamekruiseiov1alpha1.WaitToDelete), ""),
+					makePodsPrefix(gssName, ns, "a", 85, string(gamekruiseiov1alpha1.Allocated), "")...,
+				)...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "3",
+				"wtdbThreshold": "10",
+			},
+			// WTBD=5 <= 10, not exceeded. noneNum(10) >= minNum(3)
+			// desireReplicas = 100 - 5 = 95
+			wantReplicas: 95,
+		},
+		// --- wtdbThreshold: not set, existing behavior preserved ---
+		{
+			name:     "no threshold set, existing scale-up behavior",
+			replicas: 10,
+			pods: append(
+				makePods(gssName, ns, 2, string(gamekruiseiov1alpha1.None), ""),
+				makePodsPrefix(gssName, ns, "a", 8, string(gamekruiseiov1alpha1.Allocated), "")...,
+			),
+			metadata: map[string]string{
+				"minAvailable": "5",
+			},
+			// noneNum(2) < minNum(5), desireReplicas = 10 + 5 - 2 = 13
+			wantReplicas: 13,
+		},
+		// --- wtdbThreshold: not set, existing scale-down behavior ---
+		{
+			name:     "no threshold set, existing scale-down WTBD behavior",
+			replicas: 10,
+			pods: append(
+				makePods(gssName, ns, 5, string(gamekruiseiov1alpha1.None), ""),
+				makePodsPrefix(gssName, ns, "w", 3, string(gamekruiseiov1alpha1.WaitToDelete), "")...,
+			),
+			metadata: map[string]string{
+				"minAvailable": "3",
+			},
+			// noneNum(5) >= minNum(3), WTBD=3, desireReplicas = 10 - 3 = 7
+			wantReplicas: 7,
+		},
+		// --- wtdbThreshold: invalid string, falls through gracefully ---
+		{
+			name:     "invalid threshold string: falls through to existing logic",
+			replicas: 10,
+			pods: append(
+				makePods(gssName, ns, 2, string(gamekruiseiov1alpha1.None), ""),
+				makePodsPrefix(gssName, ns, "w", 5, string(gamekruiseiov1alpha1.WaitToDelete), "")...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "5",
+				"wtdbThreshold": "invalid",
+			},
+			// invalid threshold, falls through. noneNum(2) < minNum(5)
+			// desireReplicas = 10 + 5 - 2 = 13
+			wantReplicas: 13,
+		},
+		// --- wtdbThreshold: exceeded but minNum floor kicks in ---
+		{
+			name:     "threshold exceeded but minAvailable floor applied",
+			replicas: 10,
+			pods: append(
+				makePodsPrefix(gssName, ns, "w", 8, string(gamekruiseiov1alpha1.WaitToDelete), ""),
+				makePodsPrefix(gssName, ns, "a", 2, string(gamekruiseiov1alpha1.Allocated), "")...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "5",
+				"wtdbThreshold": "5",
+			},
+			// totalNum=10, WTBD=8, threshold=5, exceeded
+			// desireReplicas = max(10-8, 5) = max(2, 5) = 5
+			wantReplicas: 5,
+		},
+		// --- wtdbThreshold: zero WTBD, threshold check skipped ---
+		{
+			name:     "zero WTBD pods: threshold check skipped",
+			replicas: 10,
+			pods:     makePods(gssName, ns, 10, string(gamekruiseiov1alpha1.None), ""),
+			metadata: map[string]string{
+				"minAvailable":  "3",
+				"wtdbThreshold": "5",
+			},
+			// WTBD=0, threshold skipped. noneNum(10) >= minNum(3), WTBD=0
+			// no maxAvailable, desireReplicas = 10
+			wantReplicas: 10,
+		},
+		// --- wtdbThreshold: percentage mode, not exceeded ---
+		{
+			name:     "threshold not exceeded (percentage): existing logic",
+			replicas: 100,
+			pods: append(
+				makePods(gssName, ns, 10, string(gamekruiseiov1alpha1.None), ""),
+				append(
+					makePodsPrefix(gssName, ns, "w", 3, string(gamekruiseiov1alpha1.WaitToDelete), ""),
+					makePodsPrefix(gssName, ns, "a", 87, string(gamekruiseiov1alpha1.Allocated), "")...,
+				)...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "5",
+				"wtdbThreshold": "0.1",
+			},
+			// ratio = 3/100 = 0.03 < 0.1, not exceeded. noneNum(10) >= minNum(5)
+			// WTBD=3, desireReplicas = 100 - 3 = 97
+			wantReplicas: 97,
+		},
+		// --- WTBD in Deleting state should not be counted ---
+		{
+			name:     "WTBD pods in Deleting state excluded from count",
+			replicas: 100,
+			pods: append(
+				makePods(gssName, ns, 5, string(gamekruiseiov1alpha1.None), ""),
+				append(
+					append(
+						makePodsPrefix(gssName, ns, "w1", 5, string(gamekruiseiov1alpha1.WaitToDelete), ""),
+						makePodsPrefix(gssName, ns, "w2", 10, string(gamekruiseiov1alpha1.WaitToDelete), string(gamekruiseiov1alpha1.Deleting))...,
+					),
+					makePodsPrefix(gssName, ns, "a", 80, string(gamekruiseiov1alpha1.Allocated), "")...,
+				)...,
+			),
+			metadata: map[string]string{
+				"minAvailable":  "3",
+				"wtdbThreshold": "8",
+			},
+			// WTBD (non-Deleting) = 5, threshold=8, 5 <= 8, not exceeded
+			// noneNum(5) >= minNum(3), WTBD=5, desireReplicas = 100 - 5 = 95
+			wantReplicas: 95,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestScheme()
+			gss := makeGSS(gssName, ns, tt.replicas)
+
+			objs := []client.Object{gss}
+			for _, pod := range tt.pods {
+				objs = append(objs, pod)
+			}
+
+			c := newFakeClient(s, objs...)
+			scaler := NewExternalScaler(c)
+
+			req := &GetMetricsRequest{
+				ScaledObjectRef: &ScaledObjectRef{
+					Name:           gssName,
+					Namespace:      ns,
+					ScalerMetadata: tt.metadata,
+				},
+			}
+
+			resp, err := scaler.GetMetrics(context.Background(), req)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetMetrics() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if len(resp.MetricValues) != 1 {
+				t.Fatalf("expected 1 metric value, got %d", len(resp.MetricValues))
+			}
+			got := resp.MetricValues[0].MetricValue
+			if got != tt.wantReplicas {
+				t.Errorf("GetMetrics() desireReplicas = %d, want %d", got, tt.wantReplicas)
+			}
+		})
+	}
+}
+
+func makePods(gssName, ns string, count int, opsState, state string) []*corev1.Pod {
+	return makePodsPrefix(gssName, ns, "", count, opsState, state)
+}
+
+func makePodsPrefix(gssName, ns, prefix string, count int, opsState, state string) []*corev1.Pod {
+	pods := make([]*corev1.Pod, count)
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("%s%s-%d", prefix, gssName, i)
+		pods[i] = makePod(name, ns, gssName, opsState, state)
+	}
+	return pods
+}
 
 func TestParseWTBDThreshold(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
…n when WTBD accumulates

- Add WTBDThresholdKey constant and parseWTBDThreshold function
- Support both absolute value (>=1) and percentage (0<n<1) threshold formats
- When WTBD count exceeds threshold, prioritize scale-down by returning desiredReplicas = max(totalNum - numWaitToBeDeleted, minNum)
- Preserve existing scale-up-first behavior when threshold is not set or not exceeded
- Move WTBD pod query earlier in GetMetrics to avoid duplicate List calls
- Add unit tests for parseWTBDThreshold
- Add bilingual (EN/CN) design proposal document