### PR TITLE
fix: NLB syncTargetGroupAndService CreateOrUpdate uses empty mutate func

### DIFF
--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -732,22 +732,24 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 		protocol := awsTargetGroupProtocol(config.backends[i].protocol)
 		targetPort := int64(config.backends[i].targetPort)
 		var targetTypeIP = string(ackv1alpha1.TargetTypeEnum_ip)
-		_, err := controllerutil.CreateOrUpdate(ctx, client, &ackv1alpha1.TargetGroup{
+		tg := &ackv1alpha1.TargetGroup{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            targetGroupName,
-				Namespace:       pod.GetNamespace(),
-				OwnerReferences: ownerReference,
-				Labels: map[string]string{
-					ResourceTagKey:           ResourceTagValue,
-					SvcSelectorKey:           pod.GetName(),
-					AWSTargetGroupSyncStatus: "false",
-				},
-				Annotations: map[string]string{
-					NlbARNAnnoKey:  lbARN,
-					NlbPortAnnoKey: fmt.Sprintf("%d", ports[i]),
-				},
+				Name:      targetGroupName,
+				Namespace: pod.GetNamespace(),
 			},
-			Spec: ackv1alpha1.TargetGroupSpec{
+		}
+		_, err := controllerutil.CreateOrUpdate(ctx, client, tg, func() error {
+			tg.OwnerReferences = ownerReference
+			tg.Labels = map[string]string{
+				ResourceTagKey:           ResourceTagValue,
+				SvcSelectorKey:           pod.GetName(),
+				AWSTargetGroupSyncStatus: "false",
+			}
+			tg.Annotations = map[string]string{
+				NlbARNAnnoKey:  lbARN,
+				NlbPortAnnoKey: fmt.Sprintf("%d", ports[i]),
+			}
+			tg.Spec = ackv1alpha1.TargetGroupSpec{
 				HealthCheckEnabled:         config.healthCheck.healthCheckEnabled,
 				HealthCheckIntervalSeconds: config.healthCheck.healthCheckIntervalSeconds,
 				HealthCheckPath:            config.healthCheck.healthCheckPath,
@@ -763,8 +765,9 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 				TargetType:                 &targetTypeIP,
 				Tags: []*ackv1alpha1.Tag{{Key: ptr.To[string](ResourceTagKey),
 					Value: ptr.To[string](ResourceTagValue)}},
-			},
-		}, func() error { return nil })
+			}
+			return nil
+		})
 		if err != nil {
 			return err
 		}
@@ -778,25 +781,26 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 	for key, value := range config.annotations {
 		annotations[key] = value
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, client, &corev1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            pod.GetName(),
-			Namespace:       pod.GetNamespace(),
-			Annotations:     annotations,
-			OwnerReferences: ownerReference,
-			Labels: map[string]string{
-				ResourceTagKey: ResourceTagValue,
-				SvcSelectorKey: pod.GetName(),
-			},
+			Name:      pod.GetName(),
+			Namespace: pod.GetNamespace(),
 		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Selector: map[string]string{
-				SvcSelectorKey: pod.GetName(),
-			},
-			Ports: svcPorts,
-		},
-	}, func() error { return nil })
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, client, svc, func() error {
+		svc.Annotations = annotations
+		svc.OwnerReferences = ownerReference
+		svc.Labels = map[string]string{
+			ResourceTagKey: ResourceTagValue,
+			SvcSelectorKey: pod.GetName(),
+		}
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		svc.Spec.Selector = map[string]string{
+			SvcSelectorKey: pod.GetName(),
+		}
+		svc.Spec.Ports = svcPorts
+		return nil
+	})
 	if err != nil {
 		return err
 	}

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -817,17 +817,19 @@ func syncListenerAndTargetGroupBinding(ctx context.Context, client client.Client
 	}
 	lbARN := tg.Annotations[NlbARNAnnoKey]
 	podName := tg.Labels[SvcSelectorKey]
-	_, err = controllerutil.CreateOrUpdate(ctx, client, &ackv1alpha1.Listener{
+	listener := &ackv1alpha1.Listener{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            tg.GetName(),
-			Namespace:       tg.GetNamespace(),
-			OwnerReferences: tg.GetOwnerReferences(),
-			Labels: map[string]string{
-				ResourceTagKey: ResourceTagValue,
-				SvcSelectorKey: podName,
-			},
+			Name:      tg.GetName(),
+			Namespace: tg.GetNamespace(),
 		},
-		Spec: ackv1alpha1.ListenerSpec{
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, client, listener, func() error {
+		listener.OwnerReferences = tg.GetOwnerReferences()
+		listener.Labels = map[string]string{
+			ResourceTagKey: ResourceTagValue,
+			SvcSelectorKey: podName,
+		}
+		listener.Spec = ackv1alpha1.ListenerSpec{
 			Protocol:        tg.Spec.Protocol,
 			Port:            &port,
 			LoadBalancerARN: &lbARN,
@@ -839,32 +841,36 @@ func syncListenerAndTargetGroupBinding(ctx context.Context, client client.Client
 			},
 			Tags: []*ackv1alpha1.Tag{{Key: ptr.To[string](ResourceTagKey),
 				Value: ptr.To[string](ResourceTagValue)}},
-		},
-	}, func() error { return nil })
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
 
 	var targetTypeIP = elbv2api.TargetTypeIP
-	_, err = controllerutil.CreateOrUpdate(ctx, client, &elbv2api.TargetGroupBinding{
+	tgb := &elbv2api.TargetGroupBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            tg.GetName(),
-			Namespace:       tg.GetNamespace(),
-			OwnerReferences: tg.GetOwnerReferences(),
-			Labels: map[string]string{
-				ResourceTagKey: ResourceTagValue,
-				SvcSelectorKey: podName,
-			},
+			Name:      tg.GetName(),
+			Namespace: tg.GetNamespace(),
 		},
-		Spec: elbv2api.TargetGroupBindingSpec{
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, client, tgb, func() error {
+		tgb.OwnerReferences = tg.GetOwnerReferences()
+		tgb.Labels = map[string]string{
+			ResourceTagKey: ResourceTagValue,
+			SvcSelectorKey: podName,
+		}
+		tgb.Spec = elbv2api.TargetGroupBindingSpec{
 			TargetGroupARN: *targetGroupARN,
 			TargetType:     &targetTypeIP,
 			ServiceRef: elbv2api.ServiceReference{
 				Name: podName,
 				Port: intstr.FromInt(int(port)),
 			},
-		},
-	}, func() error { return nil })
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Ⅰ. Describe what this PR does / why we need it

Several `controllerutil.CreateOrUpdate` calls in `cloudprovider/amazonswebservices/nlb.go` pass `func() error { return nil }` as the mutate function:

- `(NlbPlugin).syncTargetGroupAndService` — ACK `TargetGroup` and `Service`
- `syncListenerAndTargetGroupBinding` — ACK `Listener` and `TargetGroupBinding`

`CreateOrUpdate` fetches the live object from the API server before invoking the mutate function, so any fields set inline on the object literal are overwritten on the **update** path. With an empty mutate, an existing object is therefore never updated — its `OwnerReferences`, labels, annotations (including `game.kruise.io/networkConfig-hash`), and `Spec` stay frozen at whatever values were assigned when the object was first created.

**Visible symptom**: when a `GameServerSet`'s NLB `networkConf` changes (health check tweak, annotations tweak, new fields, etc.), the `Service`'s `NlbConfigHashKey` annotation never matches the new `util.GetHash(config)`. As a result, `OnPodUpdated` keeps taking the "config hash mismatch" branch every reconcile, marking network as `NotReady` and re-invoking `syncTargetGroupAndService` indefinitely — but no field on the live object is ever actually reconciled. Workaround until now has been to delete the pod's `Service` so OKG recreates it on the next reconcile.

This PR moves the desired state into each `CreateOrUpdate` mutate closure so both create and update paths apply the same desired spec/metadata.

## Ⅱ. Does this pull request fix one issue?

Fixes #349

## Ⅲ. Special notes for reviews

- All four `CreateOrUpdate` calls were rewritten in the well-known `controllerutil.CreateOrUpdate` idiom: declare an empty object with just `Name`/`Namespace`, then assign the rest of the fields inside the mutate closure so they apply to both new and existing objects.
- No behavioral change for fresh creates: the same fields are still written, just inside the mutate function instead of the literal.
- For existing objects, the previously-frozen fields will now be reconciled on the next pass — this is the intended fix.
- `go build ./...`, `go vet ./...`, and `go test ./...` (excluding `test/e2e`) all pass on this branch on top of `master @ d76ace2`.

### Verification

```
$ go build ./...
$ go vet ./...
$ go test $(go list ./... | grep -v /test/e2e)
ok      github.com/openkruise/kruise-game/cloudprovider/amazonswebservices  0.012s
ok      github.com/openkruise/kruise-game/cloudprovider/...  (all packages PASS)
ok      github.com/openkruise/kruise-game/pkg/...  (all packages PASS)
```


