### PR TITLE
fix(cloudprovider): unique ServicePort name for same port with TCP and UDP (AWS NLB)

### DIFF
--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -617,6 +617,37 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 	}
 }
 
+// consSvcPorts builds the ServicePort list for the backing ClusterIP Service.
+//
+// Kubernetes requires every ServicePort in a multi-port Service to have a
+// unique Name. When the same target port is exposed for more than one protocol
+// (e.g. PortProtocols "8601/TCP,8601/UDP"), using the bare port number as the
+// Name produces duplicate names and an invalid Service that the API server
+// rejects. In that case we disambiguate by appending the lowercased protocol
+// (e.g. "8601-tcp" / "8601-udp"). Port numbers that appear only once keep the
+// legacy numeric-only name to stay backward compatible.
+func consSvcPorts(backends []*backend, ports []int32) []corev1.ServicePort {
+	portCount := make(map[int]int)
+	for i := 0; i < len(backends); i++ {
+		portCount[backends[i].targetPort]++
+	}
+
+	svcPorts := make([]corev1.ServicePort, 0)
+	for i := 0; i < len(backends); i++ {
+		name := strconv.Itoa(backends[i].targetPort)
+		if portCount[backends[i].targetPort] > 1 {
+			name = name + "-" + strings.ToLower(string(backends[i].protocol))
+		}
+		svcPorts = append(svcPorts, corev1.ServicePort{
+			Name:       name,
+			Port:       ports[i],
+			Protocol:   backends[i].protocol,
+			TargetPort: intstr.FromInt(backends[i].targetPort),
+		})
+	}
+	return svcPorts
+}
+
 func getACKTargetGroupARN(tg *ackv1alpha1.TargetGroup) (string, error) {
 	if len(tg.Status.Conditions) == 0 {
 		return "", fmt.Errorf("targetGroup status not ready")
@@ -691,15 +722,7 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 		}
 	}
 
-	svcPorts := make([]corev1.ServicePort, 0)
-	for i := 0; i < len(config.backends); i++ {
-		svcPorts = append(svcPorts, corev1.ServicePort{
-			Name:       strconv.Itoa(config.backends[i].targetPort),
-			Port:       ports[i],
-			Protocol:   config.backends[i].protocol,
-			TargetPort: intstr.FromInt(config.backends[i].targetPort),
-		})
-	}
+	svcPorts := consSvcPorts(config.backends, ports)
 	annotations := map[string]string{
 		NlbARNAnnoKey:    lbARN,
 		NlbConfigHashKey: util.GetHash(config),

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -286,3 +286,64 @@ func TestInitLbCache(t *testing.T) {
 		t.Errorf("podAllocate expect %v, but actully got %v", test.podAllocate, test.n.podAllocate)
 	}
 }
+
+func TestConsSvcPorts(t *testing.T) {
+	tests := []struct {
+		name      string
+		backends  []*backend
+		ports     []int32
+		wantNames []string
+	}{
+		{
+			name: "same port TCP and UDP gets protocol suffix",
+			backends: []*backend{
+				{targetPort: 8601, protocol: corev1.ProtocolTCP},
+				{targetPort: 8601, protocol: corev1.ProtocolUDP},
+			},
+			ports:     []int32{6000, 6001},
+			wantNames: []string{"8601-tcp", "8601-udp"},
+		},
+		{
+			name: "single protocol keeps numeric-only name (backward compatible)",
+			backends: []*backend{
+				{targetPort: 8601, protocol: corev1.ProtocolTCP},
+			},
+			ports:     []int32{6000},
+			wantNames: []string{"8601"},
+		},
+		{
+			name: "distinct ports keep numeric-only names",
+			backends: []*backend{
+				{targetPort: 8601, protocol: corev1.ProtocolTCP},
+				{targetPort: 8602, protocol: corev1.ProtocolUDP},
+			},
+			ports:     []int32{6000, 6001},
+			wantNames: []string{"8601", "8602"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcPorts := consSvcPorts(tt.backends, tt.ports)
+			if len(svcPorts) != len(tt.wantNames) {
+				t.Fatalf("got %d ports, want %d", len(svcPorts), len(tt.wantNames))
+			}
+			seen := make(map[string]bool)
+			for i, p := range svcPorts {
+				if p.Name != tt.wantNames[i] {
+					t.Errorf("port[%d].Name = %q, want %q", i, p.Name, tt.wantNames[i])
+				}
+				if seen[p.Name] {
+					t.Errorf("duplicate ServicePort name %q (invalid Service)", p.Name)
+				}
+				seen[p.Name] = true
+				if p.Port != tt.ports[i] {
+					t.Errorf("port[%d].Port = %d, want %d", i, p.Port, tt.ports[i])
+				}
+				if p.TargetPort.IntValue() != tt.backends[i].targetPort {
+					t.Errorf("port[%d].TargetPort = %d, want %d", i, p.TargetPort.IntValue(), tt.backends[i].targetPort)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

Kubernetes requires every `ServicePort` in a multi-port Service to have a unique `name`. The `AmazonWebServices-NLB` plugin used the bare target port number as the name, so exposing the same port for both TCP and UDP — e.g. `PortProtocols: "8601/TCP,8601/UDP"` — produced two ServicePorts both named `"8601"`, which is an invalid Service and is rejected by the API server:

```
Service "..." is invalid: spec.ports[1].name: Duplicate value: "8601"
```

## Fix

Append the lowercased protocol to the name **only when a port number repeats** (e.g. `8601-tcp` / `8601-udp`); ports that appear once keep the numeric-only name, so existing single-protocol Services are unaffected (backward compatible).

The port-name generation is extracted into a small pure helper `consSvcPorts` so it can be unit-tested directly. The `TargetGroupBinding.ServiceRef.Port` lookup uses the (distinct) external port number rather than the port name, so it is unaffected by this change.

## Testing

`TestConsSvcPorts` covers three cases:
- `8601/TCP,8601/UDP` → `8601-tcp` / `8601-udp`, asserting names are unique
- single `8601/TCP` → keeps name `8601` (backward compatible)
- distinct ports `8601/8602` → keep numeric-only names

`go build`, `go vet`, and `go test ./cloudprovider/amazonswebservices/...` all pass.

This mirrors the same fix applied to the `Kubernetes-NodePort` plugin in #344.