### PR TITLE
feat: aws nlb tcpudp protocal support

### DIFF
--- a/cloudprovider/amazonswebservices/README.md
+++ b/cloudprovider/amazonswebservices/README.md
@@ -111,6 +111,12 @@ Official deployment documentation: https://docs.aws.amazon.com/eks/latest/usergu
 - Meaning: Ports and protocols exposed by the pod, supports specifying multiple ports/protocols.
 - Format: port1/protocol1,port2/protocol2,... (protocol should be uppercase)
 - Support for change: Yes
+- Supported protocols: `TCP`, `UDP`, and `TCPUDP`.
+- **`TCPUDP`** is a shorthand for exposing the **same port over both TCP and UDP through a single NLB frontend port**. A backend such as `8601/TCPUDP` creates one `TCP_UDP` target group and one `TCP_UDP` listener, so both protocols share the same allocated frontend port. This differs from declaring `8601/TCP,8601/UDP`, which allocates two separate frontend ports (one per protocol).
+- Notes / limitations for `TCPUDP`:
+    - The target group is created with target type `ip` and protocol `TCP_UDP`. AWS uses a **TCP** health check for `TCP_UDP` target groups; the UDP side is not health-checked. See [Health checks for NLB target groups](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html).
+    - For target type `ip`, AWS requires health checks to be **always enabled** (they cannot be disabled), and the health-check protocol cannot be `UDP`/`TCP_UDP`. Do not set `healthCheckEnabled:false` or a UDP health-check protocol, otherwise the target group is rejected by AWS. See [CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html).
+    - Because health checks are TCP-based, the pod must accept TCP connections on the port for the target to become healthy. Ensure the pod/ENI SecurityGroup allows the health-check and client traffic on that port.
 
 #### Fixed
 - Meaning: Whether the access port is fixed. If yes, even if the pod is deleted and rebuilt, the mapping between the internal and external networks will not change.

--- a/cloudprovider/amazonswebservices/README.zh_CN.md
+++ b/cloudprovider/amazonswebservices/README.zh_CN.md
@@ -110,6 +110,12 @@ TargetGroupBinding的CRD及控制器：https://github.com/kubernetes-sigs/aws-lo
 - 含义：pod暴露的端口及协议，支持填写多个端口/协议
 - 填写格式：port1/protocol1,port2/protocol2,...（协议需大写）
 - 是否支持变更：是
+- 支持的协议：`TCP`、`UDP`、`TCPUDP`。
+- **`TCPUDP`** 表示**同一端口通过单个 NLB 前端端口同时暴露 TCP 和 UDP**。例如 `8601/TCPUDP` 会创建一个 `TCP_UDP` 目标组和一个 `TCP_UDP` 监听器，两种协议共用同一个分配出的前端端口。这与 `8601/TCP,8601/UDP` 不同——后者会分配两个独立的前端端口（每种协议各一个）。
+- `TCPUDP` 的注意事项 / 限制：
+    - 目标组以目标类型 `ip`、协议 `TCP_UDP` 创建。AWS 对 `TCP_UDP` 目标组使用 **TCP** 健康检查，不对 UDP 侧做健康检查。参见 [NLB 目标组健康检查](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html)。
+    - 对于目标类型 `ip`，AWS 要求健康检查**必须开启**（无法关闭），且健康检查协议不能为 `UDP`/`TCP_UDP`。不要设置 `healthCheckEnabled:false` 或 UDP 健康检查协议，否则目标组会被 AWS 拒绝。参见 [CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html)。
+    - 由于健康检查基于 TCP，pod 必须在该端口上接受 TCP 连接，目标才会变为 healthy。请确保 pod/ENI 的 SecurityGroup 放行该端口上的健康检查及客户端流量。
 
 #### Fixed
 - 含义：是否固定访问端口。若是，即使pod删除重建，网络内外映射关系不会改变

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -76,6 +76,17 @@ const (
 	listenerActionType         = "forward"
 )
 
+// ProtocolTCPUDP is a synthetic protocol value indicating that a target
+// port should accept both TCP and UDP traffic on the same AWS NLB
+// listener. It is NOT a Kubernetes-recognized protocol and lives only on
+// parsed backends. When emitting a Kubernetes Service the plugin expands
+// it into one TCP and one UDP ServicePort that share the same Port.
+// When emitting AWS resources (TargetGroup, Listener) it is translated
+// to the AWS protocol value "TCP_UDP".
+const ProtocolTCPUDP corev1.Protocol = "TCPUDP"
+
+const awsProtocolTCPUDP = "TCP_UDP"
+
 type portAllocated map[int32]bool
 type nlbPorts struct {
 	arn   string
@@ -627,14 +638,40 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 // (e.g. "8601-tcp" / "8601-udp"). Port numbers that appear only once keep the
 // legacy numeric-only name to stay backward compatible.
 func consSvcPorts(backends []*backend, ports []int32) []corev1.ServicePort {
+	// portCount counts how many ServicePorts will land on each target port
+	// number so we know whether to add a protocol suffix to the
+	// ServicePort name. TCPUDP entries contribute two (TCP and UDP).
 	portCount := make(map[int]int)
 	for i := 0; i < len(backends); i++ {
-		portCount[backends[i].targetPort]++
+		if backends[i].protocol == ProtocolTCPUDP {
+			portCount[backends[i].targetPort] += 2
+		} else {
+			portCount[backends[i].targetPort]++
+		}
 	}
 
 	svcPorts := make([]corev1.ServicePort, 0)
 	for i := 0; i < len(backends); i++ {
-		name := strconv.Itoa(backends[i].targetPort)
+		baseName := strconv.Itoa(backends[i].targetPort)
+		if backends[i].protocol == ProtocolTCPUDP {
+			// TCPUDP expands to TCP+UDP sharing the same Port. Always add
+			// the protocol suffix because two ServicePorts on the same
+			// Port number must have unique Names.
+			svcPorts = append(svcPorts, corev1.ServicePort{
+				Name:       baseName + "-tcp",
+				Port:       ports[i],
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt(backends[i].targetPort),
+			})
+			svcPorts = append(svcPorts, corev1.ServicePort{
+				Name:       baseName + "-udp",
+				Port:       ports[i],
+				Protocol:   corev1.ProtocolUDP,
+				TargetPort: intstr.FromInt(backends[i].targetPort),
+			})
+			continue
+		}
+		name := baseName
 		if portCount[backends[i].targetPort] > 1 {
 			name = name + "-" + strings.ToLower(string(backends[i].protocol))
 		}
@@ -646,6 +683,17 @@ func consSvcPorts(backends []*backend, ports []int32) []corev1.ServicePort {
 		})
 	}
 	return svcPorts
+}
+
+// awsTargetGroupProtocol maps a backend protocol (which may be the
+// synthetic ProtocolTCPUDP) to the string accepted by the AWS ELBv2 API
+// for TargetGroups and Listeners. NLB Listener Protocol is inherited
+// from the TargetGroup, so this single mapping is sufficient.
+func awsTargetGroupProtocol(p corev1.Protocol) string {
+	if p == ProtocolTCPUDP {
+		return awsProtocolTCPUDP
+	}
+	return string(p)
 }
 
 func getACKTargetGroupARN(tg *ackv1alpha1.TargetGroup) (string, error) {
@@ -681,7 +729,7 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 	ownerReference := getOwnerReference(client, ctx, pod, config.isFixed)
 	for i := range ports {
 		targetGroupName := fmt.Sprintf("%s-%d", pod.GetName(), ports[i])
-		protocol := string(config.backends[i].protocol)
+		protocol := awsTargetGroupProtocol(config.backends[i].protocol)
 		targetPort := int64(config.backends[i].targetPort)
 		var targetTypeIP = string(ackv1alpha1.TargetTypeEnum_ip)
 		_, err := controllerutil.CreateOrUpdate(ctx, client, &ackv1alpha1.TargetGroup{

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -617,6 +617,37 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 	}
 }
 
+// consSvcPorts builds the ServicePort list for the backing ClusterIP Service.
+//
+// Kubernetes requires every ServicePort in a multi-port Service to have a
+// unique Name. When the same target port is exposed for more than one protocol
+// (e.g. PortProtocols "8601/TCP,8601/UDP"), using the bare port number as the
+// Name produces duplicate names and an invalid Service that the API server
+// rejects. In that case we disambiguate by appending the lowercased protocol
+// (e.g. "8601-tcp" / "8601-udp"). Port numbers that appear only once keep the
+// legacy numeric-only name to stay backward compatible.
+func consSvcPorts(backends []*backend, ports []int32) []corev1.ServicePort {
+	portCount := make(map[int]int)
+	for i := 0; i < len(backends); i++ {
+		portCount[backends[i].targetPort]++
+	}
+
+	svcPorts := make([]corev1.ServicePort, 0)
+	for i := 0; i < len(backends); i++ {
+		name := strconv.Itoa(backends[i].targetPort)
+		if portCount[backends[i].targetPort] > 1 {
+			name = name + "-" + strings.ToLower(string(backends[i].protocol))
+		}
+		svcPorts = append(svcPorts, corev1.ServicePort{
+			Name:       name,
+			Port:       ports[i],
+			Protocol:   backends[i].protocol,
+			TargetPort: intstr.FromInt(backends[i].targetPort),
+		})
+	}
+	return svcPorts
+}
+
 func getACKTargetGroupARN(tg *ackv1alpha1.TargetGroup) (string, error) {
 	if len(tg.Status.Conditions) == 0 {
 		return "", fmt.Errorf("targetGroup status not ready")
@@ -691,15 +722,7 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 		}
 	}
 
-	svcPorts := make([]corev1.ServicePort, 0)
-	for i := 0; i < len(config.backends); i++ {
-		svcPorts = append(svcPorts, corev1.ServicePort{
-			Name:       strconv.Itoa(config.backends[i].targetPort),
-			Port:       ports[i],
-			Protocol:   config.backends[i].protocol,
-			TargetPort: intstr.FromInt(config.backends[i].targetPort),
-		})
-	}
+	svcPorts := consSvcPorts(config.backends, ports)
 	annotations := map[string]string{
 		NlbARNAnnoKey:    lbARN,
 		NlbConfigHashKey: util.GetHash(config),

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -286,3 +286,64 @@ func TestInitLbCache(t *testing.T) {
 		t.Errorf("podAllocate expect %v, but actully got %v", test.podAllocate, test.n.podAllocate)
 	}
 }
+
+func TestConsSvcPorts(t *testing.T) {
+	tests := []struct {
+		name      string
+		backends  []*backend
+		ports     []int32
+		wantNames []string
+	}{
+		{
+			name: "same port TCP and UDP gets protocol suffix",
+			backends: []*backend{
+				{targetPort: 8601, protocol: corev1.ProtocolTCP},
+				{targetPort: 8601, protocol: corev1.ProtocolUDP},
+			},
+			ports:     []int32{6000, 6001},
+			wantNames: []string{"8601-tcp", "8601-udp"},
+		},
+		{
+			name: "single protocol keeps numeric-only name (backward compatible)",
+			backends: []*backend{
+				{targetPort: 8601, protocol: corev1.ProtocolTCP},
+			},
+			ports:     []int32{6000},
+			wantNames: []string{"8601"},
+		},
+		{
+			name: "distinct ports keep numeric-only names",
+			backends: []*backend{
+				{targetPort: 8601, protocol: corev1.ProtocolTCP},
+				{targetPort: 8602, protocol: corev1.ProtocolUDP},
+			},
+			ports:     []int32{6000, 6001},
+			wantNames: []string{"8601", "8602"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcPorts := consSvcPorts(tt.backends, tt.ports)
+			if len(svcPorts) != len(tt.wantNames) {
+				t.Fatalf("got %d ports, want %d", len(svcPorts), len(tt.wantNames))
+			}
+			seen := make(map[string]bool)
+			for i, p := range svcPorts {
+				if p.Name != tt.wantNames[i] {
+					t.Errorf("port[%d].Name = %q, want %q", i, p.Name, tt.wantNames[i])
+				}
+				if seen[p.Name] {
+					t.Errorf("duplicate ServicePort name %q (invalid Service)", p.Name)
+				}
+				seen[p.Name] = true
+				if p.Port != tt.ports[i] {
+					t.Errorf("port[%d].Port = %d, want %d", i, p.Port, tt.ports[i])
+				}
+				if p.TargetPort.IntValue() != tt.backends[i].targetPort {
+					t.Errorf("port[%d].TargetPort = %d, want %d", i, p.TargetPort.IntValue(), tt.backends[i].targetPort)
+				}
+			}
+		})
+	}
+}

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -347,3 +347,194 @@ func TestConsSvcPorts(t *testing.T) {
 		})
 	}
 }
+
+func TestConsSvcPortsTCPUDP(t *testing.T) {
+	tests := []struct {
+		name     string
+		backends []*backend
+		ports    []int32
+		want     []corev1.ServicePort
+	}{
+		{
+			name: "single TCPUDP backend expands to TCP+UDP sharing the frontend port",
+			backends: []*backend{
+				{targetPort: 8601, protocol: ProtocolTCPUDP},
+			},
+			ports: []int32{30001},
+			want: []corev1.ServicePort{
+				{Name: "8601-tcp", Port: 30001, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8601)},
+				{Name: "8601-udp", Port: 30001, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(8601)},
+			},
+		},
+		{
+			name: "two TCPUDP backends each get their own frontend port",
+			backends: []*backend{
+				{targetPort: 8601, protocol: ProtocolTCPUDP},
+				{targetPort: 8661, protocol: ProtocolTCPUDP},
+			},
+			ports: []int32{30001, 30002},
+			want: []corev1.ServicePort{
+				{Name: "8601-tcp", Port: 30001, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8601)},
+				{Name: "8601-udp", Port: 30001, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(8601)},
+				{Name: "8661-tcp", Port: 30002, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8661)},
+				{Name: "8661-udp", Port: 30002, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(8661)},
+			},
+		},
+		{
+			name: "TCPUDP coexists with a single-protocol backend",
+			backends: []*backend{
+				{targetPort: 8601, protocol: ProtocolTCPUDP},
+				{targetPort: 9000, protocol: corev1.ProtocolTCP},
+			},
+			ports: []int32{30001, 30002},
+			want: []corev1.ServicePort{
+				{Name: "8601-tcp", Port: 30001, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8601)},
+				{Name: "8601-udp", Port: 30001, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(8601)},
+				{Name: "9000", Port: 30002, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(9000)},
+			},
+		},
+		{
+			name: "DNS-style port 53 TCPUDP",
+			backends: []*backend{
+				{targetPort: 53, protocol: ProtocolTCPUDP},
+			},
+			ports: []int32{32768},
+			want: []corev1.ServicePort{
+				{Name: "53-tcp", Port: 32768, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(53)},
+				{Name: "53-udp", Port: 32768, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(53)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := consSvcPorts(tt.backends, tt.ports)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("consSvcPorts mismatch\n got:  %s\nwant: %s",
+					pretty.Sprint(got), pretty.Sprint(tt.want))
+			}
+
+			// All ServicePort names must be unique (otherwise the K8s API
+			// server will reject the Service with a Duplicate value error).
+			seen := make(map[string]bool)
+			for _, p := range got {
+				if seen[p.Name] {
+					t.Errorf("duplicate ServicePort name %q", p.Name)
+				}
+				seen[p.Name] = true
+			}
+
+			// For each TCPUDP backend, the two emitted ServicePorts must
+			// share the same frontend Port so they land on a single AWS
+			// TCP_UDP listener.
+			for _, b := range tt.backends {
+				if b.protocol != ProtocolTCPUDP {
+					continue
+				}
+				var frontendPorts []int32
+				var protocols []corev1.Protocol
+				for _, p := range got {
+					if int(p.TargetPort.IntValue()) == b.targetPort {
+						frontendPorts = append(frontendPorts, p.Port)
+						protocols = append(protocols, p.Protocol)
+					}
+				}
+				if len(frontendPorts) != 2 {
+					t.Errorf("backend targetPort=%d: expected 2 emitted ServicePorts, got %d",
+						b.targetPort, len(frontendPorts))
+					continue
+				}
+				if frontendPorts[0] != frontendPorts[1] {
+					t.Errorf("backend targetPort=%d: expected shared frontend Port, got %v",
+						b.targetPort, frontendPorts)
+				}
+				wantProtos := map[corev1.Protocol]bool{corev1.ProtocolTCP: false, corev1.ProtocolUDP: false}
+				for _, pr := range protocols {
+					if _, ok := wantProtos[pr]; ok {
+						wantProtos[pr] = true
+					}
+				}
+				for pr, seenIt := range wantProtos {
+					if !seenIt {
+						t.Errorf("backend targetPort=%d: missing %s protocol entry", b.targetPort, pr)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseLbConfigTCPUDP(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		wantBackends []*backend
+	}{
+		{
+			name:  "single TCPUDP entry",
+			value: "8601/TCPUDP",
+			wantBackends: []*backend{
+				{targetPort: 8601, protocol: ProtocolTCPUDP},
+			},
+		},
+		{
+			name:  "multiple TCPUDP entries",
+			value: "8601/TCPUDP,8661/TCPUDP",
+			wantBackends: []*backend{
+				{targetPort: 8601, protocol: ProtocolTCPUDP},
+				{targetPort: 8661, protocol: ProtocolTCPUDP},
+			},
+		},
+		{
+			name:  "TCPUDP mixed with TCP and UDP",
+			value: "53/TCPUDP,80/TCP,9000/UDP",
+			wantBackends: []*backend{
+				{targetPort: 53, protocol: ProtocolTCPUDP},
+				{targetPort: 80, protocol: corev1.ProtocolTCP},
+				{targetPort: 9000, protocol: corev1.ProtocolUDP},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := []gamekruiseiov1alpha1.NetworkConfParams{
+				{
+					Name:  NlbARNsConfigName,
+					Value: "arn:aws:elasticloadbalancing:us-east-1:888888888888:loadbalancer/net/aaa/3b332e6841f23870",
+				},
+				{
+					Name:  PortProtocolsConfigName,
+					Value: tt.value,
+				},
+			}
+			sc := parseLbConfig(conf)
+			if !reflect.DeepEqual(sc.backends, tt.wantBackends) {
+				t.Errorf("backends mismatch\n got:  %s\nwant: %s",
+					pretty.Sprint(sc.backends), pretty.Sprint(tt.wantBackends))
+			}
+		})
+	}
+}
+
+func TestAWSTargetGroupProtocol(t *testing.T) {
+	tests := []struct {
+		name string
+		in   corev1.Protocol
+		want string
+	}{
+		{"TCP passes through", corev1.ProtocolTCP, "TCP"},
+		{"UDP passes through", corev1.ProtocolUDP, "UDP"},
+		{"TCPUDP translates to AWS TCP_UDP", ProtocolTCPUDP, "TCP_UDP"},
+		{"unknown values pass through unchanged", corev1.Protocol("SCTP"), "SCTP"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := awsTargetGroupProtocol(tt.in)
+			if got != tt.want {
+				t.Errorf("awsTargetGroupProtocol(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
用户写 PortProtocols: "8601/TCPUDP"
│
▼
kruise-game 控制器解析为 dual-protocol 端口需求
│
▼
生成 K8s Service:
port: 9007 protocol: TCP targetPort: 8601 name: 8601-tcp
port: 9007 protocol: UDP targetPort: 8601 name: 8601-udp
│ ※ Service 多端口允许同 port 不同 protocol,只要 name 不同
▼
通过 ALB Controller 创建 TargetGroupBinding
│
▼
NLB Listener: Port=9007 Protocol=TCP_UDP
NLB TargetGroup: Protocol=TCP_UDP Port=8601 HealthCheck=TCP