### PR TITLE
fix: remove minAvailable floor in scale-down priority branch

### DIFF
--- a/pkg/externalscaler/externalscaler.go
+++ b/pkg/externalscaler/externalscaler.go
@@ -170,11 +170,11 @@ func (e *ExternalScaler) GetMetrics(ctx context.Context, metricRequest *GetMetri
 			if exceeded {
 				// Prioritize scale-down: set desiredReplicas below totalNum so that
 				// the controller will delete all WTBD pods.
+				// NOTE: We intentionally do NOT apply minAvailable as a floor here.
+				// The design intent of scaleDownThreshold is "temporarily give up None
+				// guarantee to clean WTBD first". KEDA's minReplicaCount serves as
+				// the actual safety net for minimum pod count.
 				desireReplicas := totalNum - numWaitToBeDeleted
-				// Apply minAvailable as a floor to avoid scaling down too aggressively.
-				if minNum > 0 && desireReplicas < minNum {
-					desireReplicas = minNum
-				}
 				klog.Infof("GameServerSet %s/%s WTBD count %d exceeds threshold, prioritize scale-down, desire replicas is %d", ns, name, numWaitToBeDeleted, desireReplicas)
 				return &GetMetricsResponse{
 					MetricValues: []*MetricValue{{

--- a/pkg/externalscaler/externalscaler_test.go
+++ b/pkg/externalscaler/externalscaler_test.go
@@ -191,9 +191,9 @@ func TestGetMetrics(t *testing.T) {
 			// desireReplicas = 10 + 5 - 2 = 13
 			wantReplicas: 13,
 		},
-		// --- scaleDownThreshold: exceeded but minNum floor kicks in ---
+		// --- scaleDownThreshold: exceeded, no minAvailable floor (KEDA minReplicaCount is the safety net) ---
 		{
-			name:     "threshold exceeded but minAvailable floor applied",
+			name:     "threshold exceeded: no minAvailable floor applied",
 			replicas: 10,
 			pods: append(
 				makePodsPrefix(gssName, ns, "w", 8, string(gamekruiseiov1alpha1.WaitToDelete), ""),
@@ -204,8 +204,8 @@ func TestGetMetrics(t *testing.T) {
 				"scaleDownThreshold": "5",
 			},
 			// totalNum=10, WTBD=8, threshold=5, exceeded
-			// desireReplicas = max(10-8, 5) = max(2, 5) = 5
-			wantReplicas: 5,
+			// desireReplicas = 10 - 8 = 2 (no minAvailable floor, KEDA minReplicaCount is the safety net)
+			wantReplicas: 2,
 		},
 		// --- scaleDownThreshold: zero WTBD, threshold check skipped ---
 		{


### PR DESCRIPTION
When scaleDownThreshold is exceeded, the design intent is to temporarily give up None pod guarantee and prioritize WTBD cleanup. However, applying minAvailable as a floor for desireReplicas creates a deadlock when minAvailable >= totalNum (e.g., minAvailable=1000, totalNum=1000, WTBD=969 results in desireReplicas=1000=current, so nothing happens).

Remove the minAvailable floor in the scale-down priority branch. KEDA's minReplicaCount serves as the actual safety net for minimum pod count.