### PR TITLE
fix(cloudprovider): validate AWS NLB network config (reject invalid values incl. healthCheckEnabled=false for ip targets)

### DIFF
--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -280,6 +280,9 @@ func (n *NlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.C
 	}
 	networkConfig := networkManager.GetNetworkConfig()
 	lbConfig := parseLbConfig(networkConfig)
+	if err := validateLbConfig(lbConfig); err != nil {
+		return pod, cperrors.NewPluginErrorWithMessage(cperrors.ParameterError, err.Error())
+	}
 	if networkStatus == nil {
 		pod, err := networkManager.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
 			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
@@ -626,6 +629,76 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 		isFixed:          isFixed,
 		annotations:      annotations,
 	}
+}
+
+// validateLbConfig rejects network configurations that AWS would reject (or that
+// would otherwise stall silently) when the plugin creates the Service / target
+// group / listener, surfacing a clear error early instead of failing deep in an
+// AWS API call or leaving the GameServer stuck in NotReady. All limits follow
+// the AWS ELBv2 API (see CreateTargetGroup / Health checks for NLB target
+// groups). The NLB plugin always uses target type "ip".
+func validateLbConfig(config *nlbConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	// NlbARNs is required: without a load balancer ARN the plugin cannot
+	// allocate a frontend port.
+	if len(config.loadBalancerARNs) == 0 {
+		return fmt.Errorf("%s is required: at least one NLB ARN must be provided", NlbARNsConfigName)
+	}
+
+	// PortProtocols is required and each entry must be a valid port/protocol.
+	if len(config.backends) == 0 {
+		return fmt.Errorf("%s is required: at least one port/protocol must be provided", PortProtocolsConfigName)
+	}
+	for _, b := range config.backends {
+		if b.targetPort < 1 || b.targetPort > 65535 {
+			return fmt.Errorf("%s port %d is invalid: must be in [1,65535]", PortProtocolsConfigName, b.targetPort)
+		}
+		switch b.protocol {
+		case corev1.ProtocolTCP, corev1.ProtocolUDP, ProtocolTCPUDP:
+		default:
+			return fmt.Errorf("%s protocol %q is invalid: must be one of TCP, UDP, TCPUDP", PortProtocolsConfigName, b.protocol)
+		}
+	}
+
+	hc := config.healthCheck
+	if hc == nil {
+		return nil
+	}
+
+	// Target type "ip" requires health checks to be always enabled and they
+	// cannot be disabled. healthCheckEnabled=false makes ack-elbv2 fail to sync
+	// the target group ("Health check enabled must be true with groups with
+	// target type ip"), silently stalling listener creation.
+	if hc.healthCheckEnabled != nil && !*hc.healthCheckEnabled {
+		return fmt.Errorf("%s healthCheckEnabled=false is not allowed: the plugin creates target groups with target type \"ip\", for which AWS requires health checks to be always enabled; remove healthCheckEnabled or set it to true", NlbHealthCheckConfigName)
+	}
+
+	// For NLB, only TCP/HTTP/HTTPS health-check protocols are supported;
+	// UDP/TCP_UDP/TLS/GENEVE are not valid health-check protocols.
+	if hc.healthCheckProtocol != nil {
+		p := strings.ToUpper(*hc.healthCheckProtocol)
+		switch p {
+		case "TCP", "HTTP", "HTTPS":
+		default:
+			return fmt.Errorf("%s healthCheckProtocol %q is invalid: NLB health checks support only TCP, HTTP or HTTPS", NlbHealthCheckConfigName, *hc.healthCheckProtocol)
+		}
+	}
+	if hc.healthCheckIntervalSeconds != nil && (*hc.healthCheckIntervalSeconds < 5 || *hc.healthCheckIntervalSeconds > 300) {
+		return fmt.Errorf("%s healthCheckIntervalSeconds %d is invalid: must be in [5,300]", NlbHealthCheckConfigName, *hc.healthCheckIntervalSeconds)
+	}
+	if hc.healthCheckTimeoutSeconds != nil && (*hc.healthCheckTimeoutSeconds < 2 || *hc.healthCheckTimeoutSeconds > 120) {
+		return fmt.Errorf("%s healthCheckTimeoutSeconds %d is invalid: must be in [2,120]", NlbHealthCheckConfigName, *hc.healthCheckTimeoutSeconds)
+	}
+	if hc.healthyThresholdCount != nil && (*hc.healthyThresholdCount < 2 || *hc.healthyThresholdCount > 10) {
+		return fmt.Errorf("%s healthyThresholdCount %d is invalid: must be in [2,10]", NlbHealthCheckConfigName, *hc.healthyThresholdCount)
+	}
+	if hc.unhealthyThresholdCount != nil && (*hc.unhealthyThresholdCount < 2 || *hc.unhealthyThresholdCount > 10) {
+		return fmt.Errorf("%s unhealthyThresholdCount %d is invalid: must be in [2,10]", NlbHealthCheckConfigName, *hc.unhealthyThresholdCount)
+	}
+	return nil
 }
 
 // consSvcPorts builds the ServicePort list for the backing ClusterIP Service.

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -538,3 +538,50 @@ func TestAWSTargetGroupProtocol(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateLbConfig(t *testing.T) {
+	validARN := []string{"arn:aws:elasticloadbalancing:us-east-1:888888888888:loadbalancer/net/aaa/3b332e6841f23870"}
+	validBackends := []*backend{{targetPort: 8601, protocol: corev1.ProtocolTCP}}
+	base := func() *nlbConfig {
+		return &nlbConfig{
+			loadBalancerARNs: validARN,
+			backends:         validBackends,
+			healthCheck:      &healthCheck{},
+		}
+	}
+	tests := []struct {
+		name      string
+		config    *nlbConfig
+		expectErr bool
+	}{
+		{"nil config", nil, false},
+		{"valid minimal", base(), false},
+		{"missing NlbARNs", &nlbConfig{backends: validBackends, healthCheck: &healthCheck{}}, true},
+		{"missing PortProtocols", &nlbConfig{loadBalancerARNs: validARN, healthCheck: &healthCheck{}}, true},
+		{"port too low", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 0, protocol: corev1.ProtocolTCP}}, healthCheck: &healthCheck{}}, true},
+		{"port too high", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 70000, protocol: corev1.ProtocolTCP}}, healthCheck: &healthCheck{}}, true},
+		{"bad protocol", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 8601, protocol: corev1.Protocol("SCTP")}}, healthCheck: &healthCheck{}}, true},
+		{"TCPUDP protocol ok", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 8601, protocol: ProtocolTCPUDP}}, healthCheck: &healthCheck{}}, false},
+		{"healthCheckEnabled false rejected", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckEnabled: ptr.To[bool](false)}}, true},
+		{"healthCheckEnabled true ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckEnabled: ptr.To[bool](true)}}, false},
+		{"healthCheckProtocol UDP rejected", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckProtocol: ptr.To[string]("UDP")}}, true},
+		{"healthCheckProtocol TCP ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckProtocol: ptr.To[string]("TCP")}}, false},
+		{"healthCheckProtocol HTTP ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckProtocol: ptr.To[string]("HTTP")}}, false},
+		{"interval out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckIntervalSeconds: ptr.To[int64](1)}}, true},
+		{"interval ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckIntervalSeconds: ptr.To[int64](30)}}, false},
+		{"timeout out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckTimeoutSeconds: ptr.To[int64](200)}}, true},
+		{"healthy threshold out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthyThresholdCount: ptr.To[int64](11)}}, true},
+		{"unhealthy threshold out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{unhealthyThresholdCount: ptr.To[int64](1)}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLbConfig(tt.config)
+			if tt.expectErr && err == nil {
+				t.Errorf("%s: expected error, got nil", tt.name)
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("%s: expected no error, got %v", tt.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fixes #357 and hardens AWS NLB network-config validation in general.

The AWS NLB plugin previously accepted configurations that AWS would reject when creating the Service / target group / listener, or that the parser silently dropped — leaving the GameServer stuck in `NotReady` with no obvious cause.

The most painful case (the one in #357): the plugin always creates ACK `TargetGroup`s with target type `ip`. For `ip` targets, AWS requires health checks to be **always enabled and cannot be disabled**. Setting `healthCheckEnabled:false` makes `ack-elbv2-controller` fail to sync the target group with:

```
InvalidConfigurationRequest: Health check enabled must be true with groups with target type "ip"
```

so the TargetGroup ARN is never resolved, the listener is never created, and the GameServer hangs in `NotReady` with nothing abnormal logged on the kruise-game side.

This PR adds `validateLbConfig`, invoked in `OnPodUpdated`, which returns a clear `ParameterError` for invalid configs instead of failing deep in an AWS API call or stalling silently:

- `healthCheckEnabled=false` — not allowed for `ip` target type
- `healthCheckProtocol` not in `{TCP, HTTP, HTTPS}` — UDP/TCP_UDP/TLS/GENEVE are not valid NLB health-check protocols
- `healthCheckIntervalSeconds` outside `[5,300]`
- `healthCheckTimeoutSeconds` outside `[2,120]`
- `healthyThresholdCount` / `unhealthyThresholdCount` outside `[2,10]`
- missing `NlbARNs` / `PortProtocols`
- port outside `[1,65535]` or protocol not in `{TCP, UDP, TCPUDP}`

All limits follow the AWS ELBv2 API. Leaving any field unset is unchanged and applies the AWS defaults.

### Ⅱ. Does this pull request fix one issue?

Fixes #357

### Ⅲ. Describe how to verify it

`go test ./cloudprovider/amazonswebservices/...` — new `TestValidateLbConfig` covers all rules (valid/invalid for each field); existing tests unchanged.

### Ⅳ. Special notes for reviews

References:
- [CreateTargetGroup — `HealthCheckEnabled`](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html)
- [Health checks for NLB target groups](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html)
