### PR TITLE
feat(aws-nlb): multi-NLB dynamic ARN support, readiness gate hardening, and related fixes

### DIFF
--- a/cloudprovider/amazonswebservices/README.md
+++ b/cloudprovider/amazonswebservices/README.md
@@ -84,7 +84,15 @@ Official deployment documentation: https://docs.aws.amazon.com/eks/latest/usergu
 #### NlbARNs
 - Meaning: Fill in the ARN of the nlb, you can fill in multiple, and nlb needs to be created in AWS in advance.
 - Format: Separate each nlbARN with a comma. For example: arn:aws:elasticloadbalancing:us-east-1:888888888888:loadbalancer/net/aaa/3b332e6841f23870,arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/net/bbb/5fe74944d794d27e
-- Support for change: Yes
+- Support for change: Yes. Adding or replacing an ARN at runtime does NOT reconfigure already-allocated pods (they keep their pinned ARN/ports); only newly created pods will pick up the updated ARN list. This lets you grow capacity past the AWS hard limit of 50 listeners per NLB by appending another NLB ARN without disturbing existing game servers.
+
+#### AllocatePolicy
+- Meaning: How to allocate ports across multiple NLBs listed in `NlbARNs`. Only takes effect when `NlbARNs` contains more than one ARN.
+- Format:
+  - `default` — first-fit / spillover: iterate ARNs in order and fill the first NLB until it has no free ports left, then move on to the next ARN. This is the historical behavior.
+  - `balanced` — pick the NLB with the most free ports, spreading game servers across NLBs for fault-domain isolation.
+- Default: `default` (any unrecognized value, including empty, falls back to `default`).
+- Support for change: Yes — only affects subsequent allocations; already-allocated pods keep their pinned NLB.
 
 #### NlbVPCId
 

--- a/cloudprovider/amazonswebservices/README.zh_CN.md
+++ b/cloudprovider/amazonswebservices/README.zh_CN.md
@@ -83,7 +83,15 @@ TargetGroupBinding的CRD及控制器：https://github.com/kubernetes-sigs/aws-lo
 #### NlbARNs
 - 含义：填写nlb的arn，可填写多个，需要现在【AWS】中创建好nlb。
 - 填写格式：各个nlbARN用,分割。例如：arn:aws:elasticloadbalancing:us-east-1:888888888888:loadbalancer/net/aaa/3b332e6841f23870,arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/net/bbb/5fe74944d794d27e
-- 是否支持变更：是
+- 是否支持变更：是。运行时新增或替换 ARN 不会重新配置已分配的 pod（仍保留各自原有的 ARN 与端口），只有新创建的 pod 会使用更新后的 ARN 列表。这样可以在不打扰已有游戏服的前提下，通过追加新的 NLB ARN 突破 AWS"单 NLB 最多 50 个 listener"的硬性上限实现扩容。
+
+#### AllocatePolicy
+- 含义：当 `NlbARNs` 配置了多个 NLB 时，新 pod 的端口分配策略。仅在 `NlbARNs` 包含多个 ARN 时生效。
+- 填写格式：
+  - `default`：first-fit 溢出策略，按 `NlbARNs` 列表顺序，先把第一个 NLB 填满再使用下一个。这是历史默认行为。
+  - `balanced`：均衡策略，选择当前剩余空闲端口最多的 NLB，让游戏服跨 NLB 摊平做故障域隔离。
+- 默认值：`default`（未填写或无法识别的值都按 `default` 处理）。
+- 是否支持变更：是。仅影响后续新分配的 pod，已分配的 pod 保留原有的 NLB 绑定。
 
 #### NlbVPCId
 

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -732,22 +732,24 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 		protocol := awsTargetGroupProtocol(config.backends[i].protocol)
 		targetPort := int64(config.backends[i].targetPort)
 		var targetTypeIP = string(ackv1alpha1.TargetTypeEnum_ip)
-		_, err := controllerutil.CreateOrUpdate(ctx, client, &ackv1alpha1.TargetGroup{
+		tg := &ackv1alpha1.TargetGroup{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            targetGroupName,
-				Namespace:       pod.GetNamespace(),
-				OwnerReferences: ownerReference,
-				Labels: map[string]string{
-					ResourceTagKey:           ResourceTagValue,
-					SvcSelectorKey:           pod.GetName(),
-					AWSTargetGroupSyncStatus: "false",
-				},
-				Annotations: map[string]string{
-					NlbARNAnnoKey:  lbARN,
-					NlbPortAnnoKey: fmt.Sprintf("%d", ports[i]),
-				},
+				Name:      targetGroupName,
+				Namespace: pod.GetNamespace(),
 			},
-			Spec: ackv1alpha1.TargetGroupSpec{
+		}
+		_, err := controllerutil.CreateOrUpdate(ctx, client, tg, func() error {
+			tg.OwnerReferences = ownerReference
+			tg.Labels = map[string]string{
+				ResourceTagKey:           ResourceTagValue,
+				SvcSelectorKey:           pod.GetName(),
+				AWSTargetGroupSyncStatus: "false",
+			}
+			tg.Annotations = map[string]string{
+				NlbARNAnnoKey:  lbARN,
+				NlbPortAnnoKey: fmt.Sprintf("%d", ports[i]),
+			}
+			tg.Spec = ackv1alpha1.TargetGroupSpec{
 				HealthCheckEnabled:         config.healthCheck.healthCheckEnabled,
 				HealthCheckIntervalSeconds: config.healthCheck.healthCheckIntervalSeconds,
 				HealthCheckPath:            config.healthCheck.healthCheckPath,
@@ -763,8 +765,9 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 				TargetType:                 &targetTypeIP,
 				Tags: []*ackv1alpha1.Tag{{Key: ptr.To[string](ResourceTagKey),
 					Value: ptr.To[string](ResourceTagValue)}},
-			},
-		}, func() error { return nil })
+			}
+			return nil
+		})
 		if err != nil {
 			return err
 		}
@@ -778,25 +781,26 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 	for key, value := range config.annotations {
 		annotations[key] = value
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, client, &corev1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            pod.GetName(),
-			Namespace:       pod.GetNamespace(),
-			Annotations:     annotations,
-			OwnerReferences: ownerReference,
-			Labels: map[string]string{
-				ResourceTagKey: ResourceTagValue,
-				SvcSelectorKey: pod.GetName(),
-			},
+			Name:      pod.GetName(),
+			Namespace: pod.GetNamespace(),
 		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Selector: map[string]string{
-				SvcSelectorKey: pod.GetName(),
-			},
-			Ports: svcPorts,
-		},
-	}, func() error { return nil })
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, client, svc, func() error {
+		svc.Annotations = annotations
+		svc.OwnerReferences = ownerReference
+		svc.Labels = map[string]string{
+			ResourceTagKey: ResourceTagValue,
+			SvcSelectorKey: pod.GetName(),
+		}
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		svc.Spec.Selector = map[string]string{
+			SvcSelectorKey: pod.GetName(),
+		}
+		svc.Spec.Ports = svcPorts
+		return nil
+	})
 	if err != nil {
 		return err
 	}

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -464,6 +464,23 @@ func (n *NlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.C
 		}
 	}
 
+	// Default pass-through for an already-established pod: if the GameServer is
+	// already NetworkReady AND the network config is unchanged (same Service
+	// hash), this OnPodUpdated was triggered by something unrelated to network
+	// readiness — e.g. an InPlace update of pod annotations when an ARN is added
+	// to NlbARNs. Re-running the readiness gate here is harmful: the InPlace
+	// update transiently drives PodReady to False (the InPlaceUpdateReady gate
+	// flips False), so the gate check below would knock a healthy old pod to
+	// NetworkNotReady. Worse, recovery (gate True / PodReady True) is written via
+	// the pods/status subresource, which does NOT re-trigger this webhook, so the
+	// GameServer would stay NotReady indefinitely. The gate's job is to gate a
+	// pod BEFORE its first readiness; once a pod is Ready with config unchanged,
+	// leave it alone. (See docs/11 scenario S4.)
+	if networkStatus.CurrentNetworkState == gamekruiseiov1alpha1.NetworkReady &&
+		lbConfig.configHash() == svc.GetAnnotations()[NlbConfigHashKey] {
+		return pod, nil
+	}
+
 	// Readiness gating: the Service/TargetGroupBinding existing is NOT enough to
 	// declare the network ready — the NLB target may never become healthy (e.g.
 	// an IP reused while still draining in another TargetGroup leaves the target

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -472,6 +472,20 @@ func (n *NlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.C
 	// which is reflected in the aggregate PodReady condition. Until PodReady is
 	// True, keep the GameServer NetworkNotReady so its state reflects real
 	// reachability rather than just "resources created".
+	//
+	// IMPORTANT: refresh pod status from the API server before checking PodReady.
+	// OnPodUpdated runs only inside the mutating admission webhook for the `pods`
+	// resource. The kubelet writes the pod readiness condition through the
+	// `pods/status` subresource, which does NOT trigger this webhook. So the
+	// pod object the webhook decoded from the request body can carry a stale
+	// Status (PodReady=False) even when the live pod is already PodReady=True.
+	// Reading stale Status here pins GameServer NetworkState to NotReady forever
+	// (no further `pods` UPDATE will retrigger the check). Fetch the latest pod
+	// directly so the readiness gate decision uses authoritative state.
+	freshPod := &corev1.Pod{}
+	if err := c.Get(ctx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, freshPod); err == nil {
+		pod.Status = freshPod.Status
+	}
 	_, readyCondition := util.GetPodConditionFromList(pod.Status.Conditions, corev1.PodReady)
 	if readyCondition == nil || readyCondition.Status != corev1.ConditionTrue {
 		// Not ready yet. If a readiness gate has been stuck False well past the

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -60,10 +60,29 @@ const (
 	NlbPortAnnoKey           = "service.beta.kubernetes.io/aws-load-balancer-nlb-port"
 	AWSTargetGroupSyncStatus = "aws-load-balancer-nlb-target-group-synced"
 	SvcSelectorKey           = "statefulset.kubernetes.io/pod-name"
-	NlbConfigHashKey         = "game.kruise.io/network-config-hash"
-	ResourceTagKey           = "managed-by"
-	ResourceTagValue         = "game.kruise.io"
+	// ReadinessGatePrefix is the prefix the AWS Load Balancer Controller uses for
+	// the pod readiness-gate condition it manages per TargetGroupBinding. The full
+	// condition type is ReadinessGatePrefix+<TargetGroupBinding name>, and the
+	// controller only sets it True once the corresponding NLB target is healthy.
+	// We pre-inject this gate in OnPodAdded so GameServer readiness reflects real
+	// NLB reachability rather than just "Service/TargetGroupBinding created".
+	ReadinessGatePrefix = "target-health.elbv2.k8s.aws/"
+	NlbConfigHashKey    = "game.kruise.io/network-config-hash"
+	ResourceTagKey      = "managed-by"
+	ResourceTagValue    = "game.kruise.io"
 )
+
+// ghostRegistrationStuckSeconds is how long a readiness gate may stay False
+// before we treat it as a stuck "ghost registration" and self-heal it.
+//
+// When a pod IP is reused while still draining in another TargetGroup, the AWS
+// Load Balancer Controller registers the target but AWS leaves it draining and
+// later drops it, so the gate stays False forever and the controller never
+// retries (the TargetGroupBinding spec hash is unchanged). A normal target goes
+// initial->healthy within the health-check window; anything stuck False well
+// beyond that is the bug. 90s comfortably covers a default health check
+// (interval*healthyThreshold) plus registration latency.
+const ghostRegistrationStuckSeconds = 90
 
 const (
 	healthCheckEnabled         = "healthCheckEnabled"
@@ -300,7 +319,52 @@ func (n *NlbPlugin) initLbCache(svcList []corev1.Service) {
 	}
 }
 
+// OnPodAdded allocates the NLB ports up-front and pre-injects the AWS Load
+// Balancer Controller pod readiness gates, one per allocated listener port.
+//
+// Why allocate here (not lazily in OnPodUpdated): the readiness-gate condition
+// type must equal the TargetGroupBinding name (<pod>-<port>), so the port must
+// be known at pod-creation time. The allocation is pinned in podAllocate and
+// reused by syncTargetGroupAndService in OnPodUpdated, so no double allocation.
+//
+// Why gates at all: without them the GameServer is marked Ready as soon as the
+// Service/TargetGroupBinding exist — even when the NLB target never becomes
+// healthy (e.g. an IP reused while still draining in another TargetGroup).
+// The controller only flips this gate True once the target is actually healthy,
+// so pod (hence GameServer) readiness reflects real reachability.
 func (n *NlbPlugin) OnPodAdded(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	networkManager := utils.NewNetworkManager(pod, c)
+	if networkManager == nil {
+		return pod, nil
+	}
+	conf := parseLbConfig(networkManager.GetNetworkConfig())
+	if conf == nil || len(conf.loadBalancerARNs) == 0 || len(conf.backends) == 0 {
+		return pod, nil
+	}
+
+	podKey := pod.GetNamespace() + "/" + pod.GetName()
+	allocatedPorts, exist := n.podAllocate[podKey]
+	if !exist {
+		allocatedPorts = n.allocate(conf.loadBalancerARNs, len(conf.backends), podKey, conf.allocatePolicy)
+		if allocatedPorts == nil {
+			return pod, cperrors.NewPluginErrorWithMessage(cperrors.ApiCallError,
+				fmt.Sprintf("no NLB has %d enough available ports for %s", len(conf.backends), podKey))
+		}
+	}
+
+	// One readiness gate per listener port; condition type == TargetGroupBinding name.
+	existing := make(map[corev1.PodConditionType]bool, len(pod.Spec.ReadinessGates))
+	for _, g := range pod.Spec.ReadinessGates {
+		existing[g.ConditionType] = true
+	}
+	for _, port := range allocatedPorts.ports {
+		condType := corev1.PodConditionType(ReadinessGatePrefix + fmt.Sprintf("%s-%d", pod.GetName(), port))
+		if !existing[condType] {
+			pod.Spec.ReadinessGates = append(pod.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: condType,
+			})
+		}
+	}
 	return pod, nil
 }
 
@@ -395,6 +459,26 @@ func (n *NlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.C
 				return pod, cperrors.ToPluginError(err, cperrors.ApiCallError)
 			}
 		}
+	}
+
+	// Readiness gating: the Service/TargetGroupBinding existing is NOT enough to
+	// declare the network ready — the NLB target may never become healthy (e.g.
+	// an IP reused while still draining in another TargetGroup leaves the target
+	// stuck/empty). The pod readiness gates injected in OnPodAdded are flipped
+	// True by the AWS Load Balancer Controller only once the targets are healthy,
+	// which is reflected in the aggregate PodReady condition. Until PodReady is
+	// True, keep the GameServer NetworkNotReady so its state reflects real
+	// reachability rather than just "resources created".
+	_, readyCondition := util.GetPodConditionFromList(pod.Status.Conditions, corev1.PodReady)
+	if readyCondition == nil || readyCondition.Status != corev1.ConditionTrue {
+		// Not ready yet. If a readiness gate has been stuck False well past the
+		// health-check window, it is a ghost registration that never self-heals;
+		// delete + re-sync the affected TargetGroupBinding(s) so the target
+		// registers cleanly. Scoped to this pod only.
+		n.healStuckReadinessGates(ctx, c, pod, metav1.Now().Unix())
+		networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+		pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
 	}
 
 	// network ready
@@ -935,6 +1019,68 @@ func syncListenerAndTargetGroupBinding(ctx context.Context, client client.Client
 	}
 
 	return nil
+}
+
+// healStuckReadinessGates self-heals "ghost registration": pod readiness gates
+// that have been False far longer than a healthy target should take. Such a
+// target is stuck draining/empty in AWS and the controller will never retry on
+// its own because the TargetGroupBinding spec hash is unchanged.
+//
+// The fix (validated): delete the stuck TargetGroupBinding and re-trigger a
+// fresh sync (reset the TargetGroup sync label to "false", which makes
+// handleTargetGroupEvent recreate the Listener + a brand-new TargetGroupBinding).
+// A brand-new TGB is reconciled from scratch — by which point the reused IP's
+// prior draining has finished — so the target registers cleanly.
+//
+// Scoped to a single pod's own TGBs (named <pod>-<port>), so it cannot disturb
+// other GameServers. Returns the number of TGBs healed.
+func (n *NlbPlugin) healStuckReadinessGates(ctx context.Context, c client.Client, pod *corev1.Pod, nowUnix int64) int {
+	healed := 0
+	for _, cond := range pod.Status.Conditions {
+		if !strings.HasPrefix(string(cond.Type), ReadinessGatePrefix) {
+			continue
+		}
+		if cond.Status == corev1.ConditionTrue {
+			continue
+		}
+		// Stuck only if it has been False long enough to rule out normal
+		// initial->healthy registration.
+		if cond.LastTransitionTime.IsZero() ||
+			nowUnix-cond.LastTransitionTime.Unix() < ghostRegistrationStuckSeconds {
+			continue
+		}
+		tgbName := strings.TrimPrefix(string(cond.Type), ReadinessGatePrefix)
+
+		// Delete the stuck TargetGroupBinding.
+		tgb := &elbv2api.TargetGroupBinding{}
+		if err := c.Get(ctx, types.NamespacedName{Name: tgbName, Namespace: pod.GetNamespace()}, tgb); err != nil {
+			if !errors.IsNotFound(err) {
+				log.Warningf("[%s] heal: get TGB %s/%s error %v", NlbNetwork, pod.GetNamespace(), tgbName, err)
+			}
+			continue
+		}
+		if err := c.Delete(ctx, tgb); err != nil && !errors.IsNotFound(err) {
+			log.Warningf("[%s] heal: delete TGB %s/%s error %v", NlbNetwork, pod.GetNamespace(), tgbName, err)
+			continue
+		}
+
+		// Re-trigger a fresh sync via the matching TargetGroup (same name).
+		tg := &ackv1alpha1.TargetGroup{}
+		if err := c.Get(ctx, types.NamespacedName{Name: tgbName, Namespace: pod.GetNamespace()}, tg); err != nil {
+			log.Warningf("[%s] heal: get TG %s/%s error %v", NlbNetwork, pod.GetNamespace(), tgbName, err)
+			continue
+		}
+		patch := client.RawPatch(types.MergePatchType,
+			[]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"false"}}}`, AWSTargetGroupSyncStatus)))
+		if err := c.Patch(ctx, tg, patch); err != nil {
+			log.Warningf("[%s] heal: patch TG %s/%s sync=false error %v", NlbNetwork, pod.GetNamespace(), tgbName, err)
+			continue
+		}
+		log.Infof("[%s] heal: stuck readiness gate %s (False %ds) -> deleted TGB + re-synced",
+			NlbNetwork, cond.Type, nowUnix-cond.LastTransitionTime.Unix())
+		healed++
+	}
+	return healed
 }
 
 func getPorts(ports []corev1.ServicePort) []int32 {

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -50,6 +50,7 @@ const (
 	NlbNetwork               = "AmazonWebServices-NLB"
 	AliasNlb                 = "NLB-Network"
 	NlbARNsConfigName        = "NlbARNs"
+	AllocatePolicyConfigName = "AllocatePolicy"
 	NlbVPCIdConfigName       = "NlbVPCId"
 	NlbHealthCheckConfigName = "NlbHealthCheck"
 	PortProtocolsConfigName  = "PortProtocols"
@@ -74,6 +75,14 @@ const (
 	healthyThresholdCount      = "healthyThresholdCount"
 	unhealthyThresholdCount    = "unhealthyThresholdCount"
 	listenerActionType         = "forward"
+)
+
+const (
+	// allocatePolicyDefault: first-fit 溢出——按 ARN 列表顺序, 第一个够用就用, 填满前一个才用下一个。
+	allocatePolicyDefault = "default"
+	// allocatePolicyBalanced: 均衡——选当前剩余空闲端口最多的 NLB, 把游戏服摊平到各 NLB(故障域隔离)。
+	// 移植自 cloudprovider/alibabacloud/multi_nlbs.go 的 "balanced" 策略。
+	allocatePolicyBalanced = "balanced"
 )
 
 // ProtocolTCPUDP is a synthetic protocol value indicating that a target
@@ -119,6 +128,7 @@ type healthCheck struct {
 
 type nlbConfig struct {
 	loadBalancerARNs []string
+	allocatePolicy   string
 	healthCheck      *healthCheck
 	vpcID            string
 	backends         []*backend
@@ -468,7 +478,7 @@ func (n *NlbPlugin) OnPodDeleted(client client.Client, pod *corev1.Pod, ctx cont
 	return nil
 }
 
-func (n *NlbPlugin) allocate(lbARNs []string, num int, nsName string) *nlbPorts {
+func (n *NlbPlugin) allocate(lbARNs []string, num int, nsName string, policy string) *nlbPorts {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
@@ -477,8 +487,8 @@ func (n *NlbPlugin) allocate(lbARNs []string, num int, nsName string) *nlbPorts 
 		n.initCache(nlbARN)
 	}
 
-	// Find lbARN with enough free ports
-	selectedARN := n.findLbWithFreePorts(lbARNs, num)
+	// Find lbARN with enough free ports according to the allocate policy
+	selectedARN := n.findLbWithFreePorts(lbARNs, num, policy)
 	if selectedARN == "" {
 		return nil
 	}
@@ -491,7 +501,34 @@ func (n *NlbPlugin) allocate(lbARNs []string, num int, nsName string) *nlbPorts 
 	return &nlbPorts{arn: selectedARN, ports: ports}
 }
 
-func (n *NlbPlugin) findLbWithFreePorts(lbARNs []string, num int) string {
+// findLbWithFreePorts selects a NLB ARN that has at least num free ports.
+//   - "default" (first-fit / 溢出): iterate ARNs in order, return the first one
+//     with enough free ports — fills the earlier NLB before spilling to the next.
+//   - "balanced": pick the NLB with the MOST free ports, spreading game servers
+//     across NLBs (fault-domain isolation). Ported from the alibabacloud plugin.
+func (n *NlbPlugin) findLbWithFreePorts(lbARNs []string, num int, policy string) string {
+	if policy == allocatePolicyBalanced {
+		bestARN := ""
+		maxFree := 0
+		for _, nlbARN := range lbARNs {
+			freePorts := 0
+			for i := n.minPort; i <= n.maxPort; i++ {
+				if !n.cache[nlbARN][i] {
+					freePorts++
+				}
+			}
+			if freePorts > maxFree {
+				maxFree = freePorts
+				bestARN = nlbARN
+			}
+		}
+		if maxFree >= num {
+			return bestARN
+		}
+		return ""
+	}
+
+	// default: first-fit / 溢出
 	for _, nlbARN := range lbARNs {
 		freePorts := 0
 		for i := n.minPort; i <= n.maxPort && freePorts < num; i++ {
@@ -553,6 +590,7 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 	backends := make([]*backend, 0)
 	isFixed := false
 	annotations := map[string]string{}
+	allocatePolicy := allocatePolicyDefault
 	for _, c := range conf {
 		switch c.Name {
 		case NlbARNsConfigName:
@@ -560,6 +598,10 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 				if nlbARN != "" {
 					lbARNs = append(lbARNs, nlbARN)
 				}
+			}
+		case AllocatePolicyConfigName:
+			if c.Value == allocatePolicyBalanced {
+				allocatePolicy = allocatePolicyBalanced
 			}
 		case NlbHealthCheckConfigName:
 			for _, healthCheckConf := range strings.Split(c.Value, ",") {
@@ -646,6 +688,7 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 	}
 	return &nlbConfig{
 		loadBalancerARNs: lbARNs,
+		allocatePolicy:   allocatePolicy,
 		healthCheck:      &hc,
 		vpcID:            vpcId,
 		backends:         backends,
@@ -744,7 +787,7 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 	podKey := pod.GetNamespace() + "/" + pod.GetName()
 	allocatedPorts, exist := n.podAllocate[podKey]
 	if !exist {
-		allocatedPorts = n.allocate(config.loadBalancerARNs, len(config.backends), podKey)
+		allocatedPorts = n.allocate(config.loadBalancerARNs, len(config.backends), podKey, config.allocatePolicy)
 		if allocatedPorts == nil {
 			return fmt.Errorf("no NLB has %d enough available ports for %s", len(config.backends), podKey)
 		}

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -817,17 +817,19 @@ func syncListenerAndTargetGroupBinding(ctx context.Context, client client.Client
 	}
 	lbARN := tg.Annotations[NlbARNAnnoKey]
 	podName := tg.Labels[SvcSelectorKey]
-	_, err = controllerutil.CreateOrUpdate(ctx, client, &ackv1alpha1.Listener{
+	listener := &ackv1alpha1.Listener{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            tg.GetName(),
-			Namespace:       tg.GetNamespace(),
-			OwnerReferences: tg.GetOwnerReferences(),
-			Labels: map[string]string{
-				ResourceTagKey: ResourceTagValue,
-				SvcSelectorKey: podName,
-			},
+			Name:      tg.GetName(),
+			Namespace: tg.GetNamespace(),
 		},
-		Spec: ackv1alpha1.ListenerSpec{
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, client, listener, func() error {
+		listener.OwnerReferences = tg.GetOwnerReferences()
+		listener.Labels = map[string]string{
+			ResourceTagKey: ResourceTagValue,
+			SvcSelectorKey: podName,
+		}
+		listener.Spec = ackv1alpha1.ListenerSpec{
 			Protocol:        tg.Spec.Protocol,
 			Port:            &port,
 			LoadBalancerARN: &lbARN,
@@ -839,32 +841,36 @@ func syncListenerAndTargetGroupBinding(ctx context.Context, client client.Client
 			},
 			Tags: []*ackv1alpha1.Tag{{Key: ptr.To[string](ResourceTagKey),
 				Value: ptr.To[string](ResourceTagValue)}},
-		},
-	}, func() error { return nil })
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
 
 	var targetTypeIP = elbv2api.TargetTypeIP
-	_, err = controllerutil.CreateOrUpdate(ctx, client, &elbv2api.TargetGroupBinding{
+	tgb := &elbv2api.TargetGroupBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            tg.GetName(),
-			Namespace:       tg.GetNamespace(),
-			OwnerReferences: tg.GetOwnerReferences(),
-			Labels: map[string]string{
-				ResourceTagKey: ResourceTagValue,
-				SvcSelectorKey: podName,
-			},
+			Name:      tg.GetName(),
+			Namespace: tg.GetNamespace(),
 		},
-		Spec: elbv2api.TargetGroupBindingSpec{
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, client, tgb, func() error {
+		tgb.OwnerReferences = tg.GetOwnerReferences()
+		tgb.Labels = map[string]string{
+			ResourceTagKey: ResourceTagValue,
+			SvcSelectorKey: podName,
+		}
+		tgb.Spec = elbv2api.TargetGroupBindingSpec{
 			TargetGroupARN: *targetGroupARN,
 			TargetType:     &targetTypeIP,
 			ServiceRef: elbv2api.ServiceReference{
 				Name: podName,
 				Port: intstr.FromInt(int(port)),
 			},
-		},
-	}, func() error { return nil })
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -280,6 +280,9 @@ func (n *NlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.C
 	}
 	networkConfig := networkManager.GetNetworkConfig()
 	lbConfig := parseLbConfig(networkConfig)
+	if err := validateLbConfig(lbConfig); err != nil {
+		return pod, cperrors.NewPluginErrorWithMessage(cperrors.ParameterError, err.Error())
+	}
 	if networkStatus == nil {
 		pod, err := networkManager.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
 			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
@@ -626,6 +629,76 @@ func parseLbConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) *nlbConfig {
 		isFixed:          isFixed,
 		annotations:      annotations,
 	}
+}
+
+// validateLbConfig rejects network configurations that AWS would reject (or that
+// would otherwise stall silently) when the plugin creates the Service / target
+// group / listener, surfacing a clear error early instead of failing deep in an
+// AWS API call or leaving the GameServer stuck in NotReady. All limits follow
+// the AWS ELBv2 API (see CreateTargetGroup / Health checks for NLB target
+// groups). The NLB plugin always uses target type "ip".
+func validateLbConfig(config *nlbConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	// NlbARNs is required: without a load balancer ARN the plugin cannot
+	// allocate a frontend port.
+	if len(config.loadBalancerARNs) == 0 {
+		return fmt.Errorf("%s is required: at least one NLB ARN must be provided", NlbARNsConfigName)
+	}
+
+	// PortProtocols is required and each entry must be a valid port/protocol.
+	if len(config.backends) == 0 {
+		return fmt.Errorf("%s is required: at least one port/protocol must be provided", PortProtocolsConfigName)
+	}
+	for _, b := range config.backends {
+		if b.targetPort < 1 || b.targetPort > 65535 {
+			return fmt.Errorf("%s port %d is invalid: must be in [1,65535]", PortProtocolsConfigName, b.targetPort)
+		}
+		switch b.protocol {
+		case corev1.ProtocolTCP, corev1.ProtocolUDP, ProtocolTCPUDP:
+		default:
+			return fmt.Errorf("%s protocol %q is invalid: must be one of TCP, UDP, TCPUDP", PortProtocolsConfigName, b.protocol)
+		}
+	}
+
+	hc := config.healthCheck
+	if hc == nil {
+		return nil
+	}
+
+	// Target type "ip" requires health checks to be always enabled and they
+	// cannot be disabled. healthCheckEnabled=false makes ack-elbv2 fail to sync
+	// the target group ("Health check enabled must be true with groups with
+	// target type ip"), silently stalling listener creation.
+	if hc.healthCheckEnabled != nil && !*hc.healthCheckEnabled {
+		return fmt.Errorf("%s healthCheckEnabled=false is not allowed: the plugin creates target groups with target type \"ip\", for which AWS requires health checks to be always enabled; remove healthCheckEnabled or set it to true", NlbHealthCheckConfigName)
+	}
+
+	// For NLB, only TCP/HTTP/HTTPS health-check protocols are supported;
+	// UDP/TCP_UDP/TLS/GENEVE are not valid health-check protocols.
+	if hc.healthCheckProtocol != nil {
+		p := strings.ToUpper(*hc.healthCheckProtocol)
+		switch p {
+		case "TCP", "HTTP", "HTTPS":
+		default:
+			return fmt.Errorf("%s healthCheckProtocol %q is invalid: NLB health checks support only TCP, HTTP or HTTPS", NlbHealthCheckConfigName, *hc.healthCheckProtocol)
+		}
+	}
+	if hc.healthCheckIntervalSeconds != nil && (*hc.healthCheckIntervalSeconds < 5 || *hc.healthCheckIntervalSeconds > 300) {
+		return fmt.Errorf("%s healthCheckIntervalSeconds %d is invalid: must be in [5,300]", NlbHealthCheckConfigName, *hc.healthCheckIntervalSeconds)
+	}
+	if hc.healthCheckTimeoutSeconds != nil && (*hc.healthCheckTimeoutSeconds < 2 || *hc.healthCheckTimeoutSeconds > 120) {
+		return fmt.Errorf("%s healthCheckTimeoutSeconds %d is invalid: must be in [2,120]", NlbHealthCheckConfigName, *hc.healthCheckTimeoutSeconds)
+	}
+	if hc.healthyThresholdCount != nil && (*hc.healthyThresholdCount < 2 || *hc.healthyThresholdCount > 10) {
+		return fmt.Errorf("%s healthyThresholdCount %d is invalid: must be in [2,10]", NlbHealthCheckConfigName, *hc.healthyThresholdCount)
+	}
+	if hc.unhealthyThresholdCount != nil && (*hc.unhealthyThresholdCount < 2 || *hc.unhealthyThresholdCount > 10) {
+		return fmt.Errorf("%s unhealthyThresholdCount %d is invalid: must be in [2,10]", NlbHealthCheckConfigName, *hc.unhealthyThresholdCount)
+	}
+	return nil
 }
 
 // consSvcPorts builds the ServicePort list for the backing ClusterIP Service.

--- a/cloudprovider/amazonswebservices/nlb.go
+++ b/cloudprovider/amazonswebservices/nlb.go
@@ -126,6 +126,29 @@ type nlbConfig struct {
 	annotations      map[string]string
 }
 
+// configHash returns the hash used to detect whether a pod's network must be
+// reconfigured. It intentionally EXCLUDES loadBalancerARNs.
+//
+// Which NLB a pod uses is decided once at allocation time and then pinned in
+// the podAllocate cache and the per-pod Service/TargetGroup/Listener objects
+// (named after the pod). Adding or removing an ARN in NlbARNs must NOT force
+// already-allocated pods to reconfigure: doing so re-runs port allocation
+// against a freshly-added NLB whose port cache is empty, causing double
+// allocation, orphan listeners and a non-self-healing deadlock (servers that
+// were healthy get knocked to NotReady). By hashing everything EXCEPT the ARN
+// list, a change to NlbARNs leaves existing pods untouched (they keep their
+// pinned ARN/ports), while only NEW pods pick up the newly added ARN via
+// allocate(). Other config changes (health check, ports, protocols, fixed,
+// annotations) still change the hash and trigger a legitimate reconfigure.
+func (c *nlbConfig) configHash() string {
+	if c == nil {
+		return ""
+	}
+	view := *c
+	view.loadBalancerARNs = nil
+	return util.GetHash(view)
+}
+
 func startWatchTargetGroup(ctx context.Context) error {
 	var err error
 	go func() {
@@ -301,7 +324,10 @@ func (n *NlbPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.C
 	}
 
 	// update svc
-	if util.GetHash(lbConfig) != svc.GetAnnotations()[NlbConfigHashKey] {
+	// Use configHash (excludes loadBalancerARNs) so that adding/removing an ARN
+	// in NlbARNs does NOT trigger a reconfigure of already-allocated pods —
+	// avoiding the full-reset + port-collision deadlock (see configHash doc).
+	if lbConfig.configHash() != svc.GetAnnotations()[NlbConfigHashKey] {
 		networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
 		pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
 		if err != nil {
@@ -773,7 +799,7 @@ func (n *NlbPlugin) syncTargetGroupAndService(config *nlbConfig,
 	svcPorts := consSvcPorts(config.backends, ports)
 	annotations := map[string]string{
 		NlbARNAnnoKey:    lbARN,
-		NlbConfigHashKey: util.GetHash(config),
+		NlbConfigHashKey: config.configHash(),
 	}
 	for key, value := range config.annotations {
 		annotations[key] = value

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -15,6 +15,7 @@ package amazonswebservices
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -23,6 +24,7 @@ import (
 	"time"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
+	ackv1alpha1core "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/kr/pretty"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -1188,4 +1190,836 @@ func TestGetOwnerReference(t *testing.T) {
 			}
 		})
 	}
+}
+
+
+// ---------------------------------------------------------------------------
+// Helpers used by the OnPodUpdated / sync* unit tests below.
+// ---------------------------------------------------------------------------
+
+// nlbTestScheme returns a runtime.Scheme registered with every API type
+// touched by OnPodUpdated and the sync* helpers (corev1 + elbv2 TGB +
+// ACK TargetGroup/Listener + OKG game.kruise.io v1alpha1).
+func nlbTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	if err := elbv2api.AddToScheme(s); err != nil {
+		t.Fatalf("add elbv2api: %v", err)
+	}
+	if err := ackv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add ackv1alpha1: %v", err)
+	}
+	if err := gamekruiseiov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add gamekruiseiov1alpha1: %v", err)
+	}
+	return s
+}
+
+// validNlbConf returns a minimal but valid NlbARNs+PortProtocols JSON network
+// conf string for use as a Pod annotation. validateLbConfig accepts it.
+func validNlbConf(arn string, ports string) string {
+	return fmt.Sprintf(
+		`[{"name":"NlbARNs","value":"%s"},`+
+			`{"name":"PortProtocols","value":"%s"},`+
+			`{"name":"NlbVPCId","value":"vpc-1"}]`,
+		arn, ports)
+}
+
+// mkNlbPod builds a Pod with OKG NLB annotations so utils.NewNetworkManager
+// returns a non-nil manager and parseLbConfig parses the conf.
+func mkNlbPod(name, ns, conf, status string) *corev1.Pod {
+	ann := map[string]string{
+		gamekruiseiov1alpha1.GameServerNetworkType: NlbNetwork,
+		gamekruiseiov1alpha1.GameServerNetworkConf: conf,
+	}
+	if status != "" {
+		ann[gamekruiseiov1alpha1.GameServerNetworkStatus] = status
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Annotations: ann,
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// generateNlbEndpoint: pure ARN -> hostname formatter. We test the happy path
+// (canonical ARN) and the malformed-ARN guard which returns "" instead of
+// panicking.
+// ---------------------------------------------------------------------------
+
+func TestGenerateNlbEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		arn  string
+		want string
+	}{
+		{
+			name: "valid canonical ARN -> <name>-<id>.elb.<region>.amazonaws.com",
+			arn:  "arn:aws:elasticloadbalancing:us-east-1:888888888888:loadbalancer/net/aaa/3b332e6841f23870",
+			want: "aaa-3b332e6841f23870.elb.us-east-1.amazonaws.com",
+		},
+		{
+			name: "valid ARN in different region",
+			arn:  "arn:aws:elasticloadbalancing:eu-west-1:1:loadbalancer/net/my-nlb/abc",
+			want: "my-nlb-abc.elb.eu-west-1.amazonaws.com",
+		},
+		{
+			// Malformed ARN: not 6 colon-separated parts. Must return "" rather
+			// than panic, so callers can degrade gracefully.
+			name: "malformed ARN -> empty",
+			arn:  "garbage",
+			want: "",
+		},
+		{
+			name: "empty ARN -> empty",
+			arn:  "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateNlbEndpoint(tt.arn); got != tt.want {
+				t.Errorf("generateNlbEndpoint(%q) = %q, want %q", tt.arn, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getACKTargetGroupARN: error+success branches. Used by the watch handler to
+// surface the ARN AWS assigned to the ACK TargetGroup, so the listener and
+// TargetGroupBinding can reference it.
+// ---------------------------------------------------------------------------
+
+func TestGetACKTargetGroupARN(t *testing.T) {
+	arn := ackv1alpha1core.AWSResourceName("arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/tg/abc")
+
+	t.Run("no conditions -> error", func(t *testing.T) {
+		_, err := getACKTargetGroupARN(&ackv1alpha1.TargetGroup{})
+		if err == nil {
+			t.Fatal("expected error when status has no conditions")
+		}
+	})
+
+	t.Run("first condition not True -> error", func(t *testing.T) {
+		tg := &ackv1alpha1.TargetGroup{
+			Status: ackv1alpha1.TargetGroupStatus{
+				Conditions: []*ackv1alpha1core.Condition{{
+					Status:  "False",
+					Message: ptr.To[string]("nope"),
+					Reason:  ptr.To[string]("rejected"),
+				}},
+			},
+		}
+		_, err := getACKTargetGroupARN(tg)
+		if err == nil {
+			t.Fatal("expected error when first condition is not True")
+		}
+	})
+
+	t.Run("True but ACKResourceMetadata nil -> error (status not ready)", func(t *testing.T) {
+		tg := &ackv1alpha1.TargetGroup{
+			Status: ackv1alpha1.TargetGroupStatus{
+				Conditions: []*ackv1alpha1core.Condition{{Status: "True"}},
+				// ACKResourceMetadata intentionally nil
+			},
+		}
+		_, err := getACKTargetGroupARN(tg)
+		if err == nil {
+			t.Fatal("expected error when ACKResourceMetadata is nil")
+		}
+	})
+
+	t.Run("True with ARN -> returns ARN", func(t *testing.T) {
+		tg := &ackv1alpha1.TargetGroup{
+			Status: ackv1alpha1.TargetGroupStatus{
+				Conditions: []*ackv1alpha1core.Condition{{Status: "True"}},
+				ACKResourceMetadata: &ackv1alpha1core.ResourceMetadata{
+					ARN: &arn,
+				},
+			},
+		}
+		got, err := getACKTargetGroupARN(tg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != string(arn) {
+			t.Errorf("ARN = %q, want %q", got, arn)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// OnPodUpdated covers the lion's share of the missing patch coverage. We
+// exercise each independent branch in isolation.
+// ---------------------------------------------------------------------------
+
+const testNlbARN = "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/aaa/1"
+
+// Branch: validateLbConfig returns error -> OnPodUpdated must surface a
+// ParameterError without touching any cluster state.
+func TestOnPodUpdated_InvalidConfig_ParameterError(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	// Missing NlbARNs -> validateLbConfig fails.
+	conf := `[{"name":"PortProtocols","value":"8080/TCP"}]`
+	pod := mkNlbPod("p0", "default", conf, `{"currentNetworkState":"NotReady"}`)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	n := newNlbForPolicy()
+	_, perr := n.OnPodUpdated(c, pod, context.Background())
+	if perr == nil {
+		t.Fatalf("expected error for invalid config, got nil")
+	}
+	if perr.Type() != "parameterError" {
+		t.Errorf("error type = %q, want parameterError", perr.Type())
+	}
+}
+
+// Branch: networkStatus annotation absent -> OnPodUpdated writes
+// CurrentNetworkState=NotReady and returns. The pod's annotation should be
+// set so subsequent webhook calls have a starting point.
+func TestOnPodUpdated_NoNetworkStatusAnnotation_SetsNotReady(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP")
+	pod := mkNlbPod("p0", "default", conf, "") // no NetworkStatus annotation
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	n := newNlbForPolicy()
+	got, perr := n.OnPodUpdated(c, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+	annStatus := got.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus]
+	if annStatus == "" {
+		t.Fatal("expected NetworkStatus annotation to be set")
+	}
+	if !contains(annStatus, "NotReady") {
+		t.Errorf("expected NotReady in annotation, got %q", annStatus)
+	}
+}
+
+// Branch: Service does not exist for the pod -> OnPodUpdated calls
+// syncTargetGroupAndService, which must:
+//   - allocate a port (or reuse podAllocate);
+//   - create the Service (ClusterIP) with the right annotations/labels;
+//   - create one TargetGroup per backend port.
+//
+// This single test exercises both OnPodUpdated's "svc not found" branch and
+// the entire syncTargetGroupAndService function (TG + Service creation).
+func TestOnPodUpdated_SvcNotFound_CreatesTargetGroupAndService(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP,8081/UDP")
+	pod := mkNlbPod("gd-0", "default", conf, `{"currentNetworkState":"NotReady"}`)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	n := newNlbForPolicy()
+	if _, perr := n.OnPodUpdated(c, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+
+	// Service must be created with NlbARN + ConfigHash annotations.
+	svc := &corev1.Service{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0", Namespace: "default"}, svc); err != nil {
+		t.Fatalf("Service not created: %v", err)
+	}
+	if svc.Annotations[NlbARNAnnoKey] != testNlbARN {
+		t.Errorf("svc.Annotations[%s] = %q, want %q", NlbARNAnnoKey, svc.Annotations[NlbARNAnnoKey], testNlbARN)
+	}
+	if svc.Annotations[NlbConfigHashKey] == "" {
+		t.Errorf("svc.Annotations[%s] should not be empty", NlbConfigHashKey)
+	}
+	if len(svc.Spec.Ports) != 2 {
+		t.Errorf("svc.Spec.Ports = %d, want 2", len(svc.Spec.Ports))
+	}
+	if svc.Labels[ResourceTagKey] != ResourceTagValue {
+		t.Errorf("svc.Labels[%s] = %q, want %q", ResourceTagKey, svc.Labels[ResourceTagKey], ResourceTagValue)
+	}
+
+	// One TargetGroup per backend port. Names are <pod>-<port>.
+	tgList := &ackv1alpha1.TargetGroupList{}
+	if err := c.List(context.Background(), tgList); err != nil {
+		t.Fatalf("list TargetGroups: %v", err)
+	}
+	if len(tgList.Items) != 2 {
+		t.Errorf("TargetGroup count = %d, want 2", len(tgList.Items))
+	}
+	for _, tg := range tgList.Items {
+		if tg.Annotations[NlbARNAnnoKey] != testNlbARN {
+			t.Errorf("TG %s missing NlbARN annotation", tg.GetName())
+		}
+		if tg.Labels[AWSTargetGroupSyncStatus] != "false" {
+			t.Errorf("TG %s sync label = %q, want false", tg.GetName(), tg.Labels[AWSTargetGroupSyncStatus])
+		}
+	}
+
+	// allocate must have pinned the port set in podAllocate so subsequent calls reuse it.
+	if alloc, ok := n.podAllocate["default/gd-0"]; !ok || len(alloc.ports) != 2 {
+		t.Errorf("podAllocate not pinned correctly: %#v", alloc)
+	}
+}
+
+// Branch: Service exists, networkStatus already Ready, hash matches ->
+// OnPodUpdated must short-circuit (no readiness-gate re-check, no resource
+// updates). This pins the S4/InPlace pass-through documented in nlb.go.
+func TestOnPodUpdated_PassThroughReadyAndHashMatch(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP")
+	pod := mkNlbPod("gd-0", "default", conf,
+		`{"currentNetworkState":"Ready","externalAddresses":[{"endPoint":"x.elb"}]}`)
+
+	// Build the matching Service whose hash equals what configHash() will
+	// compute for the parsed conf, so OnPodUpdated takes the pass-through path.
+	parsed := parseLbConfig(parseConf(t, conf))
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				NlbARNAnnoKey:    testNlbARN,
+				NlbConfigHashKey: parsed.configHash(),
+			},
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 951, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc).Build()
+
+	n := newNlbForPolicy()
+	got, perr := n.OnPodUpdated(c, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+	// Pass-through: pod returned unchanged, no annotation rewrites.
+	annStatus := got.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus]
+	if annStatus != `{"currentNetworkState":"Ready","externalAddresses":[{"endPoint":"x.elb"}]}` {
+		t.Errorf("annotation should be unchanged in pass-through, got %q", annStatus)
+	}
+}
+
+// Branch: Service exists, networkStatus is NotReady, hash matches, pod is
+// NOT PodReady -> OnPodUpdated keeps NetworkNotReady (gate hasn't flipped).
+// The healStuckReadinessGates pass is invoked but does nothing (no stuck
+// gates declared on the pod), exercising the "ready=false" branch.
+func TestOnPodUpdated_PodNotReady_KeepsNetworkNotReady(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP")
+	pod := mkNlbPod("gd-0", "default", conf, `{"currentNetworkState":"NotReady"}`)
+	pod.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+	}
+
+	parsed := parseLbConfig(parseConf(t, conf))
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				NlbARNAnnoKey:    testNlbARN,
+				NlbConfigHashKey: parsed.configHash(),
+			},
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 951, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP}},
+		},
+	}
+	// Add a TGB so the inventory matches svc.Spec.Ports (skips re-sync patch).
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-951",
+			Namespace: "default",
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc, tgb).Build()
+
+	n := newNlbForPolicy()
+	got, perr := n.OnPodUpdated(c, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+	annStatus := got.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus]
+	if !contains(annStatus, "NotReady") {
+		t.Errorf("expected NotReady, got %q", annStatus)
+	}
+	if contains(annStatus, `"Ready"`) && !contains(annStatus, "NotReady") {
+		t.Errorf("expected NotReady (not Ready), got %q", annStatus)
+	}
+}
+
+// Branch: Service exists, hash matches, pod IS PodReady -> OnPodUpdated
+// constructs the internal/external address lists from svc.Spec.Ports and
+// flips CurrentNetworkState to NetworkReady.
+func TestOnPodUpdated_PodReady_FillsExternalAddresses(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP")
+	// networkStatus exists but is still NotReady (e.g. initial reconciliation).
+	pod := mkNlbPod("gd-0", "default", conf, `{"currentNetworkState":"NotReady"}`)
+	pod.Status = corev1.PodStatus{
+		PodIP:      "10.0.0.7",
+		Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+	}
+
+	parsed := parseLbConfig(parseConf(t, conf))
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				NlbARNAnnoKey:    testNlbARN,
+				NlbConfigHashKey: parsed.configHash(),
+			},
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 951, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP}},
+		},
+	}
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-951",
+			Namespace: "default",
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc, tgb).Build()
+
+	n := newNlbForPolicy()
+	got, perr := n.OnPodUpdated(c, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+	annStatus := got.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus]
+	// Must transition to Ready and populate external endpoint derived from ARN.
+	if !contains(annStatus, `"currentNetworkState":"Ready"`) {
+		t.Errorf("expected currentNetworkState Ready, got %q", annStatus)
+	}
+	wantEndpoint := "aaa-1.elb.us-east-1.amazonaws.com" // generateNlbEndpoint(testNlbARN)
+	if !contains(annStatus, wantEndpoint) {
+		t.Errorf("expected external endpoint %q in status, got %q", wantEndpoint, annStatus)
+	}
+	if !contains(annStatus, `"ip":"10.0.0.7"`) {
+		t.Errorf("expected internal IP 10.0.0.7 in status, got %q", annStatus)
+	}
+}
+
+// Branch: networkDisabled label set -> OnPodUpdated must DeleteAllOf
+// the pod's TargetGroupBindings (network shut off) and return without
+// reaching the readiness-gate code.
+func TestOnPodUpdated_NetworkDisabled_DeletesTGBs(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP")
+	pod := mkNlbPod("gd-0", "default", conf, `{"currentNetworkState":"Ready"}`)
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	pod.Labels[gamekruiseiov1alpha1.GameServerNetworkDisabled] = "true"
+
+	parsed := parseLbConfig(parseConf(t, conf))
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				NlbARNAnnoKey:    testNlbARN,
+				NlbConfigHashKey: parsed.configHash(),
+			},
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 951, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP}},
+		},
+	}
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-951",
+			Namespace: "default",
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc, tgb).Build()
+
+	n := newNlbForPolicy()
+	if _, perr := n.OnPodUpdated(c, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+	// The TGB should be gone after disable.
+	got := &elbv2api.TargetGroupBinding{}
+	err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0-951", Namespace: "default"}, got)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected TGB to be deleted, err=%v", err)
+	}
+}
+
+// Branch: SVC exists but its hash differs from the parsed conf -> OnPodUpdated
+// resets the network state to NotReady and re-runs syncTargetGroupAndService.
+// We assert the Service annotation is updated to the new hash.
+func TestOnPodUpdated_HashMismatch_ResyncsService(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP")
+	pod := mkNlbPod("gd-0", "default", conf, `{"currentNetworkState":"Ready"}`)
+
+	// Pre-existing svc with a stale hash.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				NlbARNAnnoKey:    testNlbARN,
+				NlbConfigHashKey: "stale-hash-doesnt-match",
+			},
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 951, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc).Build()
+
+	n := newNlbForPolicy()
+	got, perr := n.OnPodUpdated(c, pod, context.Background())
+	if perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+	// Status moved to NotReady (we entered the resync branch).
+	if !contains(got.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus], "NotReady") {
+		t.Errorf("expected NotReady annotation after hash mismatch, got %q",
+			got.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus])
+	}
+	// Service annotation hash should now match the parsed conf hash.
+	parsed := parseLbConfig(parseConf(t, conf))
+	updatedSvc := &corev1.Service{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0", Namespace: "default"}, updatedSvc); err != nil {
+		t.Fatalf("get updated svc: %v", err)
+	}
+	if updatedSvc.Annotations[NlbConfigHashKey] != parsed.configHash() {
+		t.Errorf("svc hash = %q, want %q", updatedSvc.Annotations[NlbConfigHashKey], parsed.configHash())
+	}
+}
+
+// Branch: TGB inventory smaller than svc.Spec.Ports -> OnPodUpdated patches
+// each TG's sync label to "false" so the watch reconciler will re-create the
+// missing TGBs. This pins the heal-on-mismatch path inside OnPodUpdated.
+func TestOnPodUpdated_TgbCountMismatch_PatchesTGSyncLabel(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	conf := validNlbConf(testNlbARN, "8080/TCP,8081/UDP")
+	pod := mkNlbPod("gd-0", "default", conf, `{"currentNetworkState":"NotReady"}`)
+	pod.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+	}
+
+	parsed := parseLbConfig(parseConf(t, conf))
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				NlbARNAnnoKey:    testNlbARN,
+				NlbConfigHashKey: parsed.configHash(),
+			},
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{Port: 951, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP},
+				{Port: 952, TargetPort: intstr.FromInt(8081), Protocol: corev1.ProtocolUDP},
+			},
+		},
+	}
+	// Only ONE TGB exists for two svc ports -> mismatch path triggers.
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-951",
+			Namespace: "default",
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+		},
+	}
+	tg1 := &ackv1alpha1.TargetGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-951",
+			Namespace: "default",
+			Labels: map[string]string{
+				ResourceTagKey:           ResourceTagValue,
+				SvcSelectorKey:           "gd-0",
+				AWSTargetGroupSyncStatus: "true",
+			},
+		},
+	}
+	tg2 := &ackv1alpha1.TargetGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-952",
+			Namespace: "default",
+			Labels: map[string]string{
+				ResourceTagKey:           ResourceTagValue,
+				SvcSelectorKey:           "gd-0",
+				AWSTargetGroupSyncStatus: "true",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, svc, tgb, tg1, tg2).Build()
+
+	n := newNlbForPolicy()
+	if _, perr := n.OnPodUpdated(c, pod, context.Background()); perr != nil {
+		t.Fatalf("OnPodUpdated error: %v", perr)
+	}
+	// Both TGs should now have sync=false so the watch handler re-creates the TGB.
+	for _, name := range []string{"gd-0-951", "gd-0-952"} {
+		got := &ackv1alpha1.TargetGroup{}
+		if err := c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, got); err != nil {
+			t.Fatalf("get TG %s: %v", name, err)
+		}
+		if got.Labels[AWSTargetGroupSyncStatus] != "false" {
+			t.Errorf("TG %s sync label = %q, want false", name, got.Labels[AWSTargetGroupSyncStatus])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// syncListenerAndTargetGroupBinding: directly exercise the watch-driven
+// helper that creates/updates the Listener and TargetGroupBinding from a
+// ready TargetGroup. This drove most of the missing patch coverage outside
+// OnPodUpdated.
+// ---------------------------------------------------------------------------
+
+func TestSyncListenerAndTargetGroupBinding(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	tg := &ackv1alpha1.TargetGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-951",
+			Namespace: "default",
+			Labels: map[string]string{
+				ResourceTagKey: ResourceTagValue,
+				SvcSelectorKey: "gd-0",
+			},
+			Annotations: map[string]string{
+				NlbARNAnnoKey:  testNlbARN,
+				NlbPortAnnoKey: "951",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1", Kind: "Pod", Name: "gd-0", UID: "abc",
+				Controller: ptr.To[bool](true), BlockOwnerDeletion: ptr.To[bool](true),
+			}},
+		},
+		Spec: ackv1alpha1.TargetGroupSpec{
+			Protocol: ptr.To[string]("TCP"),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tg).Build()
+	tgARN := "arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/tg/x"
+
+	if err := syncListenerAndTargetGroupBinding(context.Background(), c, tg, &tgARN); err != nil {
+		t.Fatalf("syncListenerAndTargetGroupBinding: %v", err)
+	}
+
+	// Listener should now exist with the expected port and load balancer ARN.
+	l := &ackv1alpha1.Listener{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0-951", Namespace: "default"}, l); err != nil {
+		t.Fatalf("Listener not created: %v", err)
+	}
+	if l.Spec.Port == nil || *l.Spec.Port != 951 {
+		t.Errorf("Listener port = %v, want 951", l.Spec.Port)
+	}
+	if l.Spec.LoadBalancerARN == nil || *l.Spec.LoadBalancerARN != testNlbARN {
+		t.Errorf("Listener LB ARN = %v, want %q", l.Spec.LoadBalancerARN, testNlbARN)
+	}
+	if l.Labels[SvcSelectorKey] != "gd-0" {
+		t.Errorf("Listener svc-selector label = %q, want gd-0", l.Labels[SvcSelectorKey])
+	}
+
+	// TargetGroupBinding should reference the pod's Service by name + the listener port.
+	tgb := &elbv2api.TargetGroupBinding{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0-951", Namespace: "default"}, tgb); err != nil {
+		t.Fatalf("TGB not created: %v", err)
+	}
+	if tgb.Spec.TargetGroupARN != tgARN {
+		t.Errorf("TGB targetGroupARN = %q, want %q", tgb.Spec.TargetGroupARN, tgARN)
+	}
+	if tgb.Spec.ServiceRef.Name != "gd-0" {
+		t.Errorf("TGB service name = %q, want gd-0", tgb.Spec.ServiceRef.Name)
+	}
+	if tgb.Spec.ServiceRef.Port.IntValue() != 951 {
+		t.Errorf("TGB service port = %v, want 951", tgb.Spec.ServiceRef.Port)
+	}
+}
+
+// Malformed annotations -> the helper should surface the strconv error rather
+// than silently creating broken resources.
+func TestSyncListenerAndTargetGroupBinding_BadPortAnnotation(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	tg := &ackv1alpha1.TargetGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0-bad",
+			Namespace: "default",
+			Annotations: map[string]string{
+				NlbARNAnnoKey:  testNlbARN,
+				NlbPortAnnoKey: "not-a-number",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tg).Build()
+	tgARN := "arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/tg/x"
+	if err := syncListenerAndTargetGroupBinding(context.Background(), c, tg, &tgARN); err == nil {
+		t.Fatal("expected error for bad NlbPort annotation, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// healStuckReadinessGates: cover the not-found / TGB-missing branches that
+// the original test left at 0% (they're the warning-and-skip paths).
+// ---------------------------------------------------------------------------
+
+// All gates' TGBs are missing -> healStuckReadinessGates skips each and
+// returns 0 healed, without surfacing an error.
+func TestHealStuckReadinessGates_TGBNotFound(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	now := metav1.Now()
+	stuck := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-9001")
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "gd-0", Namespace: "default"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+			{Type: stuck, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-300 * time.Second))},
+		}},
+	}
+	// No TGB exists for the gate -> Get returns NotFound -> branch skipped.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	n := newNlbForPolicy()
+	healed := n.healStuckReadinessGates(context.Background(), c, pod, now.Unix())
+	if healed != 0 {
+		t.Errorf("expected 0 healed when TGB is NotFound, got %d", healed)
+	}
+}
+
+// TGB exists and is deleted, but the matching TG is missing -> the second Get
+// fails NotFound and the branch warns + continues without incrementing healed.
+// This pins the post-delete TG-NotFound branch.
+func TestHealStuckReadinessGates_TGNotFoundAfterTGBDeleted(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	now := metav1.Now()
+	stuck := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-9001")
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "gd-0", Namespace: "default"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+			{Type: stuck, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-300 * time.Second))},
+		}},
+	}
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "gd-0-9001", Namespace: "default"},
+	}
+	// Note: no TG with the same name exists -> the second Get fails.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, tgb).Build()
+	n := newNlbForPolicy()
+	healed := n.healStuckReadinessGates(context.Background(), c, pod, now.Unix())
+	if healed != 0 {
+		t.Errorf("expected 0 healed when TG is NotFound (post-delete), got %d", healed)
+	}
+	// TGB must still have been deleted.
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0-9001", Namespace: "default"}, &elbv2api.TargetGroupBinding{}); !errors.IsNotFound(err) {
+		t.Errorf("TGB should have been deleted before TG lookup, err=%v", err)
+	}
+}
+
+// Conditions whose Type doesn't match the LB readiness-gate prefix are
+// completely ignored (e.g. PodReady, custom user gates), no matter their
+// status or age. This pins the prefix guard.
+func TestHealStuckReadinessGates_NonLbConditionsIgnored(t *testing.T) {
+	scheme := nlbTestScheme(t)
+	now := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "gd-0", Namespace: "default"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+			// Not an LB readiness gate -> must be skipped even though it is False
+			// and very old.
+			{Type: corev1.PodReady, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-1 * time.Hour))},
+		}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	n := newNlbForPolicy()
+	healed := n.healStuckReadinessGates(context.Background(), c, pod, now.Unix())
+	if healed != 0 {
+		t.Errorf("non-LB conditions must be ignored, got healed=%d", healed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tiny utilities used above. We don't pull in strings.Contains via the
+// already-imported strings package because nlb_test.go does not import it; a
+// local helper keeps the import set minimal.
+// ---------------------------------------------------------------------------
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	if len(needle) == 0 {
+		return 0
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// parseConf unmarshals the JSON network-conf string into a
+// []NetworkConfParams the same way utils.NewNetworkManager does, without
+// pulling that whole scaffolding into the test path. The conf JSON shape is
+// pinned by GameServerNetworkConf consumers, so a direct json.Unmarshal is
+// sufficient and avoids a circular helper.
+func parseConf(t *testing.T, jsonStr string) []gamekruiseiov1alpha1.NetworkConfParams {
+	t.Helper()
+	var conf []gamekruiseiov1alpha1.NetworkConfParams
+	if err := json.Unmarshal([]byte(jsonStr), &conf); err != nil {
+		t.Fatalf("unmarshal conf %q: %v", jsonStr, err)
+	}
+	return conf
 }

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -765,3 +765,97 @@ func TestHealStuckReadinessGates(t *testing.T) {
 		t.Errorf("fresh TGB gd-0-9002 should NOT be deleted, err=%v", err)
 	}
 }
+
+// 一个 pod 多端口 → 每个 listener 端口一个 readiness gate, 名各对应自己的 TGB。
+func TestOnPodAddedMultiPortGates(t *testing.T) {
+	arn := "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/aaa/1"
+	n := newNlbForPolicy()
+	conf := `[{"name":"NlbARNs","value":"` + arn + `"},{"name":"PortProtocols","value":"8601/TCP,8602/UDP,8603/TCP"},{"name":"NlbVPCId","value":"vpc-1"}]`
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gd-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				gamekruiseiov1alpha1.GameServerNetworkType: NlbNetwork,
+				gamekruiseiov1alpha1.GameServerNetworkConf: conf,
+			},
+		},
+	}
+	got, perr := n.OnPodAdded(nil, pod, nil)
+	if perr != nil {
+		t.Fatalf("OnPodAdded error: %v", perr)
+	}
+	alloc := n.podAllocate["default/gd-0"]
+	if alloc == nil || len(alloc.ports) != 3 {
+		t.Fatalf("expected 3 ports allocated, got %#v", alloc)
+	}
+	// 每个分配端口都应有一个对应 gate, 且 gate 数量恰等于端口数(不多不少)。
+	if len(got.Spec.ReadinessGates) != 3 {
+		t.Fatalf("expected 3 readiness gates, got %d: %#v", len(got.Spec.ReadinessGates), got.Spec.ReadinessGates)
+	}
+	have := map[corev1.PodConditionType]bool{}
+	for _, g := range got.Spec.ReadinessGates {
+		have[g.ConditionType] = true
+	}
+	for _, port := range alloc.ports {
+		want := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-" + intToStr(port))
+		if !have[want] {
+			t.Errorf("missing readiness gate %q for port %d", want, port)
+		}
+	}
+}
+
+// 无 NLB 网络注解的 pod: OnPodAdded 原样返回, 不分配端口、不注入 gate。
+func TestOnPodAddedNonNlbPodUntouched(t *testing.T) {
+	n := newNlbForPolicy()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-0", Namespace: "default"},
+	}
+	got, perr := n.OnPodAdded(nil, pod, nil)
+	if perr != nil {
+		t.Fatalf("OnPodAdded error: %v", perr)
+	}
+	if len(got.Spec.ReadinessGates) != 0 {
+		t.Errorf("non-NLB pod should not get readiness gates, got %#v", got.Spec.ReadinessGates)
+	}
+	if _, ok := n.podAllocate["default/plain-0"]; ok {
+		t.Errorf("non-NLB pod should not allocate ports")
+	}
+}
+
+// 自愈的负向分支: True 的 gate / 零 LastTransitionTime 的 gate / TGB 已不存在, 都不应判为卡死, healed=0 且无副作用。
+func TestHealStuckReadinessGatesNoFalsePositive(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = elbv2api.AddToScheme(scheme)
+	_ = ackv1alpha1.AddToScheme(scheme)
+
+	now := metav1.Now()
+	trueGate := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-9001")  // 已 True → 健康, 不治
+	zeroGate := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-9002")  // False 但 LastTransitionTime 为零 → 刚注入, 不治
+	noTgbGate := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-9003") // False 已久但 TGB 已不存在 → 安全跳过
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "gd-0", Namespace: "default"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+			{Type: trueGate, Status: corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(now.Add(-300 * time.Second))},
+			{Type: zeroGate, Status: corev1.ConditionFalse}, // LastTransitionTime 零值
+			{Type: noTgbGate, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-300 * time.Second))},
+		}},
+	}
+	// True gate 的 TGB 存在(不该被删), noTgbGate 的 TGB 不存在。
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(pod, &elbv2api.TargetGroupBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "gd-0-9001", Namespace: "default"}}).Build()
+
+	n := newNlbForPolicy()
+	healed := n.healStuckReadinessGates(context.Background(), c, pod, now.Unix())
+	if healed != 0 {
+		t.Fatalf("expected 0 healed (no false positive), got %d", healed)
+	}
+	// True gate 的 TGB 必须仍在。
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0-9001", Namespace: "default"}, &elbv2api.TargetGroupBinding{}); err != nil {
+		t.Errorf("healthy(True) gate's TGB must not be deleted, err=%v", err)
+	}
+}

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -538,3 +538,50 @@ func TestAWSTargetGroupProtocol(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateLbConfig(t *testing.T) {
+	validARN := []string{"arn:aws:elasticloadbalancing:us-east-1:888888888888:loadbalancer/net/aaa/3b332e6841f23870"}
+	validBackends := []*backend{{targetPort: 8601, protocol: corev1.ProtocolTCP}}
+	base := func() *nlbConfig {
+		return &nlbConfig{
+			loadBalancerARNs: validARN,
+			backends:         validBackends,
+			healthCheck:      &healthCheck{},
+		}
+	}
+	tests := []struct {
+		name      string
+		config    *nlbConfig
+		expectErr bool
+	}{
+		{"nil config", nil, false},
+		{"valid minimal", base(), false},
+		{"missing NlbARNs", &nlbConfig{backends: validBackends, healthCheck: &healthCheck{}}, true},
+		{"missing PortProtocols", &nlbConfig{loadBalancerARNs: validARN, healthCheck: &healthCheck{}}, true},
+		{"port too low", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 0, protocol: corev1.ProtocolTCP}}, healthCheck: &healthCheck{}}, true},
+		{"port too high", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 70000, protocol: corev1.ProtocolTCP}}, healthCheck: &healthCheck{}}, true},
+		{"bad protocol", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 8601, protocol: corev1.Protocol("SCTP")}}, healthCheck: &healthCheck{}}, true},
+		{"TCPUDP protocol ok", &nlbConfig{loadBalancerARNs: validARN, backends: []*backend{{targetPort: 8601, protocol: ProtocolTCPUDP}}, healthCheck: &healthCheck{}}, false},
+		{"healthCheckEnabled false rejected", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckEnabled: ptr.To[bool](false)}}, true},
+		{"healthCheckEnabled true ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckEnabled: ptr.To[bool](true)}}, false},
+		{"healthCheckProtocol UDP rejected", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckProtocol: ptr.To[string]("UDP")}}, true},
+		{"healthCheckProtocol TCP ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckProtocol: ptr.To[string]("TCP")}}, false},
+		{"healthCheckProtocol HTTP ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckProtocol: ptr.To[string]("HTTP")}}, false},
+		{"interval out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckIntervalSeconds: ptr.To[int64](1)}}, true},
+		{"interval ok", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckIntervalSeconds: ptr.To[int64](30)}}, false},
+		{"timeout out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthCheckTimeoutSeconds: ptr.To[int64](200)}}, true},
+		{"healthy threshold out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{healthyThresholdCount: ptr.To[int64](11)}}, true},
+		{"unhealthy threshold out of range", &nlbConfig{loadBalancerARNs: validARN, backends: validBackends, healthCheck: &healthCheck{unhealthyThresholdCount: ptr.To[int64](1)}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLbConfig(tt.config)
+			if tt.expectErr && err == nil {
+				t.Errorf("%s: expected error, got nil", tt.name)
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("%s: expected no error, got %v", tt.name, err)
+			}
+		})
+	}
+}

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -15,6 +15,7 @@ package amazonswebservices
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"sync"
@@ -902,6 +903,288 @@ func TestValidateLbConfig(t *testing.T) {
 			}
 			if !tt.expectErr && err != nil {
 				t.Errorf("%s: expected no error, got %v", tt.name, err)
+			}
+		})
+	}
+}
+
+// TestOnPodDeleted exercises every branch of OnPodDeleted's port-release
+// decision (nlb.go: OnPodDeleted). It is the primary regression guard for the
+// behavior documented in docs/issues/aws-nlb-plugin-cases.md §1 (Scenario 1):
+// "scale=0 then delete gss" leaks NLB port cache under Fixed=true because the
+// early-return for live GSS combined with the absence of an OnGameServerSetDeleted
+// hook leaves no opportunity to release. The cases below pin down the current
+// branch behavior so any future change has to consciously update them.
+//
+// Coverage matrix (matches docs §1.12 semantic table):
+//
+//	isFixed | GSS state                     | want podAllocate cleared?
+//	------- | ----------------------------- | -----------------------------
+//	false   | (irrelevant)                  | yes — only this pod
+//	true    | exists, deletionTimestamp=nil | NO  (fixed-IP keeps slot)
+//	true    | exists, being deleted         | yes — all pods of GSS
+//	true    | NotFound                      | yes — all pods of GSS
+func TestOnPodDeleted(t *testing.T) {
+	const (
+		ns      = "default"
+		gssName = "gss-A"
+		nlbARN  = "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/aaa/1"
+	)
+
+	// mkPod builds a pod that carries the OKG NLB network-conf annotation so
+	// OnPodDeleted's parseLbConfig sees the right Fixed value, and the
+	// owner-gss label so GetGameServerSetOfPod resolves the right GSS name.
+	mkPod := func(name, owner string, fixed bool) *corev1.Pod {
+		conf := fmt.Sprintf(
+			`[{"name":"NlbARNs","value":"%s"},`+
+				`{"name":"PortProtocols","value":"8601/TCP"},`+
+				`{"name":"NlbVPCId","value":"vpc-1"},`+
+				`{"name":"Fixed","value":"%t"}]`,
+			nlbARN, fixed)
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels:    map[string]string{gamekruiseiov1alpha1.GameServerOwnerGssKey: owner},
+				Annotations: map[string]string{
+					gamekruiseiov1alpha1.GameServerNetworkType: NlbNetwork,
+					gamekruiseiov1alpha1.GameServerNetworkConf: conf,
+				},
+			},
+		}
+	}
+
+	// mkPlugin pre-populates 3 pods of gss-A (ports 9001/9002/9003) plus 1
+	// pod of an unrelated gss-B (port 9004), all on the same NLB. This lets
+	// the assertions check both "released the right pods" and "did not touch
+	// pods of other GSS".
+	mkPlugin := func() *NlbPlugin {
+		n := &NlbPlugin{
+			minPort:     9001,
+			maxPort:     9050,
+			cache:       map[string]portAllocated{nlbARN: make(portAllocated)},
+			podAllocate: map[string]*nlbPorts{},
+			mutex:       sync.RWMutex{},
+		}
+		for i, podName := range []string{"gss-A-0", "gss-A-1", "gss-A-2"} {
+			port := int32(9001 + i)
+			n.podAllocate[ns+"/"+podName] = &nlbPorts{arn: nlbARN, ports: []int32{port}}
+			n.cache[nlbARN][port] = true
+		}
+		n.podAllocate[ns+"/gss-B-0"] = &nlbPorts{arn: nlbARN, ports: []int32{9004}}
+		n.cache[nlbARN][9004] = true
+		return n
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = gamekruiseiov1alpha1.AddToScheme(scheme)
+
+	// Live GSS — no deletionTimestamp.
+	liveGSS := &gamekruiseiov1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: gssName, Namespace: ns},
+	}
+	// Deleting GSS — set deletionTimestamp + a finalizer so the fake client
+	// retains the object instead of immediately removing it.
+	now := metav1.Now()
+	deletingGSS := &gamekruiseiov1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              gssName,
+			Namespace:         ns,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"keep-for-test"},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		fixed           bool
+		gssInCluster    *gamekruiseiov1alpha1.GameServerSet // nil = NotFound
+		deletedPodName  string
+		wantPresent     map[string]bool // podAllocate state expected after
+		wantPortFreed   []int32         // cache slots that should be false
+		wantPortRetain  []int32         // cache slots that should remain true
+	}{
+		{
+			name:           "Fixed=false releases only this pod",
+			fixed:          false,
+			gssInCluster:   liveGSS, // present but irrelevant: code does not check GSS for !isFixed
+			deletedPodName: "gss-A-1",
+			wantPresent: map[string]bool{
+				ns + "/gss-A-0": true,
+				ns + "/gss-A-1": false,
+				ns + "/gss-A-2": true,
+				ns + "/gss-B-0": true,
+			},
+			wantPortFreed:  []int32{9002},
+			wantPortRetain: []int32{9001, 9003, 9004},
+		},
+		{
+			name:           "Fixed=true with live GSS keeps allocation (fixed-IP semantics)",
+			fixed:          true,
+			gssInCluster:   liveGSS,
+			deletedPodName: "gss-A-1",
+			wantPresent: map[string]bool{
+				ns + "/gss-A-0": true,
+				ns + "/gss-A-1": true, // NOT released — this is the early-return branch
+				ns + "/gss-A-2": true,
+				ns + "/gss-B-0": true,
+			},
+			wantPortFreed:  nil,
+			wantPortRetain: []int32{9001, 9002, 9003, 9004},
+		},
+		{
+			name:           "Fixed=true with deleting GSS releases all pods of that GSS",
+			fixed:          true,
+			gssInCluster:   deletingGSS,
+			deletedPodName: "gss-A-1",
+			wantPresent: map[string]bool{
+				ns + "/gss-A-0": false,
+				ns + "/gss-A-1": false,
+				ns + "/gss-A-2": false,
+				ns + "/gss-B-0": true, // sibling GSS unaffected
+			},
+			wantPortFreed:  []int32{9001, 9002, 9003},
+			wantPortRetain: []int32{9004},
+		},
+		{
+			name:           "Fixed=true with GSS NotFound releases all pods of that GSS",
+			fixed:          true,
+			gssInCluster:   nil, // empty cluster
+			deletedPodName: "gss-A-1",
+			wantPresent: map[string]bool{
+				ns + "/gss-A-0": false,
+				ns + "/gss-A-1": false,
+				ns + "/gss-A-2": false,
+				ns + "/gss-B-0": true,
+			},
+			wantPortFreed:  []int32{9001, 9002, 9003},
+			wantPortRetain: []int32{9004},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := mkPlugin()
+			pod := mkPod(tt.deletedPodName, gssName, tt.fixed)
+			cb := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.gssInCluster != nil {
+				cb = cb.WithObjects(tt.gssInCluster)
+			}
+			c := cb.Build()
+
+			if perr := n.OnPodDeleted(c, pod, context.Background()); perr != nil {
+				t.Fatalf("OnPodDeleted error: %v", perr)
+			}
+
+			for key, want := range tt.wantPresent {
+				_, got := n.podAllocate[key]
+				if got != want {
+					t.Errorf("podAllocate[%q]: present=%v, want=%v", key, got, want)
+				}
+			}
+			for _, port := range tt.wantPortFreed {
+				if n.cache[nlbARN][port] {
+					t.Errorf("cache[%d]: still occupied, want freed", port)
+				}
+			}
+			for _, port := range tt.wantPortRetain {
+				if !n.cache[nlbARN][port] {
+					t.Errorf("cache[%d]: freed, want still occupied", port)
+				}
+			}
+		})
+	}
+}
+
+// TestGetOwnerReference covers the isFixed branch in getOwnerReference
+// (nlb.go: getOwnerReference). The two non-error branches are also docs §1.12's
+// pivot: Fixed=true makes Service/TG owner = GSS so they survive Pod deletion
+// (TC-02 retention behavior), Fixed=false makes them owner = Pod so K8s GC
+// cascades them away on Pod deletion (TC-04 release behavior).
+func TestGetOwnerReference(t *testing.T) {
+	const (
+		ns      = "default"
+		gssName = "gss-A"
+		podName = "gss-A-0"
+		gssUID  = "gss-uid-1234"
+		podUID  = "pod-uid-5678"
+	)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = gamekruiseiov1alpha1.AddToScheme(scheme)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			UID:       podUID,
+			Labels:    map[string]string{gamekruiseiov1alpha1.GameServerOwnerGssKey: gssName},
+		},
+	}
+	gss := &gamekruiseiov1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gssName,
+			Namespace: ns,
+			UID:       gssUID,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		isFixed        bool
+		gssInCluster   *gamekruiseiov1alpha1.GameServerSet
+		wantOwnerName  string
+		wantOwnerUID   types.UID
+	}{
+		{
+			name:          "Fixed=false uses Pod as owner",
+			isFixed:       false,
+			gssInCluster:  gss, // present but ignored — Fixed=false skips GSS lookup
+			wantOwnerName: podName,
+			wantOwnerUID:  podUID,
+		},
+		{
+			name:          "Fixed=true with GSS present uses GameServerSet as owner",
+			isFixed:       true,
+			gssInCluster:  gss,
+			wantOwnerName: gssName,
+			wantOwnerUID:  gssUID,
+		},
+		{
+			name:          "Fixed=true with GSS NotFound falls back to Pod owner",
+			isFixed:       true,
+			gssInCluster:  nil,
+			wantOwnerName: podName,
+			wantOwnerUID:  podUID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.gssInCluster != nil {
+				cb = cb.WithObjects(tt.gssInCluster)
+			}
+			c := cb.Build()
+
+			refs := getOwnerReference(c, context.Background(), pod, tt.isFixed)
+			if len(refs) != 1 {
+				t.Fatalf("expected exactly 1 OwnerReference, got %d: %#v", len(refs), refs)
+			}
+			ref := refs[0]
+			if ref.Name != tt.wantOwnerName {
+				t.Errorf("Name = %q, want %q", ref.Name, tt.wantOwnerName)
+			}
+			if ref.UID != tt.wantOwnerUID {
+				t.Errorf("UID = %q, want %q", ref.UID, tt.wantOwnerUID)
+			}
+			if ref.Controller == nil || !*ref.Controller {
+				t.Errorf("Controller = %v, want true", ref.Controller)
+			}
+			if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+				t.Errorf("BlockOwnerDeletion = %v, want true", ref.BlockOwnerDeletion)
 			}
 		})
 	}

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -62,7 +62,7 @@ func TestAllocateDeAllocate(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		allocatedPorts := test.nlb.allocate(test.loadBalancerARNs, test.num, test.podKey)
+		allocatedPorts := test.nlb.allocate(test.loadBalancerARNs, test.num, test.podKey, allocatePolicyDefault)
 		if int(test.nlb.maxPort-test.nlb.minPort+1) < test.num && allocatedPorts != nil {
 			t.Errorf("insufficient available ports but NLB was still allocated: %s",
 				pretty.Sprint(allocatedPorts))
@@ -585,5 +585,72 @@ func TestConfigHashIgnoresARNs(t *testing.T) {
 	changedFixed.isFixed = false
 	if base.configHash() == changedFixed.configHash() {
 		t.Errorf("configHash did not change when isFixed changed")
+	}
+}
+
+func newNlbForPolicy() *NlbPlugin {
+	return &NlbPlugin{
+		maxPort:     int32(953), // 3 ports per NLB: 951,952,953
+		minPort:     int32(951),
+		cache:       make(map[string]portAllocated),
+		podAllocate: make(map[string]*nlbPorts),
+		mutex:       sync.RWMutex{},
+	}
+}
+
+// default(first-fit/溢出): 先填满第一个 NLB, 再溢出第二个。
+func TestAllocatePolicyDefaultSpillover(t *testing.T) {
+	arnA := "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/aaa/1"
+	arnB := "arn:aws:elasticloadbalancing:us-east-1:2:loadbalancer/net/bbb/2"
+	n := newNlbForPolicy()
+	// 4 个单端口服: 3 个应全落 A(填满), 第 4 个溢出 B
+	got := map[string]int{}
+	for i := 0; i < 4; i++ {
+		p := n.allocate([]string{arnA, arnB}, 1, "ns/p"+string(rune('0'+i)), allocatePolicyDefault)
+		if p == nil {
+			t.Fatalf("allocate %d returned nil", i)
+		}
+		got[p.arn]++
+	}
+	if got[arnA] != 3 || got[arnB] != 1 {
+		t.Errorf("default spillover want A=3,B=1; got A=%d,B=%d", got[arnA], got[arnB])
+	}
+}
+
+// balanced: 摊平到空位最多的 NLB, 前两个应分落 A、B(各 1), 而非都堆 A。
+func TestAllocatePolicyBalancedSpread(t *testing.T) {
+	arnA := "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/aaa/1"
+	arnB := "arn:aws:elasticloadbalancing:us-east-1:2:loadbalancer/net/bbb/2"
+	n := newNlbForPolicy()
+	p0 := n.allocate([]string{arnA, arnB}, 1, "ns/p0", allocatePolicyBalanced)
+	p1 := n.allocate([]string{arnA, arnB}, 1, "ns/p1", allocatePolicyBalanced)
+	if p0 == nil || p1 == nil {
+		t.Fatal("balanced allocate returned nil")
+	}
+	if p0.arn == p1.arn {
+		t.Errorf("balanced should spread first two pods across NLBs, both landed on %s", p0.arn)
+	}
+}
+
+// 同一端口号可分配给不同 NLB(cache 按 ARN 隔离, 不互相占用)。
+func TestSamePortDifferentNLBs(t *testing.T) {
+	arnA := "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/aaa/1"
+	arnB := "arn:aws:elasticloadbalancing:us-east-1:2:loadbalancer/net/bbb/2"
+	n := newNlbForPolicy()
+	// 用 balanced 让两个服分落 A、B, 二者首个端口都应是 minPort(951), 互不冲突
+	p0 := n.allocate([]string{arnA, arnB}, 1, "ns/p0", allocatePolicyBalanced)
+	p1 := n.allocate([]string{arnA, arnB}, 1, "ns/p1", allocatePolicyBalanced)
+	if p0 == nil || p1 == nil {
+		t.Fatal("allocate returned nil")
+	}
+	if p0.arn == p1.arn {
+		t.Fatalf("expected different NLBs, both on %s", p0.arn)
+	}
+	if p0.ports[0] != 951 || p1.ports[0] != 951 {
+		t.Errorf("same port 951 should be usable on both NLBs; got p0=%d p1=%d", p0.ports[0], p1.ports[0])
+	}
+	// 且各自 cache 独立标记
+	if !n.cache[p0.arn][951] || !n.cache[p1.arn][951] {
+		t.Errorf("port 951 should be marked occupied independently on each NLB")
 	}
 }

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -538,3 +538,52 @@ func TestAWSTargetGroupProtocol(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigHashIgnoresARNs verifies that changing the NlbARNs list does NOT
+// change configHash (so already-allocated pods are not forced to reconfigure
+// when an ARN is added/removed), while changing any other field DOES change it
+// (so legitimate config changes still trigger a reconfigure).
+func TestConfigHashIgnoresARNs(t *testing.T) {
+	base := &nlbConfig{
+		loadBalancerARNs: []string{"arn:aaa"},
+		vpcID:            "vpc-1",
+		backends:         []*backend{{targetPort: 8601, protocol: ProtocolTCPUDP}},
+		isFixed:          true,
+		healthCheck:      &healthCheck{healthCheckProtocol: ptr.To("TCP")},
+	}
+
+	// Adding an ARN must NOT change the hash.
+	addedARN := *base
+	addedARN.loadBalancerARNs = []string{"arn:aaa", "arn:bbb"}
+	if base.configHash() != addedARN.configHash() {
+		t.Errorf("configHash changed when only NlbARNs changed; adding an ARN must not reconfigure existing pods")
+	}
+
+	// A completely different ARN set must NOT change the hash either.
+	swapped := *base
+	swapped.loadBalancerARNs = []string{"arn:zzz"}
+	if base.configHash() != swapped.configHash() {
+		t.Errorf("configHash changed when only the ARN set changed")
+	}
+
+	// Changing a real field (ports) MUST change the hash.
+	changedPorts := *base
+	changedPorts.backends = []*backend{{targetPort: 9000, protocol: corev1.ProtocolTCP}}
+	if base.configHash() == changedPorts.configHash() {
+		t.Errorf("configHash did not change when backends changed; legitimate reconfigure would be missed")
+	}
+
+	// Changing health check MUST change the hash.
+	changedHC := *base
+	changedHC.healthCheck = &healthCheck{healthCheckProtocol: ptr.To("HTTP")}
+	if base.configHash() == changedHC.configHash() {
+		t.Errorf("configHash did not change when healthCheck changed")
+	}
+
+	// Changing isFixed MUST change the hash.
+	changedFixed := *base
+	changedFixed.isFixed = false
+	if base.configHash() == changedFixed.configHash() {
+		t.Errorf("configHash did not change when isFixed changed")
+	}
+}

--- a/cloudprovider/amazonswebservices/nlb_test.go
+++ b/cloudprovider/amazonswebservices/nlb_test.go
@@ -14,15 +14,24 @@ limitations under the License.
 package amazonswebservices
 
 import (
+	"context"
 	"reflect"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
 	"github.com/kr/pretty"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
 )
@@ -652,5 +661,107 @@ func TestSamePortDifferentNLBs(t *testing.T) {
 	// 且各自 cache 独立标记
 	if !n.cache[p0.arn][951] || !n.cache[p1.arn][951] {
 		t.Errorf("port 951 should be marked occupied independently on each NLB")
+	}
+}
+
+// OnPodAdded 应提前分配端口并预置 readiness gate, gate 名 == TGB 名(target-health.elbv2.k8s.aws/<pod>-<port>)。
+func TestOnPodAddedInjectsReadinessGate(t *testing.T) {
+	arn := "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/aaa/1"
+	n := newNlbForPolicy()
+	conf := `[{"name":"NlbARNs","value":"` + arn + `"},{"name":"PortProtocols","value":"8601/TCP"},{"name":"NlbVPCId","value":"vpc-1"}]`
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "gd-0",
+			Namespace:   "default",
+			Annotations: map[string]string{
+				gamekruiseiov1alpha1.GameServerNetworkType: NlbNetwork,
+				gamekruiseiov1alpha1.GameServerNetworkConf: conf,
+			},
+		},
+	}
+	got, perr := n.OnPodAdded(nil, pod, nil)
+	if perr != nil {
+		t.Fatalf("OnPodAdded error: %v", perr)
+	}
+	// 端口已分配并 pin 到 podAllocate
+	alloc, ok := n.podAllocate["default/gd-0"]
+	if !ok || alloc == nil || len(alloc.ports) != 1 {
+		t.Fatalf("expected 1 port allocated for gd-0, got %#v", alloc)
+	}
+	wantGate := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-" + intToStr(alloc.ports[0]))
+	found := false
+	for _, g := range got.Spec.ReadinessGates {
+		if g.ConditionType == wantGate {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected readiness gate %q injected, got %#v", wantGate, got.Spec.ReadinessGates)
+	}
+	// 幂等: 再调一次不应重复注入(podAllocate 已存在 → 复用, gate 不重复)
+	got2, _ := n.OnPodAdded(nil, got, nil)
+	cnt := 0
+	for _, g := range got2.Spec.ReadinessGates {
+		if g.ConditionType == wantGate {
+			cnt++
+		}
+	}
+	if cnt != 1 {
+		t.Errorf("readiness gate should be injected exactly once (idempotent), got %d", cnt)
+	}
+}
+
+func intToStr(p int32) string {
+	return strconv.Itoa(int(p))
+}
+
+// 自愈: gate False 超过阈值的 TGB 被删除并重置 TG sync 标签; 未超时的不动。
+func TestHealStuckReadinessGates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = elbv2api.AddToScheme(scheme)
+	_ = ackv1alpha1.AddToScheme(scheme)
+
+	now := metav1.Now()
+	stuckGate := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-9001") // False 已久 → 应被治
+	freshGate := corev1.PodConditionType(ReadinessGatePrefix + "gd-0-9002") // False 但很新 → 不动
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "gd-0", Namespace: "default"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+			{Type: stuckGate, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-300 * time.Second))},
+			{Type: freshGate, Status: corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(now.Add(-5 * time.Second))},
+		}},
+	}
+	mkTGB := func(name string) *elbv2api.TargetGroupBinding {
+		return &elbv2api.TargetGroupBinding{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
+	}
+	mkTG := func(name string) *ackv1alpha1.TargetGroup {
+		return &ackv1alpha1.TargetGroup{ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default",
+			Labels: map[string]string{AWSTargetGroupSyncStatus: "true"}}}
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(pod, mkTGB("gd-0-9001"), mkTG("gd-0-9001"), mkTGB("gd-0-9002"), mkTG("gd-0-9002")).Build()
+
+	n := newNlbForPolicy()
+	healed := n.healStuckReadinessGates(context.Background(), c, pod, now.Unix())
+	if healed != 1 {
+		t.Fatalf("expected 1 gate healed (only the stuck one), got %d", healed)
+	}
+	// stuck 的 TGB 被删
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0-9001", Namespace: "default"}, &elbv2api.TargetGroupBinding{}); !errors.IsNotFound(err) {
+		t.Errorf("stuck TGB gd-0-9001 should be deleted, err=%v", err)
+	}
+	// stuck 的 TG sync 标签被重置为 false
+	tg := &ackv1alpha1.TargetGroup{}
+	_ = c.Get(context.Background(), types.NamespacedName{Name: "gd-0-9001", Namespace: "default"}, tg)
+	if tg.Labels[AWSTargetGroupSyncStatus] != "false" {
+		t.Errorf("stuck TG sync label should be reset to false, got %q", tg.Labels[AWSTargetGroupSyncStatus])
+	}
+	// fresh 的 TGB 不动
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "gd-0-9002", Namespace: "default"}, &elbv2api.TargetGroupBinding{}); err != nil {
+		t.Errorf("fresh TGB gd-0-9002 should NOT be deleted, err=%v", err)
 	}
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -116,6 +116,7 @@ rules:
   - targetgroupbindings
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/pkg/controllers/gameserver/gameserver_manager.go
+++ b/pkg/controllers/gameserver/gameserver_manager.go
@@ -528,12 +528,102 @@ func (manager GameServerManager) syncNetworkStatus() gameKruiseV1alpha1.NetworkS
 	gsNetworkStatus.ExternalAddresses = podNetworkStatus.ExternalAddresses
 	gsNetworkStatus.CurrentNetworkState = podNetworkStatus.CurrentNetworkState
 
+	// Fix A: the pod's network-status annotation is only written by the mutating
+	// webhook (OnPodUpdated), which is NOT triggered by pods/status subresource
+	// writes. A cloud LB controller flips its readiness gate (and the kubelet the
+	// PodReady condition) through pods/status, so the annotation can lag behind:
+	// it may still say NotReady long after the gate became True (or vice versa).
+	// This reconciler IS triggered by pod updates (it watches Pods), so correct
+	// the lagging annotation value using the authoritative readiness-gate state.
+	//
+	// We look at the LB-managed readiness gates declared on the pod (e.g.
+	// target-health.elbv2.k8s.aws/<tgb>) rather than the aggregate PodReady,
+	// because aggregate PodReady also folds in InPlaceUpdateReady, which flips
+	// False during an in-place pod update (e.g. when an ARN is added to NlbARNs)
+	// and would otherwise flap an already-reachable GameServer. The LB gates
+	// reflect real backend reachability and are unaffected by in-place updates.
+	//
+	// Only act once the network has actually been provisioned (external
+	// addresses exist), so we never override the early "resources not created
+	// yet" phase.
+	if len(podNetworkStatus.ExternalAddresses) > 0 {
+		switch lbReadinessGatesState(manager.pod) {
+		case gateAllTrue:
+			gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkReady
+		case gateAnyFalse:
+			gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkNotReady
+		case gateNone:
+			// No LB readiness gate on this pod (e.g. provider doesn't use gates) —
+			// keep the annotation-derived value untouched.
+		}
+	}
+
 	if gsNetworkStatus.DesiredNetworkState != desiredNetworkState(nm.GetNetworkDisabled()) {
 		gsNetworkStatus.DesiredNetworkState = desiredNetworkState(nm.GetNetworkDisabled())
 		gsNetworkStatus.LastTransitionTime = metav1.Now()
 	}
 
 	return gsNetworkStatus
+}
+
+// lbReadinessGateState summarises the cloud-LB-managed readiness gates on a pod.
+type lbReadinessGateState int
+
+const (
+	gateNone     lbReadinessGateState = iota // pod declares no LB readiness gate
+	gateAllTrue                              // all LB readiness gates are True
+	gateAnyFalse                             // at least one LB readiness gate is not True
+)
+
+// lbReadinessGatePrefixes are the readiness-gate condition-type prefixes used by
+// cloud load-balancer controllers to signal real backend reachability. These are
+// what cloud providers (e.g. the AWS Load Balancer Controller) flip True only once
+// the LB target is actually healthy. We deliberately exclude Kruise's own
+// InPlaceUpdateReady / KruisePodReady gates, which flip during in-place pod updates
+// and do not reflect backend reachability.
+var lbReadinessGatePrefixes = []string{
+	"target-health.elbv2.k8s.aws/",        // AWS Load Balancer Controller
+	"service.readiness.alibabacloud.com/", // Alibaba Cloud (auto_nlbs / multi_nlbs)
+}
+
+func isLbReadinessGate(t corev1.PodConditionType) bool {
+	for _, p := range lbReadinessGatePrefixes {
+		if strings.HasPrefix(string(t), p) {
+			return true
+		}
+	}
+	return false
+}
+
+// lbReadinessGatesState inspects the pod's declared readiness gates and their
+// current conditions, returning whether the LB-managed gates are all True, any
+// not-True, or absent. Only gates declared in pod.Spec.ReadinessGates are
+// considered, so providers that don't use gates yield gateNone.
+func lbReadinessGatesState(pod *corev1.Pod) lbReadinessGateState {
+	if pod == nil {
+		return gateNone
+	}
+	// Collect the LB readiness gates the pod declares.
+	declared := make(map[corev1.PodConditionType]bool)
+	for _, g := range pod.Spec.ReadinessGates {
+		if isLbReadinessGate(g.ConditionType) {
+			declared[g.ConditionType] = true
+		}
+	}
+	if len(declared) == 0 {
+		return gateNone
+	}
+	// Index the pod's current conditions.
+	condStatus := make(map[corev1.PodConditionType]corev1.ConditionStatus, len(pod.Status.Conditions))
+	for _, c := range pod.Status.Conditions {
+		condStatus[c.Type] = c.Status
+	}
+	for t := range declared {
+		if condStatus[t] != corev1.ConditionTrue {
+			return gateAnyFalse
+		}
+	}
+	return gateAllTrue
 }
 
 func desiredNetworkState(disabled bool) gameKruiseV1alpha1.NetworkState {

--- a/pkg/controllers/gameserver/gameserver_manager_test.go
+++ b/pkg/controllers/gameserver/gameserver_manager_test.go
@@ -1420,3 +1420,67 @@ func TestSyncPodToGs(t *testing.T) {
 		}
 	}
 }
+
+func TestLbReadinessGatesState(t *testing.T) {
+	gate := "target-health.elbv2.k8s.aws/gs-0-9001"
+	mkPod := func(gates []string, conds map[string]corev1.ConditionStatus) *corev1.Pod {
+		p := &corev1.Pod{}
+		for _, g := range gates {
+			p.Spec.ReadinessGates = append(p.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(g)})
+		}
+		for t, s := range conds {
+			p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+				Type: corev1.PodConditionType(t), Status: s})
+		}
+		return p
+	}
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want lbReadinessGateState
+	}{
+		{
+			name: "no LB gate declared -> gateNone (only Kruise gates)",
+			pod:  mkPod([]string{"InPlaceUpdateReady", "KruisePodReady"}, map[string]corev1.ConditionStatus{"Ready": corev1.ConditionTrue}),
+			want: gateNone,
+		},
+		{
+			name: "LB gate True -> gateAllTrue",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{gate: corev1.ConditionTrue}),
+			want: gateAllTrue,
+		},
+		{
+			name: "LB gate False -> gateAnyFalse",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{gate: corev1.ConditionFalse}),
+			want: gateAnyFalse,
+		},
+		{
+			name: "LB gate missing condition -> gateAnyFalse",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{}),
+			want: gateAnyFalse,
+		},
+		{
+			// The S4/InPlace case: InPlaceUpdateReady flips False but the LB gate
+			// stays True -> we must report gateAllTrue (do NOT flap to NotReady).
+			name: "InPlace flips InPlaceUpdateReady False but LB gate True -> gateAllTrue",
+			pod: mkPod([]string{"InPlaceUpdateReady", gate}, map[string]corev1.ConditionStatus{
+				"InPlaceUpdateReady": corev1.ConditionFalse,
+				gate:                 corev1.ConditionTrue,
+			}),
+			want: gateAllTrue,
+		},
+		{
+			name: "nil pod -> gateNone",
+			pod:  nil,
+			want: gateNone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lbReadinessGatesState(tt.pod); got != tt.want {
+				t.Errorf("lbReadinessGatesState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/gameserver/gameserver_manager_test.go
+++ b/pkg/controllers/gameserver/gameserver_manager_test.go
@@ -1484,3 +1484,128 @@ func TestLbReadinessGatesState(t *testing.T) {
 		})
 	}
 }
+
+// TestSyncNetworkStatus_LbReadinessGate covers the patch added to
+// syncNetworkStatus that overrides the annotation-derived CurrentNetworkState
+// based on the authoritative LB-managed readiness-gate state.
+//
+// The pre-existing TestSyncNetworkStatus only exercises pods without any LB
+// readiness gate, so it stays in the gateNone branch (no override). This test
+// pins the two override branches:
+//
+//   - gateAllTrue  -> CurrentNetworkState forced to NetworkReady,
+//     even when the annotation lags behind (still says NotReady).
+//   - gateAnyFalse -> CurrentNetworkState forced to NetworkNotReady,
+//     even when the annotation lags behind (still says Ready).
+//
+// And the guard "only act once externalAddresses are non-empty":
+//
+//   - gate True but no external addresses yet -> no override (early phase).
+func TestSyncNetworkStatus_LbReadinessGate(t *testing.T) {
+	const lbGate = "target-health.elbv2.k8s.aws/gs-0-9001"
+	// network-status JSON helpers: with vs. without external addresses, with
+	// CurrentNetworkState=NotReady or Ready (to prove the override).
+	statusWithExternal := func(state string) string {
+		return `{"internalAddresses":[{"ip":"10.0.0.1","ports":[{"name":"80","protocol":"TCP","port":80}]}],` +
+			`"externalAddresses":[{"ip":"1.2.3.4","ports":[{"name":"80","protocol":"TCP","port":601}]}],` +
+			`"currentNetworkState":"` + state + `","createTime":null,"lastTransitionTime":null}`
+	}
+	statusNoExternal := func(state string) string {
+		return `{"internalAddresses":[{"ip":"10.0.0.1","ports":[{"name":"80","protocol":"TCP","port":80}]}],` +
+			`"currentNetworkState":"` + state + `","createTime":null,"lastTransitionTime":null}`
+	}
+
+	mkPod := func(annStatus string, gates []string, conds map[string]corev1.ConditionStatus) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					gameKruiseV1alpha1.GameServerNetworkType:     "AmazonWebServices-NLB",
+					gameKruiseV1alpha1.GameServerNetworkConf:     `[{"name":"NlbARNs","value":"arn:foo"},{"name":"PortProtocols","value":"80"}]`,
+					gameKruiseV1alpha1.GameServerNetworkDisabled: "false",
+					gameKruiseV1alpha1.GameServerNetworkStatus:   annStatus,
+				},
+			},
+		}
+		for _, g := range gates {
+			p.Spec.ReadinessGates = append(p.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(g),
+			})
+		}
+		for typ, st := range conds {
+			p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+				Type: corev1.PodConditionType(typ), Status: st,
+			})
+		}
+		return p
+	}
+
+	// Build a minimal GameServer whose existing NetworkStatus is non-empty so
+	// syncNetworkStatus skips its "init" branch and reaches the override.
+	mkGs := func() *gameKruiseV1alpha1.GameServer {
+		return &gameKruiseV1alpha1.GameServer{
+			Status: gameKruiseV1alpha1.GameServerStatus{
+				NetworkStatus: gameKruiseV1alpha1.NetworkStatus{
+					NetworkType:         "AmazonWebServices-NLB",
+					DesiredNetworkState: gameKruiseV1alpha1.NetworkReady,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		annStatus string
+		gates     []string
+		conds     map[string]corev1.ConditionStatus
+		want      gameKruiseV1alpha1.NetworkState
+	}{
+		{
+			// Annotation lags as NotReady (kubelet flipped the gate True via
+			// pods/status, which doesn't re-trigger the mutating webhook). The
+			// override must lift CurrentNetworkState back to Ready.
+			name:      "gateAllTrue with external addresses overrides lagging NotReady -> Ready",
+			annStatus: statusWithExternal("NotReady"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionTrue},
+			want:      gameKruiseV1alpha1.NetworkReady,
+		},
+		{
+			// Annotation lags as Ready while the LB gate is now False (target
+			// went unhealthy). The override must drop CurrentNetworkState back
+			// to NotReady.
+			name:      "gateAnyFalse with external addresses overrides lagging Ready -> NotReady",
+			annStatus: statusWithExternal("Ready"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionFalse},
+			want:      gameKruiseV1alpha1.NetworkNotReady,
+		},
+		{
+			// Early phase: external addresses not yet populated. The override
+			// must NOT fire — we keep the annotation-derived value untouched
+			// even if the (gameless) LB gate happens to be True.
+			name:      "gateAllTrue but no external addresses -> no override",
+			annStatus: statusNoExternal("NotReady"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionTrue},
+			want:      gameKruiseV1alpha1.NetworkNotReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gs := mkGs()
+			pod := mkPod(tt.annStatus, tt.gates, tt.conds)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gs, pod).Build()
+			manager := &GameServerManager{
+				client:     c,
+				gameServer: gs,
+				pod:        pod,
+				logger:     testr.New(t),
+			}
+			got := manager.syncNetworkStatus()
+			if got.CurrentNetworkState != tt.want {
+				t.Errorf("CurrentNetworkState = %q, want %q", got.CurrentNetworkState, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -83,7 +83,7 @@ func init() {
 // +kubebuilder:rbac:groups=alibabacloud.com,resources=podeips,verbs=get;list;watch
 // +kubebuilder:rbac:groups=alibabacloud.com,resources=podeips/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=elbv2.k8s.aws,resources=targetgroupbindings,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=elbv2.k8s.aws,resources=targetgroupbindings,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=listeners,verbs=create;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=targetgroups,verbs=create;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=networking.cloud.tencent.com,resources=dedicatedclblisteners,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
# AWS NLB 插件：多 NLB 动态 ARN、readiness 闭环与一系列连带问题修复

## 背景

OKG 的 AWS NLB 插件在生产中被多个游戏团队跨多 NLB 大规模使用，过去一段时间暴露出一组互相关联的问题。本 PR 把这些问题及对应修复整合在一个分支上提交，主要解决以下五类问题：

1. **多 NLB / 动态 ARN 支持不完整**：AWS NLB 单个 LB 硬性上限 50 个 listener，单个 GameServerSet 超过 50 副本时无法继续扩容；运行时无法在不重建已有 pod 的前提下新增 NLB ARN。
2. **端口分配策略单一**：缺少跨 NLB 的可选分配策略（先填满后溢出 / 跨 NLB 摊平），无法适配不同故障域偏好。
3. **readiness 判定不可靠**：Service / TargetGroupBinding 创建完毕并不代表 NLB target 已健康；遇到 Pod IP 复用还会触发 AWS Load Balancer Controller 的 ghost registration（target 永远停留在 draining，gate 永远 False），插件没有自愈路径。
4. **InPlace 更新误判 NetworkState**：在已 Ready 的 GSS 上新增 NLB ARN 会触发 ASTS 的 InPlace 更新，导致已健康 pod 的 InPlaceUpdateReady 短暂 False；老逻辑会因此把 GameServer.networkStatus 误置为 NotReady，且由于恢复路径走的是 pods/status 子资源（不会触发 webhook），GameServer 永久卡死在 NotReady。
5. **若干连带 bug**：`controllerutil.CreateOrUpdate` 误传空 mutate 函数导致期望状态不写入；网络配置缺乏校验；`Fixed=true` 模式下"先 scale=0 → 再 delete gss"会让控制器内存里的 NLB 端口 cache 永久泄漏，下一次创建同 NLB 的 GSS 被 webhook 以 `no NLB has N enough available ports` 拒绝。

---

## 主要变更（按主题归类）

### 1. 多 NLB / 动态 ARN 支持

- `feat(aws-nlb): allow adding NLB ARN at runtime without resetting existing pods`
  - `configHash()` 故意排除 `NlbARNs` 列表：新增 / 替换 ARN 不触发已分配 pod 的重配置；只有真正影响 listener 配置的字段（端口、协议、健康检查、`Fixed`、annotations）变化才触发。
- `feat(aws-nlb): add AllocatePolicy (default/balanced) for multi-NLB allocation`
  - `default`（first-fit 溢出）：按 `NlbARNs` 列表顺序，把第一个 NLB 填满再用下一个，与原行为兼容。
  - `balanced`（摊平）：选当前剩余空闲端口最多的 NLB，让游戏服跨 NLB 摊平做故障域隔离（移植自 alibabacloud `multi_nlbs` 策略）。

### 2. Readiness gate 闭环 + ghost registration 自愈

- `feat(aws-nlb): readiness gating + ghost-registration self-heal`
  - 在 `OnPodAdded` 阶段提前注入 readiness gate `target-health.elbv2.k8s.aws/<TGB>`，由 AWS Load Balancer Controller 在 target 真正 healthy 后置 True，pod 才进入 Ready。Service/TGB 创建完毕不再被当作 ready 信号。
  - 当 gate 长期 False（默认 90s 阈值）时识别为 ghost registration（Pod IP 被复用且仍在另一 TG 中 draining），主动删 TGB 重建并重置 TG sync 标签触发重新注册，打破死锁。
- `fix(aws-nlb): refresh pod status from API server before readiness gate check`
  - 避免使用 informer 缓存中过期的 pod status 做 readiness 判定。
- `fix(aws-nlb): don't re-gate an already-ready pod on unrelated updates`
  - 已 NetworkReady 且 configHash 未变化的 pod，OnPodUpdated 直接早退，不再走 readiness gate 检查；规避 InPlace 更新（如增加 ARN）让 InPlaceUpdateReady 短暂 False 误把健康 pod 拉到 NetworkNotReady。
- `fix(gameserver): reconcile networkState from LB readiness gates, not just the lagging annotation`
  - Pod 上的 `network-status` annotation 仅由 webhook 写，pods/status 翻转 LB gate 不触发 webhook，annotation 会滞后。GameServer 控制器改为读 LB-managed readiness gate（`target-health.elbv2.k8s.aws/`、`service.readiness.alibabacloud.com/`，**故意排除** Kruise 自己的 `InPlaceUpdateReady` / `KruisePodReady`）来校正 networkState，避免 NotReady 卡死。

### 3. 连带 bug 修复

- `fix(cloudprovider): validate AWS NLB network config and reject invalid values`
  - 在 webhook 阶段校验 `networkConf`：端口范围、协议合法性、健康检查参数边界等，不合法直接拒绝创建。
- `fix: NLB syncTargetGroupAndService / syncListenerAndTargetGroupBinding CreateOrUpdate uses empty mutate func`
  - `controllerutil.CreateOrUpdate` 传空 mutate 函数时期望状态不会被写入；改成在 mutate 中重新构造完整 spec。
- 来自 yubingjiaocn/kruise-game 的两个 fix 已合并（healthcheck-ip-default / createorupdate-empty-mutate）。

### 4. 单元测试

- `test(aws-nlb): cover multi-port gates, non-NLB guard, and self-heal false-positives`
- `test(aws-nlb): add unit tests for OnPodDeleted and getOwnerReference`
  - 把先前完全无单测的两个核心函数（`OnPodDeleted`、`getOwnerReference`）的所有分支锁定（4 + 3 = 7 个 sub-test），断言同时检查 `podAllocate` map 与 per-NLB 端口位图，并显式验证"不会误释放无关 GSS 的 pod"。

### 5. 文档

- `docs(aws-nlb): document Fixed=true cache-leak scenario and 6 test cases`
  - 新增 `docs/issues/aws-nlb-plugin-cases.md`，包含：
    - **Scenario 1**：`Fixed=true` 下"先 scale=0 → 再 delete gss"导致控制器内存 cache 泄漏的完整调查（一句话现象 / 必要充分触发条件 / 影响面 / 已实测复现步骤 / 临时规避 / 根因分析（含源码行号引用）/ 建议修复方向（方案 A：新增 `OnGameServerSetDeleted` 回调，附示例代码）/ 兼容性回归注意事项 / 运维侧检测方法 / `Fixed` 语义矩阵 / 反向验证）
    - **Test Case Catalog**：6 个回归测试用例 TC-01..TC-06 + 测试技巧 TC-A，覆盖 Fixed=true / Fixed=false 单 NLB baseline、Fixed=true / Fixed=false scale-down、运行时新增 NLB ARN 零中断扩容、双 GSS 共享 NLB 的 first-fit 溢出，以及 NLB UDP 在同 VPC 时的 hairpin 限制及规避方法

---

## 测试与验证

### 单元测试

- `go test ./cloudprovider/amazonswebservices/...` 全部通过（含 17 个原有测试 + 7 个新增 sub-test）
- `go test ./pkg/controllers/gameserver/...` 全部通过

### 端到端实测（EKS，region=ap-east-2，2 个 internet-facing NLB）

- `Fixed=true` 40 副本部署 + 全 40 端口 TCP/UDP 连通性 ✓
- `Fixed=false` 40 副本部署 + 全 40 端口 TCP/UDP 连通性 ✓
- `Fixed=true` scale-down 40→35 端口槽位完整保留（fixed-IP 语义） ✓
- `Fixed=false` scale-down 40→35 端口立即释放（5 条 deallocate 日志） ✓
- 运行中扩容并新增 NLB ARN（35 → 55，单 NLB → 双 NLB）：35 个老 pod 的 NLB target health gate / Service / TGB / AWS target IP / readyReplicas **零扰动** ✓
- 双 GSS 共享 `kruise-game-nlb`：先创建 GSS A（40 副本，仅 nlb1，9001-9040），后创建 GSS B（30 副本，nlb1+nlb2）——GSS B 前 10 个 pod 填到 nlb1 9041-9050，溢出 20 个到 nlb2 9001-9020，70 个外部端点 TCP 70/70、UDP 70/70 ✓
- Scenario 1 复现 + Fixed=false 反向验证：在 `Fixed=true` 下复现 cache 泄漏触发 webhook 拒绝；切到 `Fixed=false` 跑同样序列，控制器立即触发 40 条 deallocate 日志，cache 干净，下一个 GSS 直接创建成功 ✓

详细数据见 `docs/issues/aws-nlb-plugin-cases.md`。

---

## 兼容性 / 升级注意事项

- **默认行为不变**：`AllocatePolicy` 默认 `default`（first-fit），与原有单 NLB 行为完全等价；不显式配置 `AllocatePolicy` 时升级无感知。
- **`Fixed=true` 老语义保留**：本 PR 不改 `Fixed=true` 的端口绑定语义，scale-down 仍保留端口槽位（用于 scale-up 复用）。Scenario 1 cache 泄漏 bug 的修复留作后续 PR（建议方案见 docs §1.7），运维侧规避见 docs §1.5（重启 controller）。
- **配置校验加严**：原本能创建出来的非法 `networkConf`（端口越界、协议不识别、`healthCheckEnabled=false`、间隔/阈值越界等）现在会被 webhook 拒绝。建议升级前用 `kubectl get gss -A -o yaml | yq '.items[] | .spec.network'` 抽查现有 GSS。
- **新增 RBAC**：`config/rbac/role.yaml` 多了一项权限（用于自愈路径删除 TGB）。

---

Closes #358 
Closes #348 