### PR TITLE
fix(gameserver): reconcile networkState from LB readiness gates, not just the lagging annotation

### DIFF
--- a/pkg/controllers/gameserver/gameserver_manager.go
+++ b/pkg/controllers/gameserver/gameserver_manager.go
@@ -528,12 +528,102 @@ func (manager GameServerManager) syncNetworkStatus() gameKruiseV1alpha1.NetworkS
 	gsNetworkStatus.ExternalAddresses = podNetworkStatus.ExternalAddresses
 	gsNetworkStatus.CurrentNetworkState = podNetworkStatus.CurrentNetworkState
 
+	// Fix A: the pod's network-status annotation is only written by the mutating
+	// webhook (OnPodUpdated), which is NOT triggered by pods/status subresource
+	// writes. A cloud LB controller flips its readiness gate (and the kubelet the
+	// PodReady condition) through pods/status, so the annotation can lag behind:
+	// it may still say NotReady long after the gate became True (or vice versa).
+	// This reconciler IS triggered by pod updates (it watches Pods), so correct
+	// the lagging annotation value using the authoritative readiness-gate state.
+	//
+	// We look at the LB-managed readiness gates declared on the pod (e.g.
+	// target-health.elbv2.k8s.aws/<tgb>) rather than the aggregate PodReady,
+	// because aggregate PodReady also folds in InPlaceUpdateReady, which flips
+	// False during an in-place pod update (e.g. when an ARN is added to NlbARNs)
+	// and would otherwise flap an already-reachable GameServer. The LB gates
+	// reflect real backend reachability and are unaffected by in-place updates.
+	//
+	// Only act once the network has actually been provisioned (external
+	// addresses exist), so we never override the early "resources not created
+	// yet" phase.
+	if len(podNetworkStatus.ExternalAddresses) > 0 {
+		switch lbReadinessGatesState(manager.pod) {
+		case gateAllTrue:
+			gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkReady
+		case gateAnyFalse:
+			gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkNotReady
+		case gateNone:
+			// No LB readiness gate on this pod (e.g. provider doesn't use gates) —
+			// keep the annotation-derived value untouched.
+		}
+	}
+
 	if gsNetworkStatus.DesiredNetworkState != desiredNetworkState(nm.GetNetworkDisabled()) {
 		gsNetworkStatus.DesiredNetworkState = desiredNetworkState(nm.GetNetworkDisabled())
 		gsNetworkStatus.LastTransitionTime = metav1.Now()
 	}
 
 	return gsNetworkStatus
+}
+
+// lbReadinessGateState summarises the cloud-LB-managed readiness gates on a pod.
+type lbReadinessGateState int
+
+const (
+	gateNone     lbReadinessGateState = iota // pod declares no LB readiness gate
+	gateAllTrue                              // all LB readiness gates are True
+	gateAnyFalse                             // at least one LB readiness gate is not True
+)
+
+// lbReadinessGatePrefixes are the readiness-gate condition-type prefixes used by
+// cloud load-balancer controllers to signal real backend reachability. These are
+// what cloud providers (e.g. the AWS Load Balancer Controller) flip True only once
+// the LB target is actually healthy. We deliberately exclude Kruise's own
+// InPlaceUpdateReady / KruisePodReady gates, which flip during in-place pod updates
+// and do not reflect backend reachability.
+var lbReadinessGatePrefixes = []string{
+	"target-health.elbv2.k8s.aws/",        // AWS Load Balancer Controller
+	"service.readiness.alibabacloud.com/", // Alibaba Cloud (auto_nlbs / multi_nlbs)
+}
+
+func isLbReadinessGate(t corev1.PodConditionType) bool {
+	for _, p := range lbReadinessGatePrefixes {
+		if strings.HasPrefix(string(t), p) {
+			return true
+		}
+	}
+	return false
+}
+
+// lbReadinessGatesState inspects the pod's declared readiness gates and their
+// current conditions, returning whether the LB-managed gates are all True, any
+// not-True, or absent. Only gates declared in pod.Spec.ReadinessGates are
+// considered, so providers that don't use gates yield gateNone.
+func lbReadinessGatesState(pod *corev1.Pod) lbReadinessGateState {
+	if pod == nil {
+		return gateNone
+	}
+	// Collect the LB readiness gates the pod declares.
+	declared := make(map[corev1.PodConditionType]bool)
+	for _, g := range pod.Spec.ReadinessGates {
+		if isLbReadinessGate(g.ConditionType) {
+			declared[g.ConditionType] = true
+		}
+	}
+	if len(declared) == 0 {
+		return gateNone
+	}
+	// Index the pod's current conditions.
+	condStatus := make(map[corev1.PodConditionType]corev1.ConditionStatus, len(pod.Status.Conditions))
+	for _, c := range pod.Status.Conditions {
+		condStatus[c.Type] = c.Status
+	}
+	for t := range declared {
+		if condStatus[t] != corev1.ConditionTrue {
+			return gateAnyFalse
+		}
+	}
+	return gateAllTrue
 }
 
 func desiredNetworkState(disabled bool) gameKruiseV1alpha1.NetworkState {

--- a/pkg/controllers/gameserver/gameserver_manager_test.go
+++ b/pkg/controllers/gameserver/gameserver_manager_test.go
@@ -1420,3 +1420,67 @@ func TestSyncPodToGs(t *testing.T) {
 		}
 	}
 }
+
+func TestLbReadinessGatesState(t *testing.T) {
+	gate := "target-health.elbv2.k8s.aws/gs-0-9001"
+	mkPod := func(gates []string, conds map[string]corev1.ConditionStatus) *corev1.Pod {
+		p := &corev1.Pod{}
+		for _, g := range gates {
+			p.Spec.ReadinessGates = append(p.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(g)})
+		}
+		for t, s := range conds {
+			p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+				Type: corev1.PodConditionType(t), Status: s})
+		}
+		return p
+	}
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want lbReadinessGateState
+	}{
+		{
+			name: "no LB gate declared -> gateNone (only Kruise gates)",
+			pod:  mkPod([]string{"InPlaceUpdateReady", "KruisePodReady"}, map[string]corev1.ConditionStatus{"Ready": corev1.ConditionTrue}),
+			want: gateNone,
+		},
+		{
+			name: "LB gate True -> gateAllTrue",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{gate: corev1.ConditionTrue}),
+			want: gateAllTrue,
+		},
+		{
+			name: "LB gate False -> gateAnyFalse",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{gate: corev1.ConditionFalse}),
+			want: gateAnyFalse,
+		},
+		{
+			name: "LB gate missing condition -> gateAnyFalse",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{}),
+			want: gateAnyFalse,
+		},
+		{
+			// The S4/InPlace case: InPlaceUpdateReady flips False but the LB gate
+			// stays True -> we must report gateAllTrue (do NOT flap to NotReady).
+			name: "InPlace flips InPlaceUpdateReady False but LB gate True -> gateAllTrue",
+			pod: mkPod([]string{"InPlaceUpdateReady", gate}, map[string]corev1.ConditionStatus{
+				"InPlaceUpdateReady": corev1.ConditionFalse,
+				gate:                 corev1.ConditionTrue,
+			}),
+			want: gateAllTrue,
+		},
+		{
+			name: "nil pod -> gateNone",
+			pod:  nil,
+			want: gateNone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lbReadinessGatesState(tt.pod); got != tt.want {
+				t.Errorf("lbReadinessGatesState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/gameserver/gameserver_manager_test.go
+++ b/pkg/controllers/gameserver/gameserver_manager_test.go
@@ -1484,3 +1484,128 @@ func TestLbReadinessGatesState(t *testing.T) {
 		})
 	}
 }
+
+// TestSyncNetworkStatus_LbReadinessGate covers the patch added to
+// syncNetworkStatus that overrides the annotation-derived CurrentNetworkState
+// based on the authoritative LB-managed readiness-gate state.
+//
+// The pre-existing TestSyncNetworkStatus only exercises pods without any LB
+// readiness gate, so it stays in the gateNone branch (no override). This test
+// pins the two override branches:
+//
+//   - gateAllTrue  -> CurrentNetworkState forced to NetworkReady,
+//     even when the annotation lags behind (still says NotReady).
+//   - gateAnyFalse -> CurrentNetworkState forced to NetworkNotReady,
+//     even when the annotation lags behind (still says Ready).
+//
+// And the guard "only act once externalAddresses are non-empty":
+//
+//   - gate True but no external addresses yet -> no override (early phase).
+func TestSyncNetworkStatus_LbReadinessGate(t *testing.T) {
+	const lbGate = "target-health.elbv2.k8s.aws/gs-0-9001"
+	// network-status JSON helpers: with vs. without external addresses, with
+	// CurrentNetworkState=NotReady or Ready (to prove the override).
+	statusWithExternal := func(state string) string {
+		return `{"internalAddresses":[{"ip":"10.0.0.1","ports":[{"name":"80","protocol":"TCP","port":80}]}],` +
+			`"externalAddresses":[{"ip":"1.2.3.4","ports":[{"name":"80","protocol":"TCP","port":601}]}],` +
+			`"currentNetworkState":"` + state + `","createTime":null,"lastTransitionTime":null}`
+	}
+	statusNoExternal := func(state string) string {
+		return `{"internalAddresses":[{"ip":"10.0.0.1","ports":[{"name":"80","protocol":"TCP","port":80}]}],` +
+			`"currentNetworkState":"` + state + `","createTime":null,"lastTransitionTime":null}`
+	}
+
+	mkPod := func(annStatus string, gates []string, conds map[string]corev1.ConditionStatus) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					gameKruiseV1alpha1.GameServerNetworkType:     "AmazonWebServices-NLB",
+					gameKruiseV1alpha1.GameServerNetworkConf:     `[{"name":"NlbARNs","value":"arn:foo"},{"name":"PortProtocols","value":"80"}]`,
+					gameKruiseV1alpha1.GameServerNetworkDisabled: "false",
+					gameKruiseV1alpha1.GameServerNetworkStatus:   annStatus,
+				},
+			},
+		}
+		for _, g := range gates {
+			p.Spec.ReadinessGates = append(p.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(g),
+			})
+		}
+		for typ, st := range conds {
+			p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+				Type: corev1.PodConditionType(typ), Status: st,
+			})
+		}
+		return p
+	}
+
+	// Build a minimal GameServer whose existing NetworkStatus is non-empty so
+	// syncNetworkStatus skips its "init" branch and reaches the override.
+	mkGs := func() *gameKruiseV1alpha1.GameServer {
+		return &gameKruiseV1alpha1.GameServer{
+			Status: gameKruiseV1alpha1.GameServerStatus{
+				NetworkStatus: gameKruiseV1alpha1.NetworkStatus{
+					NetworkType:         "AmazonWebServices-NLB",
+					DesiredNetworkState: gameKruiseV1alpha1.NetworkReady,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		annStatus string
+		gates     []string
+		conds     map[string]corev1.ConditionStatus
+		want      gameKruiseV1alpha1.NetworkState
+	}{
+		{
+			// Annotation lags as NotReady (kubelet flipped the gate True via
+			// pods/status, which doesn't re-trigger the mutating webhook). The
+			// override must lift CurrentNetworkState back to Ready.
+			name:      "gateAllTrue with external addresses overrides lagging NotReady -> Ready",
+			annStatus: statusWithExternal("NotReady"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionTrue},
+			want:      gameKruiseV1alpha1.NetworkReady,
+		},
+		{
+			// Annotation lags as Ready while the LB gate is now False (target
+			// went unhealthy). The override must drop CurrentNetworkState back
+			// to NotReady.
+			name:      "gateAnyFalse with external addresses overrides lagging Ready -> NotReady",
+			annStatus: statusWithExternal("Ready"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionFalse},
+			want:      gameKruiseV1alpha1.NetworkNotReady,
+		},
+		{
+			// Early phase: external addresses not yet populated. The override
+			// must NOT fire — we keep the annotation-derived value untouched
+			// even if the (gameless) LB gate happens to be True.
+			name:      "gateAllTrue but no external addresses -> no override",
+			annStatus: statusNoExternal("NotReady"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionTrue},
+			want:      gameKruiseV1alpha1.NetworkNotReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gs := mkGs()
+			pod := mkPod(tt.annStatus, tt.gates, tt.conds)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gs, pod).Build()
+			manager := &GameServerManager{
+				client:     c,
+				gameServer: gs,
+				pod:        pod,
+				logger:     testr.New(t),
+			}
+			got := manager.syncNetworkStatus()
+			if got.CurrentNetworkState != tt.want {
+				t.Errorf("CurrentNetworkState = %q, want %q", got.CurrentNetworkState, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Background

This PR is **split out from #359** (which was merged in `a156c64` then reverted in #360 per maintainer feedback) to land the GameServer-controller change independently of the AWS NLB plugin change. The two are logically separable:

- **This PR** changes `pkg/controllers/gameserver/gameserver_manager.go` only — a generic fix that applies to any cloud provider that injects a pod readiness gate (currently AWS NLB and AlibabaCloud auto_nlbs / multi_nlbs).
- **The companion PR** carries the AWS NLB plugin work.

## Problem

The pod's `network-status` annotation is written **only** by the mutating webhook (`OnPodUpdated`), which is *not* triggered by `pods/status` subresource writes. A cloud LB controller flips its readiness gate (e.g. `target-health.elbv2.k8s.aws/<TGB>`) through `pods/status` once the backend target is healthy, so the annotation can stay `NotReady` long after the target is actually reachable.

The GameServer reconciler already watches Pods (so it IS triggered by that gate flip), but `syncNetworkStatus` only copied the lagging annotation value → the GameServer stayed `NotReady` until some unrelated `pods` UPDATE happened to re-run the webhook.

## Fix

Correct the lagging annotation value using the LB readiness gates declared on the pod:

- All True → `NetworkReady`
- Any not-True → `NetworkNotReady`
- None declared → leave the annotation value untouched (providers without gates are unaffected)

Look at the **LB gates specifically**, NOT the aggregate `PodReady`: `PodReady` also folds in Kruise's `InPlaceUpdateReady`, which flips False during an in-place pod update (e.g. adding an ARN to NlbARNs) and would otherwise falsely flap an already-reachable GameServer to `NotReady`. LB gates reflect real backend reachability and are unaffected by in-place updates.

This patch only touches `GameServer.Status.NetworkState`; it never touches the pod, Service, TargetGroupBinding, or any cloud API, so player connections are unaffected.

LB gate prefixes recognised:

- `target-health.elbv2.k8s.aws/` — AWS Load Balancer Controller
- `service.readiness.alibabacloud.com/` — Alibaba Cloud (auto_nlbs / multi_nlbs)

Kruise's own `InPlaceUpdateReady` / `KruisePodReady` are deliberately excluded.

## Tests

- `TestLbReadinessGatesState` pins all branches: `gateNone` / `gateAllTrue` / `gateAnyFalse`, including the **S4/InPlace case** (LB gate True while `InPlaceUpdateReady` False → still `gateAllTrue`, no false flap).
- `TestSyncNetworkStatus_LbReadinessGate` covers the override paths in `syncNetworkStatus`: `gateAllTrue` lifts a lagging `NotReady` to `Ready`, `gateAnyFalse` drops a lagging `Ready` to `NotReady`, and the no-external-addresses guard leaves state untouched (no override during the early "resources not created yet" phase).

```
$ go test ./pkg/controllers/gameserver/...
ok      github.com/openkruise/kruise-game/pkg/controllers/gameserver    1.272s
```

## E2E evidence (re-run on the original #359 build, with `gs.status.networkStatus.currentNetworkState` polled at 1s intervals)

In the **TC-05 scenario** — patch a running 35-replica GSS to add a second NLB ARN and scale 35→55 — the 35 *old* pods' `currentNetworkState` stayed `Ready` for the entire patch window (zero transient `NotReady`):

```
35 (Ready)             ← initial
35 + 1 null            ← first new pod created after the patch
35 + 7 null
...
35 + 20 null           ← all 20 new pods created
35 + 18 null + 2 NotReady   ← new pods entering NotReady (gate still False)
...
35 + 20 NotReady       ← all 20 new pods NotReady (gate False)
38 + 17 NotReady       ← new pods start flipping to Ready
...
55                     ← fully ready
```

The 35 old pods' Ready count never dropped below 35 throughout the entire patch window, demonstrating that this fix together with the companion `OnPodUpdated` early-return in the AWS NLB plugin works as designed: the InPlace transient `InPlaceUpdateReady=False` did **not** propagate into `gs.networkStatus.currentNetworkState=NotReady` for already-Ready pods.

## Compatibility

- No-op for any provider that does not declare LB readiness gates on its pods (e.g. Kubernetes-HostPort, Kubernetes-Ingress).
- Only acts once `externalAddresses` is non-empty, so the "resources not created yet" early phase is unchanged.

Companion PR (AWS NLB plugin): coming separately, see commit `c399868` of `feat/aws-nlb-multi-arn-and-readiness`.

Original PR: #359
Revert PR: #360

Signed-off-by: zhangzhenhuajack <zhangzhenhua846@126.com>
