### PR TITLE
fix(gameserver): reconcile NetworkState from LB readiness gates (companion to #363)

### DIFF
--- a/pkg/controllers/gameserver/gameserver_manager.go
+++ b/pkg/controllers/gameserver/gameserver_manager.go
@@ -528,12 +528,102 @@ func (manager GameServerManager) syncNetworkStatus() gameKruiseV1alpha1.NetworkS
 	gsNetworkStatus.ExternalAddresses = podNetworkStatus.ExternalAddresses
 	gsNetworkStatus.CurrentNetworkState = podNetworkStatus.CurrentNetworkState
 
+	// Fix A: the pod's network-status annotation is only written by the mutating
+	// webhook (OnPodUpdated), which is NOT triggered by pods/status subresource
+	// writes. A cloud LB controller flips its readiness gate (and the kubelet the
+	// PodReady condition) through pods/status, so the annotation can lag behind:
+	// it may still say NotReady long after the gate became True (or vice versa).
+	// This reconciler IS triggered by pod updates (it watches Pods), so correct
+	// the lagging annotation value using the authoritative readiness-gate state.
+	//
+	// We look at the LB-managed readiness gates declared on the pod (e.g.
+	// target-health.elbv2.k8s.aws/<tgb>) rather than the aggregate PodReady,
+	// because aggregate PodReady also folds in InPlaceUpdateReady, which flips
+	// False during an in-place pod update (e.g. when an ARN is added to NlbARNs)
+	// and would otherwise flap an already-reachable GameServer. The LB gates
+	// reflect real backend reachability and are unaffected by in-place updates.
+	//
+	// Only act once the network has actually been provisioned (external
+	// addresses exist), so we never override the early "resources not created
+	// yet" phase.
+	if len(podNetworkStatus.ExternalAddresses) > 0 {
+		switch lbReadinessGatesState(manager.pod) {
+		case gateAllTrue:
+			gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkReady
+		case gateAnyFalse:
+			gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkNotReady
+		case gateNone:
+			// No LB readiness gate on this pod (e.g. provider doesn't use gates) —
+			// keep the annotation-derived value untouched.
+		}
+	}
+
 	if gsNetworkStatus.DesiredNetworkState != desiredNetworkState(nm.GetNetworkDisabled()) {
 		gsNetworkStatus.DesiredNetworkState = desiredNetworkState(nm.GetNetworkDisabled())
 		gsNetworkStatus.LastTransitionTime = metav1.Now()
 	}
 
 	return gsNetworkStatus
+}
+
+// lbReadinessGateState summarises the cloud-LB-managed readiness gates on a pod.
+type lbReadinessGateState int
+
+const (
+	gateNone     lbReadinessGateState = iota // pod declares no LB readiness gate
+	gateAllTrue                              // all LB readiness gates are True
+	gateAnyFalse                             // at least one LB readiness gate is not True
+)
+
+// lbReadinessGatePrefixes are the readiness-gate condition-type prefixes used by
+// cloud load-balancer controllers to signal real backend reachability. These are
+// what cloud providers (e.g. the AWS Load Balancer Controller) flip True only once
+// the LB target is actually healthy. We deliberately exclude Kruise's own
+// InPlaceUpdateReady / KruisePodReady gates, which flip during in-place pod updates
+// and do not reflect backend reachability.
+var lbReadinessGatePrefixes = []string{
+	"target-health.elbv2.k8s.aws/",        // AWS Load Balancer Controller
+	"service.readiness.alibabacloud.com/", // Alibaba Cloud (auto_nlbs / multi_nlbs)
+}
+
+func isLbReadinessGate(t corev1.PodConditionType) bool {
+	for _, p := range lbReadinessGatePrefixes {
+		if strings.HasPrefix(string(t), p) {
+			return true
+		}
+	}
+	return false
+}
+
+// lbReadinessGatesState inspects the pod's declared readiness gates and their
+// current conditions, returning whether the LB-managed gates are all True, any
+// not-True, or absent. Only gates declared in pod.Spec.ReadinessGates are
+// considered, so providers that don't use gates yield gateNone.
+func lbReadinessGatesState(pod *corev1.Pod) lbReadinessGateState {
+	if pod == nil {
+		return gateNone
+	}
+	// Collect the LB readiness gates the pod declares.
+	declared := make(map[corev1.PodConditionType]bool)
+	for _, g := range pod.Spec.ReadinessGates {
+		if isLbReadinessGate(g.ConditionType) {
+			declared[g.ConditionType] = true
+		}
+	}
+	if len(declared) == 0 {
+		return gateNone
+	}
+	// Index the pod's current conditions.
+	condStatus := make(map[corev1.PodConditionType]corev1.ConditionStatus, len(pod.Status.Conditions))
+	for _, c := range pod.Status.Conditions {
+		condStatus[c.Type] = c.Status
+	}
+	for t := range declared {
+		if condStatus[t] != corev1.ConditionTrue {
+			return gateAnyFalse
+		}
+	}
+	return gateAllTrue
 }
 
 func desiredNetworkState(disabled bool) gameKruiseV1alpha1.NetworkState {

--- a/pkg/controllers/gameserver/gameserver_manager_test.go
+++ b/pkg/controllers/gameserver/gameserver_manager_test.go
@@ -1420,3 +1420,67 @@ func TestSyncPodToGs(t *testing.T) {
 		}
 	}
 }
+
+func TestLbReadinessGatesState(t *testing.T) {
+	gate := "target-health.elbv2.k8s.aws/gs-0-9001"
+	mkPod := func(gates []string, conds map[string]corev1.ConditionStatus) *corev1.Pod {
+		p := &corev1.Pod{}
+		for _, g := range gates {
+			p.Spec.ReadinessGates = append(p.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(g)})
+		}
+		for t, s := range conds {
+			p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+				Type: corev1.PodConditionType(t), Status: s})
+		}
+		return p
+	}
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want lbReadinessGateState
+	}{
+		{
+			name: "no LB gate declared -> gateNone (only Kruise gates)",
+			pod:  mkPod([]string{"InPlaceUpdateReady", "KruisePodReady"}, map[string]corev1.ConditionStatus{"Ready": corev1.ConditionTrue}),
+			want: gateNone,
+		},
+		{
+			name: "LB gate True -> gateAllTrue",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{gate: corev1.ConditionTrue}),
+			want: gateAllTrue,
+		},
+		{
+			name: "LB gate False -> gateAnyFalse",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{gate: corev1.ConditionFalse}),
+			want: gateAnyFalse,
+		},
+		{
+			name: "LB gate missing condition -> gateAnyFalse",
+			pod:  mkPod([]string{gate}, map[string]corev1.ConditionStatus{}),
+			want: gateAnyFalse,
+		},
+		{
+			// The S4/InPlace case: InPlaceUpdateReady flips False but the LB gate
+			// stays True -> we must report gateAllTrue (do NOT flap to NotReady).
+			name: "InPlace flips InPlaceUpdateReady False but LB gate True -> gateAllTrue",
+			pod: mkPod([]string{"InPlaceUpdateReady", gate}, map[string]corev1.ConditionStatus{
+				"InPlaceUpdateReady": corev1.ConditionFalse,
+				gate:                 corev1.ConditionTrue,
+			}),
+			want: gateAllTrue,
+		},
+		{
+			name: "nil pod -> gateNone",
+			pod:  nil,
+			want: gateNone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lbReadinessGatesState(tt.pod); got != tt.want {
+				t.Errorf("lbReadinessGatesState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/gameserver/gameserver_manager_test.go
+++ b/pkg/controllers/gameserver/gameserver_manager_test.go
@@ -1484,3 +1484,128 @@ func TestLbReadinessGatesState(t *testing.T) {
 		})
 	}
 }
+
+// TestSyncNetworkStatus_LbReadinessGate covers the patch added to
+// syncNetworkStatus that overrides the annotation-derived CurrentNetworkState
+// based on the authoritative LB-managed readiness-gate state.
+//
+// The pre-existing TestSyncNetworkStatus only exercises pods without any LB
+// readiness gate, so it stays in the gateNone branch (no override). This test
+// pins the two override branches:
+//
+//   - gateAllTrue  -> CurrentNetworkState forced to NetworkReady,
+//     even when the annotation lags behind (still says NotReady).
+//   - gateAnyFalse -> CurrentNetworkState forced to NetworkNotReady,
+//     even when the annotation lags behind (still says Ready).
+//
+// And the guard "only act once externalAddresses are non-empty":
+//
+//   - gate True but no external addresses yet -> no override (early phase).
+func TestSyncNetworkStatus_LbReadinessGate(t *testing.T) {
+	const lbGate = "target-health.elbv2.k8s.aws/gs-0-9001"
+	// network-status JSON helpers: with vs. without external addresses, with
+	// CurrentNetworkState=NotReady or Ready (to prove the override).
+	statusWithExternal := func(state string) string {
+		return `{"internalAddresses":[{"ip":"10.0.0.1","ports":[{"name":"80","protocol":"TCP","port":80}]}],` +
+			`"externalAddresses":[{"ip":"1.2.3.4","ports":[{"name":"80","protocol":"TCP","port":601}]}],` +
+			`"currentNetworkState":"` + state + `","createTime":null,"lastTransitionTime":null}`
+	}
+	statusNoExternal := func(state string) string {
+		return `{"internalAddresses":[{"ip":"10.0.0.1","ports":[{"name":"80","protocol":"TCP","port":80}]}],` +
+			`"currentNetworkState":"` + state + `","createTime":null,"lastTransitionTime":null}`
+	}
+
+	mkPod := func(annStatus string, gates []string, conds map[string]corev1.ConditionStatus) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					gameKruiseV1alpha1.GameServerNetworkType:     "AmazonWebServices-NLB",
+					gameKruiseV1alpha1.GameServerNetworkConf:     `[{"name":"NlbARNs","value":"arn:foo"},{"name":"PortProtocols","value":"80"}]`,
+					gameKruiseV1alpha1.GameServerNetworkDisabled: "false",
+					gameKruiseV1alpha1.GameServerNetworkStatus:   annStatus,
+				},
+			},
+		}
+		for _, g := range gates {
+			p.Spec.ReadinessGates = append(p.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(g),
+			})
+		}
+		for typ, st := range conds {
+			p.Status.Conditions = append(p.Status.Conditions, corev1.PodCondition{
+				Type: corev1.PodConditionType(typ), Status: st,
+			})
+		}
+		return p
+	}
+
+	// Build a minimal GameServer whose existing NetworkStatus is non-empty so
+	// syncNetworkStatus skips its "init" branch and reaches the override.
+	mkGs := func() *gameKruiseV1alpha1.GameServer {
+		return &gameKruiseV1alpha1.GameServer{
+			Status: gameKruiseV1alpha1.GameServerStatus{
+				NetworkStatus: gameKruiseV1alpha1.NetworkStatus{
+					NetworkType:         "AmazonWebServices-NLB",
+					DesiredNetworkState: gameKruiseV1alpha1.NetworkReady,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		annStatus string
+		gates     []string
+		conds     map[string]corev1.ConditionStatus
+		want      gameKruiseV1alpha1.NetworkState
+	}{
+		{
+			// Annotation lags as NotReady (kubelet flipped the gate True via
+			// pods/status, which doesn't re-trigger the mutating webhook). The
+			// override must lift CurrentNetworkState back to Ready.
+			name:      "gateAllTrue with external addresses overrides lagging NotReady -> Ready",
+			annStatus: statusWithExternal("NotReady"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionTrue},
+			want:      gameKruiseV1alpha1.NetworkReady,
+		},
+		{
+			// Annotation lags as Ready while the LB gate is now False (target
+			// went unhealthy). The override must drop CurrentNetworkState back
+			// to NotReady.
+			name:      "gateAnyFalse with external addresses overrides lagging Ready -> NotReady",
+			annStatus: statusWithExternal("Ready"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionFalse},
+			want:      gameKruiseV1alpha1.NetworkNotReady,
+		},
+		{
+			// Early phase: external addresses not yet populated. The override
+			// must NOT fire — we keep the annotation-derived value untouched
+			// even if the (gameless) LB gate happens to be True.
+			name:      "gateAllTrue but no external addresses -> no override",
+			annStatus: statusNoExternal("NotReady"),
+			gates:     []string{lbGate},
+			conds:     map[string]corev1.ConditionStatus{lbGate: corev1.ConditionTrue},
+			want:      gameKruiseV1alpha1.NetworkNotReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gs := mkGs()
+			pod := mkPod(tt.annStatus, tt.gates, tt.conds)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gs, pod).Build()
+			manager := &GameServerManager{
+				client:     c,
+				gameServer: gs,
+				pod:        pod,
+				logger:     testr.New(t),
+			}
+			got := manager.syncNetworkStatus()
+			if got.CurrentNetworkState != tt.want {
+				t.Errorf("CurrentNetworkState = %q, want %q", got.CurrentNetworkState, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Background

Companion to #363. PR #359 (reverted in #360) bundled an AWS-NLB-plugin change with a gameserver-controller change; the AWS-NLB-only half was re-submitted in #363 (multi-NLB / dynamic ARN / `AllocatePolicy`). This PR is the **gameserver-only** half: a small, generic fix in `syncNetworkStatus` that benefits every provider whose network plugin uses LB-controller readiness gates.

This PR is a true cross-provider fix and **does not depend on #363** to land.

## Problem

`GameServer.Status.NetworkState` lags behind real reachability for any provider whose network plugin relies on LB-controller-injected readiness gates (today: AWS Load Balancer Controller's `target-health.elbv2.k8s.aws/<TGB>`, and Alibaba Cloud's `service.readiness.alibabacloud.com/<svc>` used by `auto_nlbs` / `multi_nlbs`).

Why the lag:

- The pod's `game.kruise.io/network-status` annotation — the only source `syncNetworkStatus` previously consulted — is written **only by the OKG mutating webhook** (`OnPodUpdated`).
- The mutating webhook is **not invoked** on writes to the `pods/status` subresource.
- A cloud LB controller flips its readiness-gate condition (and the kubelet then flips `PodReady`) through `pods/status` once the backend target is actually healthy.
- Net effect: gate becomes True → the pod is genuinely reachable → annotation is **not** re-evaluated → `GameServer.Status.NetworkState` stays `NotReady` until some unrelated update hits the pod and re-runs the webhook (or never, in steady state).

The GameServer reconciler already watches Pods, so the controller is woken on the gate flip — it just wasn't using that signal.

## What changes

`pkg/controllers/gameserver/gameserver_manager.go` — in `syncNetworkStatus`, after copying the annotation-derived value, override `CurrentNetworkState` based on the LB-controller-managed gates the pod declares:

```go
if len(podNetworkStatus.ExternalAddresses) > 0 {
    switch lbReadinessGatesState(manager.pod) {
    case gateAllTrue:    // all LB gates True
        gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkReady
    case gateAnyFalse:   // any LB gate not-True
        gsNetworkStatus.CurrentNetworkState = gameKruiseV1alpha1.NetworkNotReady
    case gateNone:       // pod declares no LB gates — leave annotation value untouched
    }
}
```

`lbReadinessGatesState` looks at gates declared on `pod.Spec.ReadinessGates` whose condition type starts with one of the known LB-controller prefixes:

| Prefix | Source |
|---|---|
| `target-health.elbv2.k8s.aws/` | AWS Load Balancer Controller |
| `service.readiness.alibabacloud.com/` | Alibaba Cloud (`auto_nlbs` / `multi_nlbs`) |

If neither prefix appears on the pod, the pod is considered to have no LB gates and the annotation-derived value is left untouched — providers without gates are unaffected.

## Why look at LB gates specifically, not aggregate `PodReady`?

`PodReady` folds in Kruise's `InPlaceUpdateReady`, which flips False during any in-place pod update (e.g. when an ARN is added to `NlbARNs`). Using aggregate `PodReady` would falsely flap an already-reachable `GameServer` to `NotReady` during InPlace updates. LB readiness gates reflect real backend reachability and are unaffected by in-place updates, so they are the right signal for `NetworkState`.

## Safety

- **Status-only change.** Only `GameServer.Status.NetworkState` is patched. The pod, Service, TargetGroupBinding, and cloud APIs are not touched, so player connections cannot be affected.
- **Gated by `ExternalAddresses`.** When the network has not been provisioned yet (no external addresses), the override is skipped — the existing "resources not created yet" annotation value is preserved verbatim.
- **No-op for providers without gates.** Plugins that don't use readiness gates yield `gateNone` and the annotation value is preserved.
- **Two-file diff.** Only `pkg/controllers/gameserver/gameserver_manager.go` (+ its test) — no other controller, plugin, RBAC, CRD, or API surface is touched.

## Verification

- `make test` — `TestLbReadinessGatesState` (logic table for all-True / any-False / no-gates / multi-gate / empty-pod) and `TestSyncNetworkStatus_LbReadinessGate` (the new switch as integrated into `syncNetworkStatus`: lift-lagging-NotReady-to-Ready, drop-lagging-Ready-to-NotReady, no-external-addresses guard) both pass.
- The new switch lines in `syncNetworkStatus` go from uncovered to fully covered (visible as a delta in codecov's patch coverage).
- Manually validated end-to-end on AWS: with #363 applied (no OKG-injected gate; the AWS Load Balancer Controller injects the same `target-health.elbv2.k8s.aws/<TGB>` gate via its own mutating webhook on pods that are TGB targets), 35 already-Ready GameServers stayed Ready throughout a runtime-ARN-add + scale-up (35 → 55) patch — no false-flap to `NotReady`. The detailed regression report is posted as a comment on #363.

## Compatibility

- **Default behavior preserved** for providers without LB readiness gates (`gateNone` → annotation value untouched).
- **No new RBAC, no CRD changes, no API changes.** Pure controller-side reconciliation logic.
- **Not coupled to #363.** This PR works whether or not #363 is merged. On AWS specifically, the `target-health.elbv2.k8s.aws/<TGB>` gate is injected by the AWS Load Balancer Controller's own mutating webhook on any pod that is the target of a TargetGroupBinding — i.e. independently of whether OKG injects it. On Alibaba, the same is true via the LB controller's own gate.

## Files touched

```
pkg/controllers/gameserver/gameserver_manager.go         (+90)
pkg/controllers/gameserver/gameserver_manager_test.go    (+189)
```

No other code is touched.

## Out of scope (separate PRs)

- AWS NLB plugin: multi-NLB / dynamic ARN / `AllocatePolicy` — see #363.
- The `Fixed=true` port-cache leak on `scale=0 -> delete gss` — left for a follow-up; ops-side workaround is to restart the controller.
