### PR TITLE
feat: add huaweicloud multi elbs network plugin

### DIFF
--- a/cloudprovider/hwcloud/multi_elbs.go
+++ b/cloudprovider/hwcloud/multi_elbs.go
@@ -1,0 +1,986 @@
+/*
+Copyright 2024 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hwcloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	"github.com/openkruise/kruise-game/cloudprovider"
+	cperrors "github.com/openkruise/kruise-game/cloudprovider/errors"
+	provideroptions "github.com/openkruise/kruise-game/cloudprovider/options"
+	"github.com/openkruise/kruise-game/cloudprovider/utils"
+	"github.com/openkruise/kruise-game/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	log "k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	MultiElbsNetwork = "HwCloud-Multi-ELBs"
+	AliasMultiElbs   = "Multi-ELBs-Network"
+
+	// ConfigNames defined by OKG
+	ElbIdNamesConfigName     = "ElbIdNames"
+	AllocatePolicyConfigName = "AllocatePolicy"
+
+	// service annotation defined by OKG
+	LBIDBelongIndexKey = "game.kruise.io/lb-belong-index"
+
+	// service label defined by OKG
+	ServiceBelongNetworkTypeKey = "game.kruise.io/network-type"
+
+	PrefixReadyReadinessGate = "target-health.elb.k8s.cce/"
+
+	// ElbClassPerformance is the dedicated load balancer class.
+	ElbClassPerformance = "performance"
+
+	ElbMappingPoolAnnotationKey = "cce.io/game.kruise.isp-name"
+
+	ElbHealthCheckFlagAnnotationKey = "kubernetes.io/elb.health-check-flag"
+	ElbHealthCheckFlagConfigName    = "LBHealthCheckFlag"
+
+	ElbHealthCheckOptionsAnnotationKey      = "kubernetes.io/elb.health-check-options"
+	ElbHealthCheckOptionsConfigName         = "LBHealthCheckConfig"
+	ElbUserDefineConfigName                 = "UserDefine"
+	AllocateLoadBalancerNodePortsConfigName = "AllocateLoadBalancerNodePorts"
+
+	ElbPortMappingResultCount = "cce.io/game.kruise.mapping-result-count"
+
+	// ReadinessGateConfigName enables target-health readiness gates.
+	ReadinessGateConfigName = "ReadinessGate"
+
+	ServiceProxyName = "service.kubernetes.io/service-proxy-name"
+)
+
+var (
+	notAllowedAnnotationKeyMap = map[string]struct{}{
+		ElbAutocreateAnnotationKey:         {},
+		ElbMappingPoolAnnotationKey:        {},
+		ElbClassAnnotationKey:              {},
+		ElbIdAnnotationKey:                 {},
+		ElbHealthCheckOptionsAnnotationKey: {},
+	}
+)
+
+type MultiElbsPlugin struct {
+	maxPort    int32
+	minPort    int32
+	blockPorts []int32
+	cache      [][]bool
+	// podAllocate records the allocated LB group and service ports for each pod.
+	podAllocate map[string]*lbsPorts
+	mutex       sync.RWMutex
+}
+
+type lbsPorts struct {
+	index      int
+	lbIds      []string
+	lbNames    []string
+	ports      []int32
+	targetPort []int
+	protocols  []corev1.Protocol
+}
+
+type recoveredServicePortKey struct {
+	port       int32
+	targetPort int
+}
+
+type allocatedLbBinding struct {
+	id   string
+	name string
+}
+
+// allocatedLbBindings rebuilds allocated {id,name} pairs from the pod snapshot.
+// Empty snapshot names fall back to config; unresolved bindings are skipped.
+func allocatedLbBindings(podLbsPorts *lbsPorts, conf *multiELBsConfig) []allocatedLbBinding {
+	bindings := make([]allocatedLbBinding, 0, len(podLbsPorts.lbIds))
+	for i, lbId := range podLbsPorts.lbIds {
+		lbName := ""
+		if i < len(podLbsPorts.lbNames) {
+			lbName = podLbsPorts.lbNames[i]
+		}
+		if lbName == "" {
+			lbName = conf.lbNames[lbId]
+		}
+		if lbName == "" {
+			log.Warningf("[%s] allocated lb %s has no lbName snapshot and is no longer in config; skipping", MultiElbsNetwork, lbId)
+			continue
+		}
+		bindings = append(bindings, allocatedLbBinding{id: lbId, name: lbName})
+	}
+	return bindings
+}
+
+func (m *MultiElbsPlugin) Name() string {
+	return MultiElbsNetwork
+}
+
+func (m *MultiElbsPlugin) Alias() string {
+	return AliasMultiElbs
+}
+
+func (m *MultiElbsPlugin) Init(c client.Client, options cloudprovider.CloudProviderOptions, ctx context.Context) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	elbOptions := options.(provideroptions.HwCloudOptions).CCEELBOptions.MultiELBOptions
+	m.minPort = elbOptions.MinPort
+	m.maxPort = elbOptions.MaxPort
+	m.blockPorts = elbOptions.BlockPorts
+
+	svcList := &corev1.ServiceList{}
+	err := c.List(ctx, svcList, client.MatchingLabels{ServiceBelongNetworkTypeKey: MultiElbsNetwork})
+	if err != nil {
+		return err
+	}
+	m.podAllocate, m.cache = initMultiLBCache(svcList.Items, m.minPort, m.maxPort, m.blockPorts)
+
+	log.Infof("[%s] podAllocate cache complete initialization: ", MultiElbsNetwork)
+	for podNsName, lps := range m.podAllocate {
+		log.Infof("[%s] pod %s: %v", MultiElbsNetwork, podNsName, *lps)
+	}
+	return nil
+}
+
+func initMultiLBCache(svcList []corev1.Service, minPort, maxPort int32, blockPorts []int32) (map[string]*lbsPorts, [][]bool) {
+	podAllocate := make(map[string]*lbsPorts)
+	cache := make([][]bool, 0)
+
+	for _, svc := range svcList {
+		index, err := strconv.Atoi(svc.GetAnnotations()[LBIDBelongIndexKey])
+		if err != nil {
+			continue
+		}
+		lenCache := len(cache)
+		for i := lenCache; i <= index; i++ {
+			cacheLevel := make([]bool, int(maxPort-minPort)+1)
+			for _, p := range blockPorts {
+				if p < minPort || p > maxPort {
+					log.Warningf("[%s] skip out-of-range block port %d for cache [%d, %d]", MultiElbsNetwork, p, minPort, maxPort)
+					continue
+				}
+				cacheLevel[int(p-minPort)] = true
+			}
+			cache = append(cache, cacheLevel)
+		}
+
+		ports := make([]int32, 0)
+		protocols := make([]corev1.Protocol, 0)
+		targetPorts := make([]int, 0)
+		portIndexes := make(map[recoveredServicePortKey]int)
+		for _, port := range svc.Spec.Ports {
+			if port.Port < minPort || port.Port > maxPort {
+				log.Warningf("[%s] skip out-of-range service port %d for svc %s/%s cache [%d, %d]", MultiElbsNetwork, port.Port, svc.Namespace, svc.Name, minPort, maxPort)
+				continue
+			}
+			cache[index][(port.Port - minPort)] = true
+			key := recoveredServicePortKey{
+				port:       port.Port,
+				targetPort: port.TargetPort.IntValue(),
+			}
+			if portIndex, ok := portIndexes[key]; ok {
+				if isTCPUDPProtocolPair(protocols[portIndex], port.Protocol) {
+					protocols[portIndex] = ProtocolTCPUDP
+				}
+				continue
+			}
+			portIndexes[key] = len(ports)
+			ports = append(ports, port.Port)
+			protocols = append(protocols, port.Protocol)
+			targetPorts = append(targetPorts, port.TargetPort.IntValue())
+		}
+
+		nsName := svc.GetNamespace() + "/" + svc.Spec.Selector[SvcSelectorKey]
+		lbName := svc.Annotations[ElbMappingPoolAnnotationKey]
+		if lbName == "" {
+			// Recover lbName from "<pod>-<lbName>" for older Services.
+			if podName := svc.Spec.Selector[SvcSelectorKey]; podName != "" && strings.HasPrefix(svc.Name, podName+"-") {
+				lbName = svc.Name[len(podName)+1:]
+			}
+		}
+		if podAllocate[nsName] == nil {
+			podAllocate[nsName] = &lbsPorts{
+				index:      index,
+				lbIds:      []string{svc.Annotations[ElbIdAnnotationKey]},
+				lbNames:    []string{lbName},
+				ports:      ports,
+				protocols:  protocols,
+				targetPort: targetPorts,
+			}
+		} else {
+			podAllocate[nsName].lbIds = append(podAllocate[nsName].lbIds, svc.Annotations[ElbIdAnnotationKey])
+			podAllocate[nsName].lbNames = append(podAllocate[nsName].lbNames, lbName)
+		}
+	}
+	return podAllocate, cache
+}
+
+func isTCPUDPProtocolPair(existing, incoming corev1.Protocol) bool {
+	return (existing == corev1.ProtocolTCP && incoming == corev1.ProtocolUDP) ||
+		(existing == corev1.ProtocolUDP && incoming == corev1.ProtocolTCP) ||
+		(existing == ProtocolTCPUDP && (incoming == corev1.ProtocolTCP || incoming == corev1.ProtocolUDP))
+}
+
+func (m *MultiElbsPlugin) OnPodAdded(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	networkManager := utils.NewNetworkManager(pod, c)
+	networkConfig := networkManager.GetNetworkConfig()
+	conf, err := parseMultiELBsConfig(networkConfig)
+	if err != nil {
+		return pod, cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+	var lbNames []string
+	for _, lbName := range conf.lbNames {
+		if !util.IsStringInList(lbName, lbNames) {
+			lbNames = append(lbNames, lbName)
+		}
+	}
+	// Readiness gates are supported only in CCE Turbo passthrough scenarios
+	// with dedicated ELBs.
+	if conf.readinessGate && conf.elbClass == ElbClassPerformance {
+		for _, lbName := range lbNames {
+			pod.Spec.ReadinessGates = append(pod.Spec.ReadinessGates, corev1.PodReadinessGate{
+				ConditionType: corev1.PodConditionType(PrefixReadyReadinessGate + pod.GetName() + "-" + strings.ToLower(lbName)),
+			})
+		}
+	}
+
+	return pod, nil
+}
+
+func (m *MultiElbsPlugin) OnPodUpdated(c client.Client, pod *corev1.Pod, ctx context.Context) (*corev1.Pod, cperrors.PluginError) {
+	networkManager := utils.NewNetworkManager(pod, c)
+
+	networkStatus, _ := networkManager.GetNetworkStatus()
+	networkConfig := networkManager.GetNetworkConfig()
+	if networkStatus == nil {
+		pod, err := networkManager.UpdateNetworkStatus(gamekruiseiov1alpha1.NetworkStatus{
+			CurrentNetworkState: gamekruiseiov1alpha1.NetworkNotReady,
+		}, pod)
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	conf, err := parseMultiELBsConfig(networkConfig)
+	if err != nil {
+		return pod, cperrors.NewPluginError(cperrors.ParameterError, err.Error())
+	}
+
+	podNsName := pod.GetNamespace() + "/" + pod.GetName()
+	podLbsPorts, err := m.allocate(conf, podNsName)
+	if err != nil {
+		return pod, cperrors.ToPluginError(err, cperrors.ParameterError)
+	}
+	lbBindings := allocatedLbBindings(podLbsPorts, conf)
+	if len(lbBindings) == 0 {
+		// Avoid publishing Ready when every allocated LB binding is unresolved.
+		networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+		pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+		return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+	}
+
+	var servicesToUpdate []*corev1.Service
+	var servicesToCreate []*corev1.Service
+	var needNetworkNotReady bool
+
+	for _, lbBinding := range lbBindings {
+		// get svc
+		svc := &corev1.Service{}
+		err = c.Get(ctx, types.NamespacedName{
+			Name:      pod.GetName() + "-" + strings.ToLower(lbBinding.name),
+			Namespace: pod.GetNamespace(),
+		}, svc)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				service, err := m.consSvc(podLbsPorts, conf, pod, lbBinding.id, lbBinding.name, len(lbBindings), c, ctx)
+				if err != nil {
+					return pod, cperrors.ToPluginError(err, cperrors.ParameterError)
+				}
+				servicesToCreate = append(servicesToCreate, service)
+			} else {
+				return pod, cperrors.NewPluginError(cperrors.ApiCallError, err.Error())
+			}
+		} else {
+			// old svc remain
+			if svc.OwnerReferences[0].Kind == "Pod" && svc.OwnerReferences[0].UID != pod.UID {
+				log.Infof("[%s] waiting old svc %s/%s deleted. old owner pod uid is %s, but now is %s", "HwCloud-ELB", svc.Namespace, svc.Name, svc.OwnerReferences[0].UID, pod.UID)
+				return pod, nil
+			}
+
+			// update svc
+			if util.GetHash(conf) != svc.GetAnnotations()[ElbConfigHashKey] {
+				needNetworkNotReady = true
+				service, err := m.consSvc(podLbsPorts, conf, pod, lbBinding.id, lbBinding.name, len(lbBindings), c, ctx)
+				if err != nil {
+					return pod, cperrors.ToPluginError(err, cperrors.ParameterError)
+				}
+				// Preserve health-check options for this pod's frozen target ports.
+				preserveHealthCheckAnnotation(service, svc.GetAnnotations(), conf)
+				servicesToUpdate = append(servicesToUpdate, service)
+			}
+		}
+	}
+
+	for _, service := range servicesToCreate {
+		err = c.Create(ctx, service)
+		if err != nil {
+			if errors.IsAlreadyExists(err) {
+				log.Infof("[%s] service %s/%s already exists, skip creation", MultiElbsNetwork, service.Namespace, service.Name)
+				continue
+			}
+			return pod, cperrors.NewPluginError(cperrors.ApiCallError, err.Error())
+		}
+	}
+
+	for _, service := range servicesToUpdate {
+		err = c.Update(ctx, service)
+		if err != nil {
+			return pod, cperrors.NewPluginError(cperrors.ApiCallError, err.Error())
+		}
+	}
+
+	if len(servicesToUpdate) > 0 || len(servicesToCreate) > 0 {
+		if needNetworkNotReady && networkStatus != nil {
+			networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+			pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+			if err != nil {
+				return pod, cperrors.NewPluginError(cperrors.InternalError, err.Error())
+			}
+		}
+		// Let the next reconcile observe Service status.
+		return pod, nil
+	}
+
+	// Build status from all allocated LB Services.
+	endPoints := ""
+	internalAddresses := make([]gamekruiseiov1alpha1.NetworkAddress, 0)
+	externalAddresses := make([]gamekruiseiov1alpha1.NetworkAddress, 0)
+	for i, lbBinding := range lbBindings {
+		svc := &corev1.Service{}
+		err = c.Get(ctx, types.NamespacedName{
+			Name:      pod.GetName() + "-" + strings.ToLower(lbBinding.name),
+			Namespace: pod.GetNamespace(),
+		}, svc)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return pod, cperrors.NewPluginError(cperrors.ApiCallError, err.Error())
+			}
+			continue
+		}
+
+		// disable network
+		if networkManager.GetNetworkDisabled() && svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+			return pod, cperrors.ToPluginError(c.Update(ctx, svc), cperrors.ApiCallError)
+		}
+
+		// enable network
+		if !networkManager.GetNetworkDisabled() && svc.Spec.Type == corev1.ServiceTypeClusterIP {
+			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+			return pod, cperrors.ToPluginError(c.Update(ctx, svc), cperrors.ApiCallError)
+		}
+
+		// network not ready
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+			pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+			return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+		}
+
+		ingressIP := svc.Status.LoadBalancer.Ingress[0].IP
+		_, readyCondition := util.GetPodConditionFromList(pod.Status.Conditions, corev1.PodReady)
+		if readyCondition == nil || readyCondition.Status == corev1.ConditionFalse {
+			networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkNotReady
+			pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+			return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+		}
+
+		// allow not ready containers
+		if util.IsAllowNotReadyContainers(networkManager.GetNetworkConfig()) {
+			toUpDateSvc, err := utils.AllowNotReadyContainers(c, ctx, pod, svc, false)
+			if err != nil {
+				return pod, err
+			}
+
+			if toUpDateSvc {
+				err := c.Update(ctx, svc)
+				if err != nil {
+					return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+				}
+			}
+		}
+
+		// network ready
+		host := svc.Status.LoadBalancer.Ingress[0].Hostname
+		if host == "" {
+			host = ingressIP
+		}
+		endPoints = endPoints + host + "/" + lbBinding.name
+		if i != len(lbBindings)-1 {
+			endPoints = endPoints + ","
+		}
+		for _, port := range svc.Spec.Ports {
+			instrIPort := port.TargetPort
+			instrEPort := intstr.FromInt(int(port.Port))
+			internalAddress := gamekruiseiov1alpha1.NetworkAddress{
+				IP: pod.Status.PodIP,
+				Ports: []gamekruiseiov1alpha1.NetworkPort{
+					{
+						Name:     port.Name,
+						Port:     &instrIPort,
+						Protocol: port.Protocol,
+					},
+				},
+			}
+			externalAddress := gamekruiseiov1alpha1.NetworkAddress{
+				IP: "",
+				Ports: []gamekruiseiov1alpha1.NetworkPort{
+					{
+						Name:     port.Name,
+						Port:     &instrEPort,
+						Protocol: port.Protocol,
+					},
+				},
+			}
+			internalAddresses = append(internalAddresses, internalAddress)
+			externalAddresses = append(externalAddresses, externalAddress)
+		}
+	}
+
+	// Every external address carries the full endpoint list.
+	for i := range externalAddresses {
+		externalAddresses[i].EndPoint = endPoints
+	}
+	networkStatus.InternalAddresses = internalAddresses
+	networkStatus.ExternalAddresses = externalAddresses
+
+	networkStatus.CurrentNetworkState = gamekruiseiov1alpha1.NetworkReady
+	pod, err = networkManager.UpdateNetworkStatus(*networkStatus, pod)
+	return pod, cperrors.ToPluginError(err, cperrors.InternalError)
+}
+
+func (m *MultiElbsPlugin) OnPodDeleted(c client.Client, pod *corev1.Pod, ctx context.Context) cperrors.PluginError {
+	log.Infof("执行OnPodDeleted：%s/%s", pod.GetNamespace(), pod.GetName())
+	networkManager := utils.NewNetworkManager(pod, c)
+	networkConfig := networkManager.GetNetworkConfig()
+	sc, err := parseMultiELBsConfig(networkConfig)
+	if err != nil {
+		return cperrors.NewPluginError(cperrors.ApiCallError, err.Error())
+	}
+
+	var podKeys []string
+	if sc.isFixed {
+		gss, err := util.GetGameServerSetOfPod(pod, c, ctx)
+		if err != nil && !errors.IsNotFound(err) {
+			return cperrors.ToPluginError(err, cperrors.ApiCallError)
+		}
+		// Keep fixed allocations while the owning GameServerSet still exists.
+		if err == nil && gss.GetDeletionTimestamp() == nil {
+			return nil
+		}
+		// Release allocations for pods owned by the deleted GameServerSet.
+		for key := range m.podAllocate {
+			gssName := pod.GetLabels()[gamekruiseiov1alpha1.GameServerOwnerGssKey]
+			if strings.Contains(key, pod.GetNamespace()+"/"+gssName) {
+				podKeys = append(podKeys, key)
+			}
+		}
+	} else {
+		podKeys = append(podKeys, pod.GetNamespace()+"/"+pod.GetName())
+	}
+
+	for _, podKey := range podKeys {
+		m.deAllocate(podKey)
+	}
+	log.Infof("完成OnPodDeleted：%s/%s", pod.GetNamespace(), pod.GetName())
+	return nil
+}
+
+func init() {
+	MultiElbsPlugin := MultiElbsPlugin{
+		mutex: sync.RWMutex{},
+	}
+	hwCloudProvider.registerPlugin(&MultiElbsPlugin)
+}
+
+type multiELBsConfig struct {
+	lbNames                       map[string]string
+	idList                        [][]string
+	targetPorts                   []int
+	protocols                     []corev1.Protocol
+	isFixed                       bool
+	externalTrafficPolicy         corev1.ServiceExternalTrafficPolicyType
+	allocatePolicy                string
+	elbClass                      string
+	lbHealthCheckFlag             string
+	lbHealthCheckConfig           string
+	userDefine                    string
+	allocateLoadBalancerNodePorts bool
+	readinessGate                 bool
+}
+
+func (m *MultiElbsPlugin) consSvc(podLbsPorts *lbsPorts, conf *multiELBsConfig, pod *corev1.Pod, lbId, lbName string, lbCount int, c client.Client, ctx context.Context) (*corev1.Service, error) {
+	portProtocolNum := 0
+	svcPorts := make([]corev1.ServicePort, 0)
+	for i := 0; i < len(podLbsPorts.ports); i++ {
+		if podLbsPorts.protocols[i] == ProtocolTCPUDP {
+			svcPorts = append(svcPorts, corev1.ServicePort{
+				Name:       strconv.Itoa(podLbsPorts.targetPort[i]) + "-" + strings.ToLower(string(corev1.ProtocolTCP)),
+				Port:       podLbsPorts.ports[i],
+				TargetPort: intstr.FromInt(podLbsPorts.targetPort[i]),
+				Protocol:   corev1.ProtocolTCP,
+			})
+			svcPorts = append(svcPorts, corev1.ServicePort{
+				Name:       strconv.Itoa(podLbsPorts.targetPort[i]) + "-" + strings.ToLower(string(corev1.ProtocolUDP)),
+				Port:       podLbsPorts.ports[i],
+				TargetPort: intstr.FromInt(podLbsPorts.targetPort[i]),
+				Protocol:   corev1.ProtocolUDP,
+			})
+			portProtocolNum += 2
+		} else {
+			svcPorts = append(svcPorts, corev1.ServicePort{
+				Name:       strconv.Itoa(podLbsPorts.targetPort[i]) + "-" + strings.ToLower(string(podLbsPorts.protocols[i])),
+				Port:       podLbsPorts.ports[i],
+				TargetPort: intstr.FromInt(podLbsPorts.targetPort[i]),
+				Protocol:   podLbsPorts.protocols[i],
+			})
+			portProtocolNum += 1
+		}
+	}
+
+	svcAnnotations := map[string]string{
+		ElbIdAnnotationKey:              lbId,
+		ElbConfigHashKey:                util.GetHash(conf),
+		ElbHealthCheckFlagAnnotationKey: conf.lbHealthCheckFlag,
+	}
+	if conf.userDefine != "" {
+		hwOptions := make(map[string]string)
+		err := json.Unmarshal([]byte(conf.userDefine), &hwOptions)
+		if err != nil {
+			log.Warningf("[%s] failed to unmarshal userDefine config: %s, err: %v", MultiElbsNetwork, conf.userDefine, err)
+		} else {
+			log.Infof("[%s] successfully unmarshaled userDefine config: %v", MultiElbsNetwork, hwOptions)
+		}
+		for k, v := range hwOptions {
+			if _, exists := notAllowedAnnotationKeyMap[k]; !exists {
+				svcAnnotations[k] = v
+			} else {
+				log.Warningf("[%s] not allowed annotation key %s in UserDefine", MultiElbsNetwork, k)
+			}
+		}
+	}
+
+	if conf.lbHealthCheckFlag == "on" && conf.lbHealthCheckConfig != "" {
+		processedHealthCheckConfig, err := processHealthCheckOptions(conf.lbHealthCheckConfig, podLbsPorts)
+		if err != nil {
+			log.Warningf("[%s] failed to process health check options: %v", MultiElbsNetwork, err)
+		} else if processedHealthCheckConfig != "" {
+			svcAnnotations[ElbHealthCheckOptionsAnnotationKey] = processedHealthCheckConfig
+		} else {
+			log.Warningf("[%s] Health check options processing returned empty result, skipping health check annotation", MultiElbsNetwork)
+		}
+	}
+
+	svcAnnotations[LBIDBelongIndexKey] = strconv.Itoa(podLbsPorts.index)
+	svcAnnotations[ElbMappingPoolAnnotationKey] = lbName
+	svcAnnotations[ElbClassAnnotationKey] = conf.elbClass
+	svcAnnotations[ElbPortMappingResultCount] = strconv.Itoa(lbCount * portProtocolNum)
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pod.GetName() + "-" + strings.ToLower(lbName),
+			Namespace:   pod.GetNamespace(),
+			Annotations: svcAnnotations,
+			Labels: map[string]string{
+				ServiceBelongNetworkTypeKey: MultiElbsNetwork,
+				ServiceProxyName:            "dummy",
+			},
+			OwnerReferences: getSvcOwnerReference(c, ctx, pod, conf.isFixed),
+		},
+		Spec: corev1.ServiceSpec{
+			AllocateLoadBalancerNodePorts: ptr.To[bool](conf.allocateLoadBalancerNodePorts),
+			ExternalTrafficPolicy:         conf.externalTrafficPolicy,
+			Type:                          corev1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{
+				SvcSelectorKey: pod.GetName(),
+			},
+			Ports: svcPorts,
+		},
+	}, nil
+}
+
+func (m *MultiElbsPlugin) allocate(conf *multiELBsConfig, nsName string) (*lbsPorts, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.podAllocate == nil {
+		return nil, cperrors.NewPluginError(cperrors.ApiCallError, "podAllocate is nil")
+	}
+
+	// check if pod is already allocated
+	if m.podAllocate[nsName] != nil {
+		return m.podAllocate[nsName], nil
+	}
+
+	// if the pod has not been allocated, allocate new ports to it
+	var ports []int32
+	needNum := len(conf.targetPorts)
+	index := -1
+
+	// init cache according to conf.idList.
+	// Keep stale cache levels so existing pod indexes survive ElbIdNames shrink.
+	lenCache := len(m.cache)
+	for i := lenCache; i < len(conf.idList); i++ {
+		cacheLevel := make([]bool, int(m.maxPort-m.minPort)+1)
+		for _, p := range m.blockPorts {
+			if p < m.minPort || p > m.maxPort {
+				log.Warningf("[%s] skip out-of-range block port %d for cache [%d, %d]", MultiElbsNetwork, p, m.minPort, m.maxPort)
+				continue
+			}
+			cacheLevel[int(p-m.minPort)] = true
+		}
+		m.cache = append(m.cache, cacheLevel)
+	}
+
+	// find allocated ports
+	switch conf.allocatePolicy {
+	case "default":
+		for i := 0; i < len(conf.idList); i++ {
+			sum := 0
+			ports = make([]int32, 0)
+			for j := 0; j < len(m.cache[i]); j++ {
+				if !m.cache[i][j] {
+					ports = append(ports, int32(j)+m.minPort)
+					sum++
+					if sum == needNum {
+						index = i
+						break
+					}
+				}
+			}
+			if index != -1 {
+				break
+			}
+		}
+	case "balanced":
+		maxAvailable := 0
+		for i := 0; i < len(conf.idList); i++ {
+			sum := 0
+			for j := 0; j < len(m.cache[i]); j++ {
+				if !m.cache[i][j] {
+					sum++
+				}
+			}
+			if sum > maxAvailable {
+				maxAvailable = sum
+				index = i
+			}
+		}
+		if maxAvailable < needNum {
+			return nil, fmt.Errorf("no available ports found")
+		}
+		ports = make([]int32, 0)
+		for j := 0; j < len(m.cache[index]); j++ {
+			if !m.cache[index][j] {
+				ports = append(ports, int32(j)+m.minPort)
+				if len(ports) == needNum {
+					break
+				}
+			}
+		}
+	}
+
+	if index == -1 {
+		return nil, fmt.Errorf("no available ports found")
+	}
+	for _, port := range ports {
+		m.cache[index][port-m.minPort] = true
+	}
+	lbIds := append([]string(nil), conf.idList[index]...)
+	lbNames := make([]string, 0, len(lbIds))
+	for _, lbId := range lbIds {
+		lbNames = append(lbNames, conf.lbNames[lbId])
+	}
+	m.podAllocate[nsName] = &lbsPorts{
+		index:      index,
+		lbIds:      lbIds,
+		lbNames:    lbNames,
+		ports:      ports,
+		protocols:  append([]corev1.Protocol(nil), conf.protocols...),
+		targetPort: append([]int(nil), conf.targetPorts...),
+	}
+	log.Infof("[%s] pod %s allocated: lbIds %v; ports %v", MultiElbsNetwork, nsName, conf.idList[index], ports)
+	return m.podAllocate[nsName], nil
+}
+
+func processHealthCheckOptions(healthCheckConfig string, podLbsPorts *lbsPorts) (string, error) {
+	var healthCheckOptions []HealthCheckOption
+	err := json.Unmarshal([]byte(healthCheckConfig), &healthCheckOptions)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal health check options: %v", err)
+	}
+
+	var processedOptions []HealthCheckOption
+	for _, option := range healthCheckOptions {
+		if option.PodTargetPort != "" {
+			// Convert pod_target_port, for example "TCP:80", to the allocated Service port.
+			parts := strings.Split(option.PodTargetPort, ":")
+			if len(parts) != 2 {
+				log.Warningf("Invalid pod_target_port format: %s, skipping this option", option.PodTargetPort)
+				continue
+			}
+			protocol := parts[0]
+			originalPortStr := parts[1]
+
+			podPort, err := strconv.Atoi(originalPortStr)
+			if err != nil {
+				log.Warningf("Invalid port number in pod_target_port: %s, skipping this option", originalPortStr)
+				continue
+			}
+
+			found := false
+
+			for j, targetPodPort := range podLbsPorts.targetPort {
+				if targetPodPort == podPort && j < len(podLbsPorts.protocols) {
+					serviceProtocol := strings.ToUpper(string(podLbsPorts.protocols[j]))
+
+					if serviceProtocol == "TCPUDP" {
+						servicePort := podLbsPorts.ports[j]
+						newOption := option
+						newOption.TargetServicePort = fmt.Sprintf("%s:%d", protocol, servicePort)
+						newOption.PodTargetPort = ""
+						processedOptions = append(processedOptions, newOption)
+						found = true
+						break
+					} else if serviceProtocol == protocol {
+						servicePort := podLbsPorts.ports[j]
+						newOption := option
+						newOption.TargetServicePort = fmt.Sprintf("%s:%d", protocol, servicePort)
+						newOption.PodTargetPort = ""
+						processedOptions = append(processedOptions, newOption)
+						found = true
+						break
+					}
+				}
+			}
+
+			if !found {
+				log.Warningf("pod_target_port %s does not match any port in GSS PortProtocols, health check will be skipped", option.PodTargetPort)
+			}
+
+		} else {
+			log.Warningf("[%s] Found health check option without pod_target_port field, this health check will be ignored: %+v", MultiElbsNetwork, option)
+		}
+	}
+
+	if len(processedOptions) == 0 {
+		log.Warningf("[%s] No valid health check options with pod_target_port found after processing, health check configuration will not be applied", MultiElbsNetwork)
+		return "", nil
+	}
+
+	updatedConfig, err := json.Marshal(processedOptions)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated health check options: %v", err)
+	}
+
+	return string(updatedConfig), nil
+}
+
+// preserveHealthCheckAnnotation keeps old health-check options when a config
+// update no longer matches this pod's frozen target ports.
+func preserveHealthCheckAnnotation(newSvc *corev1.Service, oldAnnotations map[string]string, conf *multiELBsConfig) {
+	if conf.lbHealthCheckFlag != "on" || conf.lbHealthCheckConfig == "" {
+		return
+	}
+	if _, ok := newSvc.Annotations[ElbHealthCheckOptionsAnnotationKey]; ok {
+		return
+	}
+	if prev, ok := oldAnnotations[ElbHealthCheckOptionsAnnotationKey]; ok && prev != "" {
+		if newSvc.Annotations == nil {
+			newSvc.Annotations = map[string]string{}
+		}
+		newSvc.Annotations[ElbHealthCheckOptionsAnnotationKey] = prev
+	}
+}
+
+func (m *MultiElbsPlugin) deAllocate(nsName string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	podLbsPorts := m.podAllocate[nsName]
+	if podLbsPorts == nil {
+		return
+	}
+	// Skip cache cleanup if the stored index is above the current cache size.
+	if podLbsPorts.index < len(m.cache) {
+		for _, port := range podLbsPorts.ports {
+			m.cache[podLbsPorts.index][port-m.minPort] = false
+		}
+	}
+	delete(m.podAllocate, nsName)
+
+	log.Infof("[%s] pod %s deallocate: lbIds %s ports %v", MultiElbsNetwork, nsName, podLbsPorts.lbIds, podLbsPorts.ports)
+}
+
+// HealthCheckOption represents a single health check configuration
+type HealthCheckOption struct {
+	Protocol          string `json:"protocol,omitempty"`
+	Delay             string `json:"delay,omitempty"`
+	Timeout           string `json:"timeout,omitempty"`
+	MaxRetries        string `json:"max_retries,omitempty"`
+	PodTargetPort     string `json:"pod_target_port,omitempty"` // From GSS config
+	TargetServicePort string `json:"target_service_port"`       // Service annotation field
+	MonitorPort       string `json:"monitor_port,omitempty"`
+	Path              string `json:"path,omitempty"`
+	ExpectedCodes     string `json:"expected_codes,omitempty"`
+}
+
+func parseMultiELBsConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) (*multiELBsConfig, error) {
+	// lbNames format {id}: {name}
+	var elbHealthCheckConfig, userDefine string
+	lbNames := make(map[string]string)
+	idList := make([][]string, 0)
+	nameNums := make(map[string]int)
+	ports := make([]int, 0)
+	protocols := make([]corev1.Protocol, 0)
+	isFixed := false
+	externalTrafficPolicy := corev1.ServiceExternalTrafficPolicyTypeCluster
+	allocatePolicy := "default"
+	elbClass := ElbClassPerformance
+	elbHealthCheckFlag := "on"
+	allocateLoadBalancerNodePorts := false
+	readinessGate := false
+
+	for _, c := range conf {
+		switch c.Name {
+		case ElbIdNamesConfigName:
+			for _, ElbIdNamesConfig := range strings.Split(c.Value, ",") {
+				if ElbIdNamesConfig != "" {
+					// Parse format: {elb-id-0}/{name-0}
+					parts := strings.Split(ElbIdNamesConfig, "/")
+					if len(parts) != 2 {
+						return nil, fmt.Errorf("invalid ElbIdNames %s. You should input as the format {elb-id-0}/{name-0}", c.Value)
+					}
+
+					id := parts[0]
+					name := parts[1]
+
+					nameNum := nameNums[name]
+					if nameNum >= len(idList) {
+						idList = append(idList, []string{id})
+					} else {
+						idList[nameNum] = append(idList[nameNum], id)
+					}
+					nameNums[name]++
+					lbNames[id] = name
+				}
+			}
+		case PortProtocolsConfigName:
+			for _, pp := range strings.Split(c.Value, ",") {
+				ppSlice := strings.Split(pp, "/")
+				port, err := strconv.Atoi(ppSlice[0])
+				if err != nil {
+					return nil, fmt.Errorf("invalid PortProtocols %s", c.Value)
+				}
+				ports = append(ports, port)
+				if len(ppSlice) != 2 {
+					protocols = append(protocols, corev1.ProtocolTCP)
+				} else {
+					protocols = append(protocols, corev1.Protocol(ppSlice[1]))
+				}
+			}
+		case FixedConfigName:
+			v, err := strconv.ParseBool(c.Value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid Fixed %s", c.Value)
+			}
+			isFixed = v
+		case ExternalTrafficPolicyTypeConfigName:
+			if strings.EqualFold(c.Value, string(corev1.ServiceExternalTrafficPolicyTypeLocal)) {
+				externalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+			}
+		case AllocateLoadBalancerNodePortsConfigName:
+			v, err := strconv.ParseBool(c.Value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid AllocateLoadBalancerNodePorts %s", c.Value)
+			}
+			allocateLoadBalancerNodePorts = v
+		case AllocatePolicyConfigName:
+			allocatePolicy = c.Value
+			if allocatePolicy != "default" && allocatePolicy != "balanced" {
+				return nil, fmt.Errorf("invalid AllocatePolicy %s", allocatePolicy)
+			}
+		case ElbClassConfigName:
+			elbClass = c.Value
+		case ReadinessGateConfigName:
+			v, err := strconv.ParseBool(c.Value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid ReadinessGate %s", c.Value)
+			}
+			readinessGate = v
+		case ElbHealthCheckFlagConfigName:
+			elbHealthCheckFlag = c.Value
+		case ElbHealthCheckOptionsConfigName:
+			elbHealthCheckConfig = c.Value
+		case ElbUserDefineConfigName:
+			userDefine = c.Value
+		default:
+		}
+	}
+
+	// check idList
+	if len(idList) == 0 {
+		return nil, fmt.Errorf("invalid ElbIdNames. You should input as the format {elb-id-0}/{name-0}")
+	}
+	num := len(idList[0])
+	for i := 1; i < len(idList); i++ {
+		if num != len(idList[i]) {
+			return nil, fmt.Errorf("invalid ElbIdNames. The number of names should be same")
+		}
+		num = len(idList[i])
+	}
+
+	// check ports & protocols
+	if len(ports) == 0 || len(protocols) == 0 {
+		return nil, fmt.Errorf("invalid PortProtocols, which can not be empty")
+	}
+
+	return &multiELBsConfig{
+		lbNames:                       lbNames,
+		idList:                        idList,
+		targetPorts:                   ports,
+		protocols:                     protocols,
+		isFixed:                       isFixed,
+		externalTrafficPolicy:         externalTrafficPolicy,
+		allocatePolicy:                allocatePolicy,
+		elbClass:                      elbClass,
+		lbHealthCheckFlag:             elbHealthCheckFlag,
+		lbHealthCheckConfig:           elbHealthCheckConfig,
+		userDefine:                    userDefine,
+		allocateLoadBalancerNodePorts: allocateLoadBalancerNodePorts,
+		readinessGate:                 readinessGate,
+	}, nil
+}

--- a/cloudprovider/hwcloud/multi_elbs_test.go
+++ b/cloudprovider/hwcloud/multi_elbs_test.go
@@ -1,0 +1,1289 @@
+package hwcloud
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	gamekruiseiov1alpha1 "github.com/openkruise/kruise-game/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMultiElbsAllocateKeepsSnapshotForAllocatedPod(t *testing.T) {
+	const nsName = "default/test-pod-0"
+	level := func() []bool { return make([]bool, 1000) }
+	markPorts := func(plugin *MultiElbsPlugin, index int, ports ...int32) *MultiElbsPlugin {
+		for _, port := range ports {
+			plugin.cache[index][port-plugin.minPort] = true
+		}
+		return plugin
+	}
+
+	tests := []struct {
+		name          string
+		plugin        *MultiElbsPlugin
+		conf          *multiELBsConfig
+		want          *lbsPorts
+		wantUsedPorts map[int][]int32
+		wantUsedCount map[int]int
+	}{
+		{
+			name: "target port value changes",
+			plugin: &MultiElbsPlugin{
+				minPort: 6000,
+				maxPort: 6005,
+				cache:   [][]bool{{true, false, false, false, false, false}},
+				podAllocate: map[string]*lbsPorts{
+					nsName: {
+						index:      0,
+						lbIds:      []string{"elb-1"},
+						lbNames:    []string{"pool-a"},
+						ports:      []int32{6000},
+						targetPort: []int{80},
+						protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+					},
+				},
+			},
+			conf: &multiELBsConfig{
+				lbNames:        map[string]string{"elb-1": "pool-a"},
+				idList:         [][]string{{"elb-1"}},
+				targetPorts:    []int{81},
+				protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+				allocatePolicy: "default",
+			},
+			want: &lbsPorts{
+				index:      0,
+				lbIds:      []string{"elb-1"},
+				lbNames:    []string{"pool-a"},
+				ports:      []int32{6000},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+			wantUsedPorts: map[int][]int32{0: []int32{6000}},
+		},
+		{
+			name: "target port count grows",
+			plugin: markPorts(&MultiElbsPlugin{
+				minPort: 6000,
+				maxPort: 6999,
+				cache:   [][]bool{level(), level()},
+				podAllocate: map[string]*lbsPorts{
+					nsName: {
+						index:      1,
+						lbIds:      []string{"elb-1"},
+						lbNames:    []string{"b"},
+						ports:      []int32{6076},
+						targetPort: []int{80},
+						protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+					},
+				},
+			}, 1, 6076),
+			conf: &multiELBsConfig{
+				lbNames:        map[string]string{"elb-0": "a", "elb-1": "b"},
+				idList:         [][]string{{"elb-0"}, {"elb-1"}},
+				targetPorts:    []int{80, 81},
+				protocols:      []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolTCP},
+				allocatePolicy: "default",
+			},
+			want: &lbsPorts{
+				index:      1,
+				lbIds:      []string{"elb-1"},
+				lbNames:    []string{"b"},
+				ports:      []int32{6076},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+			wantUsedPorts: map[int][]int32{1: []int32{6076}},
+		},
+		{
+			name: "target port count shrinks",
+			plugin: markPorts(&MultiElbsPlugin{
+				minPort: 6000,
+				maxPort: 6999,
+				cache:   [][]bool{level(), level()},
+				podAllocate: map[string]*lbsPorts{
+					nsName: {
+						index:      1,
+						lbIds:      []string{"elb-1"},
+						lbNames:    []string{"b"},
+						ports:      []int32{6076, 6077},
+						targetPort: []int{80, 81},
+						protocols:  []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolTCP},
+					},
+				},
+			}, 1, 6076, 6077),
+			conf: &multiELBsConfig{
+				lbNames:        map[string]string{"elb-0": "a", "elb-1": "b"},
+				idList:         [][]string{{"elb-0"}, {"elb-1"}},
+				targetPorts:    []int{80},
+				protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+				allocatePolicy: "default",
+			},
+			want: &lbsPorts{
+				index:      1,
+				lbIds:      []string{"elb-1"},
+				lbNames:    []string{"b"},
+				ports:      []int32{6076, 6077},
+				targetPort: []int{80, 81},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolTCP},
+			},
+			wantUsedPorts: map[int][]int32{1: []int32{6076, 6077}},
+		},
+		{
+			name: "target port count grows without reserving new port",
+			plugin: markPorts(&MultiElbsPlugin{
+				minPort: 6000,
+				maxPort: 6999,
+				cache:   [][]bool{level(), level()},
+				podAllocate: map[string]*lbsPorts{
+					nsName: {
+						index:      1,
+						lbIds:      []string{"elb-1"},
+						lbNames:    []string{"b"},
+						ports:      []int32{6002, 6003},
+						targetPort: []int{80, 81},
+						protocols:  []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolTCP},
+					},
+				},
+			}, 1, 6002, 6003),
+			conf: &multiELBsConfig{
+				lbNames:        map[string]string{"elb-0": "a", "elb-1": "b"},
+				idList:         [][]string{{"elb-0"}, {"elb-1"}},
+				targetPorts:    []int{80, 81, 82},
+				protocols:      []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolTCP, corev1.ProtocolTCP},
+				allocatePolicy: "default",
+			},
+			want: &lbsPorts{
+				index:      1,
+				lbIds:      []string{"elb-1"},
+				lbNames:    []string{"b"},
+				ports:      []int32{6002, 6003},
+				targetPort: []int{80, 81},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolTCP},
+			},
+			wantUsedCount: map[int]int{1: 2},
+		},
+		{
+			name: "lb id changes",
+			plugin: markPorts(&MultiElbsPlugin{
+				minPort: 6000,
+				maxPort: 6999,
+				cache:   [][]bool{level()},
+				podAllocate: map[string]*lbsPorts{
+					nsName: {
+						index:      0,
+						lbIds:      []string{"elb-old"},
+						lbNames:    []string{"a"},
+						ports:      []int32{6000},
+						targetPort: []int{80},
+						protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+					},
+				},
+			}, 0, 6000),
+			conf: &multiELBsConfig{
+				lbNames:        map[string]string{"elb-new": "a"},
+				idList:         [][]string{{"elb-new"}},
+				targetPorts:    []int{80},
+				protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+				allocatePolicy: "default",
+			},
+			want: &lbsPorts{
+				index:      0,
+				lbIds:      []string{"elb-old"},
+				lbNames:    []string{"a"},
+				ports:      []int32{6000},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+			wantUsedPorts: map[int][]int32{0: []int32{6000}},
+		},
+		{
+			name: "lb name changes",
+			plugin: func() *MultiElbsPlugin {
+				podAllocate, cache := initMultiLBCache([]corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod-0-old",
+							Namespace: "default",
+							Annotations: map[string]string{
+								LBIDBelongIndexKey:          "0",
+								ElbIdAnnotationKey:          "elb-1",
+								ElbMappingPoolAnnotationKey: "old",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							Selector: map[string]string{SvcSelectorKey: "test-pod-0"},
+							Ports: []corev1.ServicePort{
+								{
+									Port:       6000,
+									TargetPort: intstr.FromInt(80),
+									Protocol:   corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				}, 6000, 6000, nil)
+				return &MultiElbsPlugin{
+					minPort:     6000,
+					maxPort:     6000,
+					cache:       cache,
+					podAllocate: podAllocate,
+				}
+			}(),
+			conf: &multiELBsConfig{
+				lbNames:        map[string]string{"elb-1": "new"},
+				idList:         [][]string{{"elb-1"}},
+				targetPorts:    []int{80},
+				protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+				allocatePolicy: "default",
+			},
+			want: &lbsPorts{
+				index:      0,
+				lbIds:      []string{"elb-1"},
+				lbNames:    []string{"old"},
+				ports:      []int32{6000},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+			wantUsedPorts: map[int][]int32{0: []int32{6000}},
+		},
+		{
+			name: "target port grows before capacity check",
+			plugin: &MultiElbsPlugin{
+				minPort: 6000,
+				maxPort: 6000,
+				cache:   [][]bool{{true}},
+				podAllocate: map[string]*lbsPorts{
+					nsName: {
+						index:      0,
+						lbIds:      []string{"elb-0"},
+						lbNames:    []string{"a"},
+						ports:      []int32{6000},
+						targetPort: []int{80},
+						protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+					},
+				},
+			},
+			conf: &multiELBsConfig{
+				lbNames:        map[string]string{"elb-0": "a"},
+				idList:         [][]string{{"elb-0"}},
+				targetPorts:    []int{80, 81},
+				protocols:      []corev1.Protocol{corev1.ProtocolTCP, corev1.ProtocolTCP},
+				allocatePolicy: "default",
+			},
+			want: &lbsPorts{
+				index:      0,
+				lbIds:      []string{"elb-0"},
+				lbNames:    []string{"a"},
+				ports:      []int32{6000},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+			wantUsedPorts: map[int][]int32{0: []int32{6000}},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := tt.plugin.podAllocate[nsName]
+			if before == nil {
+				t.Fatalf("case %d: expected existing allocation for %s", i, nsName)
+			}
+
+			gotAllocated, err := tt.plugin.allocate(tt.conf, nsName)
+			if err != nil {
+				t.Fatalf("case %d: expected allocate to keep existing snapshot, got: %v", i, err)
+			}
+			if gotAllocated != before {
+				t.Fatalf("case %d: expected allocate to return existing allocation object", i)
+			}
+			got := tt.plugin.podAllocate[nsName]
+			if got != before {
+				t.Fatalf("case %d: expected existing allocation object to stay unchanged", i)
+			}
+			if got.index != tt.want.index {
+				t.Fatalf("case %d: index actual: %d, expect: %d", i, got.index, tt.want.index)
+			}
+			if !reflect.DeepEqual(got.lbIds, tt.want.lbIds) {
+				t.Fatalf("case %d: lbIds actual: %v, expect: %v", i, got.lbIds, tt.want.lbIds)
+			}
+			if !reflect.DeepEqual(got.lbNames, tt.want.lbNames) {
+				t.Fatalf("case %d: lbNames actual: %v, expect: %v", i, got.lbNames, tt.want.lbNames)
+			}
+			if !reflect.DeepEqual(got.ports, tt.want.ports) {
+				t.Fatalf("case %d: ports actual: %v, expect: %v", i, got.ports, tt.want.ports)
+			}
+			if !reflect.DeepEqual(got.targetPort, tt.want.targetPort) {
+				t.Fatalf("case %d: targetPort actual: %v, expect: %v", i, got.targetPort, tt.want.targetPort)
+			}
+			if !reflect.DeepEqual(got.protocols, tt.want.protocols) {
+				t.Fatalf("case %d: protocols actual: %v, expect: %v", i, got.protocols, tt.want.protocols)
+			}
+			for index, ports := range tt.wantUsedPorts {
+				for _, port := range ports {
+					if !tt.plugin.cache[index][port-tt.plugin.minPort] {
+						t.Fatalf("case %d: expected port %d to stay marked used on index %d", i, port, index)
+					}
+				}
+			}
+			for index, wantCount := range tt.wantUsedCount {
+				used := 0
+				for _, taken := range tt.plugin.cache[index] {
+					if taken {
+						used++
+					}
+				}
+				if used != wantCount {
+					t.Fatalf("case %d: used port count actual: %d, expect: %d", i, used, wantCount)
+				}
+			}
+		})
+	}
+}
+
+func TestMultiElbsConsSvcUsesUpdatedTargetPortAndHealthCheckConfig(t *testing.T) {
+	plugin := &MultiElbsPlugin{}
+	podLbsPorts := &lbsPorts{
+		index:      0,
+		lbIds:      []string{"elb-1"},
+		lbNames:    []string{"pool-a"},
+		ports:      []int32{6000},
+		targetPort: []int{81},
+		protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+	}
+	conf := &multiELBsConfig{
+		lbNames:               map[string]string{"elb-1": "pool-a"},
+		idList:                [][]string{{"elb-1"}},
+		targetPorts:           []int{81},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy:        "default",
+		elbClass:              "performance",
+		lbHealthCheckFlag:     "on",
+		lbHealthCheckConfig:   `[{"protocol":"tcp","pod_target_port":"TCP:81","monitor_port":"8080"}]`,
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+	}
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "default",
+			UID:       "pod-uid-1",
+		},
+	}
+
+	svc, err := plugin.consSvc(podLbsPorts, conf, pod, "elb-1", "pool-a", 1, nil, context.Background())
+	if err != nil {
+		t.Fatalf("consSvc returned error: %v", err)
+	}
+
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("expected 1 service port, got %d", len(svc.Spec.Ports))
+	}
+	if svc.Spec.Ports[0].TargetPort.IntValue() != 81 {
+		t.Fatalf("expected service targetPort 81, got %d", svc.Spec.Ports[0].TargetPort.IntValue())
+	}
+
+	got := svc.Annotations[ElbHealthCheckOptionsAnnotationKey]
+	var options []HealthCheckOption
+	if err := json.Unmarshal([]byte(got), &options); err != nil {
+		t.Fatalf("failed to unmarshal health check annotation %q: %v", got, err)
+	}
+	if len(options) != 1 {
+		t.Fatalf("expected 1 health check option, got %d", len(options))
+	}
+	if options[0].Protocol != "tcp" {
+		t.Fatalf("expected protocol tcp, got %s", options[0].Protocol)
+	}
+	if options[0].TargetServicePort != "TCP:6000" {
+		t.Fatalf("expected target_service_port TCP:6000, got %s", options[0].TargetServicePort)
+	}
+	if options[0].MonitorPort != "8080" {
+		t.Fatalf("expected monitor_port 8080, got %s", options[0].MonitorPort)
+	}
+}
+
+func TestMultiElbsConsSvcUsesSnapshotLbBindingWhenConfigChanged(t *testing.T) {
+	plugin := &MultiElbsPlugin{}
+	podLbsPorts := &lbsPorts{
+		index:      0,
+		lbIds:      []string{"elb-old"},
+		lbNames:    []string{"old"},
+		ports:      []int32{6000},
+		targetPort: []int{80},
+		protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+	}
+	conf := &multiELBsConfig{
+		lbNames:               map[string]string{"elb-new": "new"},
+		idList:                [][]string{{"elb-new"}},
+		targetPorts:           []int{80},
+		protocols:             []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy:        "default",
+		elbClass:              "performance",
+		lbHealthCheckFlag:     "off",
+		externalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+	}
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "default",
+			UID:       "pod-uid-1",
+		},
+	}
+
+	svc, err := plugin.consSvc(podLbsPorts, conf, pod, "elb-old", "old", 1, nil, context.Background())
+	if err != nil {
+		t.Fatalf("consSvc returned error: %v", err)
+	}
+
+	if svc.Name != "test-pod-0-old" {
+		t.Fatalf("expected old lbName in service name, got %s", svc.Name)
+	}
+	if got := svc.Annotations[ElbIdAnnotationKey]; got != "elb-old" {
+		t.Fatalf("expected old lbId annotation, got %q", got)
+	}
+	if got := svc.Annotations[ElbMappingPoolAnnotationKey]; got != "old" {
+		t.Fatalf("expected old lbName annotation, got %q", got)
+	}
+}
+
+func TestMultiElbsAllocatedLbBindingsFallsBackAndSkips(t *testing.T) {
+	conf := &multiELBsConfig{lbNames: map[string]string{"elb-1": "pool-a"}}
+
+	tests := []struct {
+		name        string
+		podLbsPorts *lbsPorts
+		want        []allocatedLbBinding
+	}{
+		{
+			name: "uses snapshot names",
+			podLbsPorts: &lbsPorts{
+				lbIds:   []string{"elb-1", "elb-2"},
+				lbNames: []string{"pool-a", "pool-b"},
+			},
+			want: []allocatedLbBinding{{id: "elb-1", name: "pool-a"}, {id: "elb-2", name: "pool-b"}},
+		},
+		{
+			name: "falls back to config and skips missing lb",
+			podLbsPorts: &lbsPorts{
+				lbIds:   []string{"elb-1", "elb-gone"},
+				lbNames: []string{"", ""},
+			},
+			want: []allocatedLbBinding{{id: "elb-1", name: "pool-a"}},
+		},
+		{
+			name: "falls back when lbNames is shorter than lbIds",
+			podLbsPorts: &lbsPorts{
+				lbIds:   []string{"elb-1"},
+				lbNames: []string{},
+			},
+			want: []allocatedLbBinding{{id: "elb-1", name: "pool-a"}},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allocatedLbBindings(tt.podLbsPorts, conf)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("case %d: allocatedLbBindings actual: %+v, expect: %+v", i, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMultiElbsConfig(t *testing.T) {
+	tests := []struct {
+		conf                []gamekruiseiov1alpha1.NetworkConfParams
+		lbNames             map[string]string
+		idList              [][]string
+		lbHealthCheckFlag   string
+		lbHealthCheckConfig string
+	}{
+		{
+			conf: []gamekruiseiov1alpha1.NetworkConfParams{
+				{Name: ElbIdNamesConfigName, Value: "elb-1/pool-a,elb-2/pool-a,elb-3/pool-b,elb-4/pool-b"},
+				{Name: PortProtocolsConfigName, Value: "81/TCP"},
+				{Name: ElbHealthCheckFlagConfigName, Value: "on"},
+				{Name: ElbHealthCheckOptionsConfigName, Value: `[{"protocol":"tcp","pod_target_port":"TCP:81"}]`},
+			},
+			lbNames: map[string]string{
+				"elb-1": "pool-a",
+				"elb-2": "pool-a",
+				"elb-3": "pool-b",
+				"elb-4": "pool-b",
+			},
+			idList:              [][]string{{"elb-1", "elb-3"}, {"elb-2", "elb-4"}},
+			lbHealthCheckFlag:   "on",
+			lbHealthCheckConfig: `[{"protocol":"tcp","pod_target_port":"TCP:81"}]`,
+		},
+	}
+
+	for i, tt := range tests {
+		actual, err := parseMultiELBsConfig(tt.conf)
+		if err != nil {
+			t.Fatalf("case %d: parseMultiELBsConfig returned error: %v", i, err)
+		}
+		if !reflect.DeepEqual(actual.lbNames, tt.lbNames) {
+			t.Fatalf("case %d: lbNames actual: %v, expect: %v", i, actual.lbNames, tt.lbNames)
+		}
+		if !reflect.DeepEqual(actual.idList, tt.idList) {
+			t.Fatalf("case %d: idList actual: %v, expect: %v", i, actual.idList, tt.idList)
+		}
+		if actual.lbHealthCheckFlag != tt.lbHealthCheckFlag {
+			t.Fatalf("case %d: lbHealthCheckFlag actual: %s, expect: %s", i, actual.lbHealthCheckFlag, tt.lbHealthCheckFlag)
+		}
+		if actual.lbHealthCheckConfig != tt.lbHealthCheckConfig {
+			t.Fatalf("case %d: lbHealthCheckConfig actual: %s, expect: %s", i, actual.lbHealthCheckConfig, tt.lbHealthCheckConfig)
+		}
+	}
+}
+
+func TestInitMultiLBCache(t *testing.T) {
+	tests := []struct {
+		name        string
+		svcList     []corev1.Service
+		minPort     int32
+		maxPort     int32
+		blockPorts  []int32
+		podAllocate map[string]*lbsPorts
+		cache       [][]bool
+	}{
+		{
+			name: "skips out-of-range service ports",
+			svcList: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod-0-pool-a",
+						Namespace: "default",
+						Annotations: map[string]string{
+							LBIDBelongIndexKey: "0",
+							ElbIdAnnotationKey: "elb-1",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							SvcSelectorKey: "test-pod-0",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Port:       6001,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(80),
+							},
+							{
+								Port:       7001,
+								Protocol:   corev1.ProtocolUDP,
+								TargetPort: intstr.FromInt(81),
+							},
+						},
+					},
+				},
+			},
+			minPort:    7000,
+			maxPort:    7002,
+			blockPorts: nil,
+			podAllocate: map[string]*lbsPorts{
+				"default/test-pod-0": {
+					index:      0,
+					lbIds:      []string{"elb-1"},
+					lbNames:    []string{"pool-a"},
+					ports:      []int32{7001},
+					targetPort: []int{81},
+					protocols:  []corev1.Protocol{corev1.ProtocolUDP},
+				},
+			},
+			cache: [][]bool{{false, true, false}},
+		},
+		{
+			name: "merges TCP and UDP service ports",
+			svcList: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod-0-pool-a",
+						Namespace: "default",
+						Annotations: map[string]string{
+							LBIDBelongIndexKey: "0",
+							ElbIdAnnotationKey: "elb-1",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							SvcSelectorKey: "test-pod-0",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Port:       6076,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(8601),
+							},
+							{
+								Port:       6076,
+								Protocol:   corev1.ProtocolUDP,
+								TargetPort: intstr.FromInt(8601),
+							},
+							{
+								Port:       6077,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(8661),
+							},
+							{
+								Port:       6077,
+								Protocol:   corev1.ProtocolUDP,
+								TargetPort: intstr.FromInt(8661),
+							},
+						},
+					},
+				},
+			},
+			minPort:    6076,
+			maxPort:    6077,
+			blockPorts: nil,
+			podAllocate: map[string]*lbsPorts{
+				"default/test-pod-0": {
+					index:      0,
+					lbIds:      []string{"elb-1"},
+					lbNames:    []string{"pool-a"},
+					ports:      []int32{6076, 6077},
+					targetPort: []int{8601, 8661},
+					protocols:  []corev1.Protocol{ProtocolTCPUDP, ProtocolTCPUDP},
+				},
+			},
+			cache: [][]bool{{true, true}},
+		},
+		{
+			name: "skips out-of-range block ports",
+			svcList: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod-0-pool-a",
+						Namespace: "default",
+						Annotations: map[string]string{
+							LBIDBelongIndexKey: "0",
+							ElbIdAnnotationKey: "elb-1",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							SvcSelectorKey: "test-pod-0",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Port:       7003,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(80),
+							},
+						},
+					},
+				},
+			},
+			minPort:    7000,
+			maxPort:    7003,
+			blockPorts: []int32{6999, 7001, 14001},
+			podAllocate: map[string]*lbsPorts{
+				"default/test-pod-0": {
+					index:      0,
+					lbIds:      []string{"elb-1"},
+					lbNames:    []string{"pool-a"},
+					ports:      []int32{7003},
+					targetPort: []int{80},
+					protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+				},
+			},
+			cache: [][]bool{{false, true, false, true}},
+		},
+		{
+			name: "uses min max parameter order",
+			svcList: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod-0-pool-a",
+						Namespace: "default",
+						Annotations: map[string]string{
+							LBIDBelongIndexKey: "0",
+							ElbIdAnnotationKey: "elb-1",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							SvcSelectorKey: "test-pod-0",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Port:       7002,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(80),
+							},
+						},
+					},
+				},
+			},
+			minPort:    7000,
+			maxPort:    7002,
+			blockPorts: []int32{7001},
+			podAllocate: map[string]*lbsPorts{
+				"default/test-pod-0": {
+					index:      0,
+					lbIds:      []string{"elb-1"},
+					lbNames:    []string{"pool-a"},
+					ports:      []int32{7002},
+					targetPort: []int{80},
+					protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+				},
+			},
+			cache: [][]bool{{false, true, true}},
+		},
+		{
+			name: "recovers lb name from service name",
+			svcList: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod-0-pool-a",
+						Namespace: "default",
+						Annotations: map[string]string{
+							LBIDBelongIndexKey: "0",
+							ElbIdAnnotationKey: "elb-1",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{SvcSelectorKey: "test-pod-0"},
+						Ports: []corev1.ServicePort{
+							{
+								Port:       6000,
+								TargetPort: intstr.FromInt(80),
+								Protocol:   corev1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+			minPort:    6000,
+			maxPort:    6000,
+			blockPorts: nil,
+			podAllocate: map[string]*lbsPorts{
+				"default/test-pod-0": {
+					index:      0,
+					lbIds:      []string{"elb-1"},
+					lbNames:    []string{"pool-a"},
+					ports:      []int32{6000},
+					targetPort: []int{80},
+					protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+				},
+			},
+			cache: [][]bool{{true}},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var podAllocate map[string]*lbsPorts
+			var cache [][]bool
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("case %d: initMultiLBCache panicked: %v", i, r)
+					}
+				}()
+				podAllocate, cache = initMultiLBCache(tt.svcList, tt.minPort, tt.maxPort, tt.blockPorts)
+			}()
+
+			if !reflect.DeepEqual(podAllocate, tt.podAllocate) {
+				t.Fatalf("case %d: podAllocate actual: %v, expect: %v", i, podAllocate, tt.podAllocate)
+			}
+			if !reflect.DeepEqual(cache, tt.cache) {
+				t.Fatalf("case %d: cache actual: %v, expect: %v", i, cache, tt.cache)
+			}
+		})
+	}
+}
+
+// When ElbIdNames shrinks, already-allocated pods must keep their snapshot
+// allocation and must not migrate to another index.
+func TestMultiElbsAllocateKeepsSnapshotForShrunkIdListForAllocatedPod(t *testing.T) {
+	level := func() []bool { return make([]bool, 1000) } // ports [6000,6999]
+	plugin := &MultiElbsPlugin{
+		minPort: 6000,
+		maxPort: 6999,
+		cache: [][]bool{
+			level(), // index 0
+			level(), // index 1
+			level(), // index 2 (removed from config but pod still here)
+		},
+		podAllocate: map[string]*lbsPorts{
+			"default/test-pod-b": {
+				index:      2,
+				lbIds:      []string{"elb-x"},
+				lbNames:    []string{"pool-x"},
+				ports:      []int32{6076},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+		},
+	}
+	// mark pod-b's port as taken on its (still-valid) level 2
+	plugin.cache[2][6076-6000] = true
+
+	// conf shrank to a single ELB group
+	conf := &multiELBsConfig{
+		lbNames:        map[string]string{"elb-1": "pool-a"},
+		idList:         [][]string{{"elb-1"}},
+		targetPorts:    []int{80},
+		protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy: "default",
+	}
+
+	// 1) new pod reconciles first -> fresh allocate. The cache is NOT
+	//    truncated (it only grows), so level 2 survives; pod-c lands on index 0.
+	if _, err := plugin.allocate(conf, "default/test-pod-c"); err != nil {
+		t.Fatalf("allocate for new pod c returned error: %v", err)
+	}
+	if len(plugin.cache) != 3 {
+		t.Fatalf("expected cache to keep all 3 levels (no truncation), got %d", len(plugin.cache))
+	}
+
+	// 2) stale high-index pod reconciles -> must not panic, must not migrate
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("allocate panicked on shrunk-config pod b: %v", r)
+			}
+		}()
+		got, err := plugin.allocate(conf, "default/test-pod-b")
+		if err != nil {
+			t.Fatalf("expected allocate to keep stale pod snapshot, got: %v", err)
+		}
+		if got.index != 2 || got.ports[0] != 6076 || got.lbIds[0] != "elb-x" || got.lbNames[0] != "pool-x" {
+			t.Fatalf("expected stale pod snapshot unchanged, got %+v", got)
+		}
+	}()
+
+	allocated := plugin.podAllocate["default/test-pod-b"]
+	if allocated == nil || allocated.index != 2 {
+		t.Fatalf("expected stale pod to stay on index 2, got %+v", allocated)
+	}
+	if !plugin.cache[2][6076-6000] {
+		t.Fatalf("expected pod-b's old port 6076 to stay marked on level 2")
+	}
+}
+
+// Regression (bug 1): shrink then delete a stale high-index pod that never got
+// re-updated. Previously a fresh allocate for another pod truncated m.cache,
+// and deAllocate then panicked indexing the stale level. With no-truncation the
+// level survives and deAllocate frees it cleanly.
+func TestMultiElbsDeAllocateShrunkConfigDoesNotPanic(t *testing.T) {
+	level := func() []bool { return make([]bool, 1000) } // ports [6000,6999]
+	plugin := &MultiElbsPlugin{
+		minPort: 6000,
+		maxPort: 6999,
+		cache: [][]bool{
+			level(), // index 0
+			level(), // index 1
+			level(), // index 2
+		},
+		podAllocate: map[string]*lbsPorts{
+			"default/test-pod-a": {
+				index:      2,
+				lbIds:      []string{"elb-x"},
+				lbNames:    []string{"pool-x"},
+				ports:      []int32{6076},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+		},
+	}
+	plugin.cache[2][6076-6000] = true
+
+	// conf shrank to a single ELB group
+	shrunkConf := &multiELBsConfig{
+		lbNames:        map[string]string{"elb-1": "pool-a"},
+		idList:         [][]string{{"elb-1"}},
+		targetPorts:    []int{80},
+		protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy: "default",
+	}
+
+	// 1) new pod reconciles first -> fresh allocate (cache stays 3 levels)
+	if _, err := plugin.allocate(shrunkConf, "default/test-pod-c"); err != nil {
+		t.Fatalf("allocate for new pod c returned error: %v", err)
+	}
+	if len(plugin.cache) != 3 {
+		t.Fatalf("expected cache to keep 3 levels, got %d", len(plugin.cache))
+	}
+
+	// 2) stale high-index pod is DELETED (never re-updated) -> deAllocate
+	//    must not panic, must free its port on the surviving level 2.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("deAllocate panicked on stale high-index pod: %v", r)
+			}
+		}()
+		plugin.deAllocate("default/test-pod-a")
+	}()
+
+	if plugin.podAllocate["default/test-pod-a"] != nil {
+		t.Fatalf("expected stale pod removed from podAllocate")
+	}
+	if plugin.cache[2][6076-6000] {
+		t.Fatalf("expected port 6076 freed on level 2 after deAllocate")
+	}
+}
+
+// Regression (bug 3): shrink -> IDENTICAL regrow must not let a later pod steal
+// a stale pod's external port on the same ELB. Previously the refresh branch left
+// the cache desynced (level 2 recreated empty), so a later pod was handed the
+// same port+index as the stale pod. With no-truncation the cache keeps the
+// stale pod's port marked, so the later pod fails with "no available ports"
+// instead of double-assigning.
+func TestMultiElbsShrinkIdenticalRegrowNoPortConflict(t *testing.T) {
+	one := func() []bool { return []bool{false} } // single slot: port 6000
+	plugin := &MultiElbsPlugin{
+		minPort: 6000,
+		maxPort: 6000,
+		cache: [][]bool{
+			one(), // idx 0
+			one(), // idx 1
+			one(), // idx 2
+		},
+		podAllocate: map[string]*lbsPorts{
+			"default/pod-a": {
+				index:      2,
+				lbIds:      []string{"elb-2"},
+				lbNames:    []string{"c"},
+				ports:      []int32{6000},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+		},
+	}
+	plugin.cache[2][0] = true // pod-a holds 6000 on idx 2
+
+	originalConf := &multiELBsConfig{
+		lbNames:        map[string]string{"elb-0": "a", "elb-1": "b", "elb-2": "c"},
+		idList:         [][]string{{"elb-0"}, {"elb-1"}, {"elb-2"}},
+		targetPorts:    []int{80},
+		protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy: "default",
+	}
+	shrunkConf := &multiELBsConfig{
+		lbNames:        map[string]string{"elb-0": "a"},
+		idList:         [][]string{{"elb-0"}},
+		targetPorts:    []int{80},
+		protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy: "default",
+	}
+
+	// 1) shrink to 1 group; pod-c fresh-allocates 6000 on idx 0. Cache stays 3 levels.
+	if _, err := plugin.allocate(shrunkConf, "default/pod-c"); err != nil {
+		t.Fatalf("pod-c allocate: %v", err)
+	}
+	if len(plugin.cache) != 3 {
+		t.Fatalf("expected cache to keep 3 levels, got %d", len(plugin.cache))
+	}
+
+	// 2) identical regrow; pod-a refreshes and keeps idx 2 / 6000.
+	a, err := plugin.allocate(originalConf, "default/pod-a")
+	if err != nil {
+		t.Fatalf("pod-a re-allocate: %v", err)
+	}
+	if a.index != 2 || a.ports[0] != 6000 {
+		t.Fatalf("pod-a should still hold idx 2 / 6000, got idx=%d ports=%v", a.index, a.ports)
+	}
+	if !plugin.cache[2][0] {
+		t.Fatalf("pod-a's port 6000 on level 2 must stay marked taken")
+	}
+
+	// 3) another pod fills idx 1 (idx 0 is full).
+	if _, err := plugin.allocate(originalConf, "default/pod-d1"); err != nil {
+		t.Fatalf("pod-d1 allocate: %v", err)
+	}
+
+	// 4) a 4th pod cannot steal pod-a's idx 2 / 6000: the cache still marks it
+	//    taken, so the allocate must fail rather than double-assign.
+	if _, err := plugin.allocate(originalConf, "default/pod-d2"); err == nil {
+		t.Fatalf("expected 4th allocate to fail (no free port) instead of double-assigning pod-a's port")
+	}
+	// pod-a is untouched.
+	if got := plugin.podAllocate["default/pod-a"]; got == nil || got.index != 2 || got.ports[0] != 6000 {
+		t.Fatalf("pod-a allocation must be unchanged, got %+v", got)
+	}
+}
+
+// Regression (scan bound): when ElbIdNames shrank but stale cache levels remain,
+// a fresh allocate must scan only [0, len(conf.idList)) and report "no available
+// ports" when the valid levels are full -- not pick a stale high level and fail
+// with the misleading "ElbIdNames configuration have not synced".
+func TestMultiElbsAllocateShrunkScanBoundedByConfig(t *testing.T) {
+	plugin := &MultiElbsPlugin{
+		minPort: 6000,
+		maxPort: 6000,
+		cache: [][]bool{
+			{true},  // idx 0: full (port 6000 taken)
+			{false}, // idx 1: stale, empty (left over from a prior shrink)
+			{false}, // idx 2: stale, empty
+		},
+		podAllocate: map[string]*lbsPorts{},
+	}
+	// conf shrank to a single ELB group; idx 0 is saturated.
+	conf := &multiELBsConfig{
+		lbNames:        map[string]string{"elb-1": "pool-a"},
+		idList:         [][]string{{"elb-1"}},
+		targetPorts:    []int{80},
+		protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy: "default",
+	}
+
+	_, err := plugin.allocate(conf, "default/test-pod-x")
+	if err == nil {
+		t.Fatalf("expected allocate to fail because idx 0 is full, got nil error")
+	}
+	if !strings.Contains(err.Error(), "no available ports") {
+		t.Fatalf("expected 'no available ports' error (scan bounded by conf), got: %v", err)
+	}
+	// stale levels must not be touched/marked.
+	if plugin.cache[1][0] || plugin.cache[2][0] {
+		t.Fatalf("stale cache levels must not be marked by a bounded scan")
+	}
+	if len(plugin.podAllocate) != 0 {
+		t.Fatalf("no pod should be recorded on a failed allocate, got %v", plugin.podAllocate)
+	}
+}
+
+func TestPreserveHealthCheckAnnotationCarriesOverPrevious(t *testing.T) {
+	// frozen targetPort => consSvc produces no health-check annotation; the
+	// previous one must be carried over so the ELB keeps its health check.
+	prev := `[{"protocol":"tcp","target_service_port":"TCP:6000","monitor_port":"8080"}]`
+	conf := &multiELBsConfig{
+		lbHealthCheckFlag:   "on",
+		lbHealthCheckConfig: `[{"protocol":"tcp","pod_target_port":"TCP:81","monitor_port":"8080"}]`,
+	}
+
+	svc := &corev1.Service{}
+	preserveHealthCheckAnnotation(svc, map[string]string{ElbHealthCheckOptionsAnnotationKey: prev}, conf)
+	if got := svc.Annotations[ElbHealthCheckOptionsAnnotationKey]; got != prev {
+		t.Fatalf("expected previous health-check annotation carried over, got %q", got)
+	}
+
+	// flag=off intentionally drops the annotation -> must NOT carry over.
+	conf.lbHealthCheckFlag = "off"
+	svc2 := &corev1.Service{}
+	preserveHealthCheckAnnotation(svc2, map[string]string{ElbHealthCheckOptionsAnnotationKey: prev}, conf)
+	if _, ok := svc2.Annotations[ElbHealthCheckOptionsAnnotationKey]; ok {
+		t.Fatalf("expected no carry-over when health check flag is off")
+	}
+
+	// new svc already has a fresh annotation -> do not overwrite with the old one.
+	conf.lbHealthCheckFlag = "on"
+	fresh := `[{"protocol":"tcp","target_service_port":"TCP:6001"}]`
+	svc3 := &corev1.Service{}
+	svc3.Annotations = map[string]string{ElbHealthCheckOptionsAnnotationKey: fresh}
+	preserveHealthCheckAnnotation(svc3, map[string]string{ElbHealthCheckOptionsAnnotationKey: prev}, conf)
+	if got := svc3.Annotations[ElbHealthCheckOptionsAnnotationKey]; got != fresh {
+		t.Fatalf("expected fresh annotation preserved, got %q", got)
+	}
+}
+
+func TestMultiElbsAllocateSkipsOutOfRangeBlockPortsOnCacheGrow(t *testing.T) {
+	// block port 5000 is below minPort 6000; initMultiLBCache skips it, allocate's
+	// cache-grow loop must skip it too — previously it indexed cacheLevel[-1000]
+	// and panicked when conf.idList grew beyond the existing cache.
+	plugin := &MultiElbsPlugin{
+		minPort:     6000,
+		maxPort:     6999,
+		blockPorts:  []int32{5000, 6500},
+		cache:       [][]bool{make([]bool, 1000)}, // index 0 already exists
+		podAllocate: map[string]*lbsPorts{},
+	}
+	conf := &multiELBsConfig{
+		lbNames:        map[string]string{"elb-a": "pool-a", "elb-b": "pool-b"},
+		idList:         [][]string{{"elb-a"}, {"elb-b"}}, // 2 groups -> cache grows to 2 levels
+		targetPorts:    []int{80},
+		protocols:      []corev1.Protocol{corev1.ProtocolTCP},
+		allocatePolicy: "default",
+	}
+
+	got, err := plugin.allocate(conf, "default/test-pod-0")
+	if err != nil {
+		t.Fatalf("allocate returned error: %v", err)
+	}
+	if len(plugin.cache) != 2 {
+		t.Fatalf("expected cache to grow to 2 levels, got %d", len(plugin.cache))
+	}
+	// in-range block port 6500 marked on the freshly grown level 1; out-of-range
+	// 5000 skipped (no panic, no mark at negative index).
+	if !plugin.cache[1][500] { // 6500-6000=500
+		t.Fatalf("expected in-range block port 6500 marked on level 1")
+	}
+	if got.ports[0] != 6000 {
+		t.Fatalf("expected first free port 6000, got %v", got.ports)
+	}
+}
+
+func TestMultiElbsOnPodUpdatedMarksNotReadyWhenNoResolvableBinding(t *testing.T) {
+	// Pod snapshot holds a lbId removed from conf and an empty lbName (e.g. a
+	// service recovered without the pool annotation, before the name-fallback in
+	// initMultiLBCache applies). allocatedLbBindings skips it -> lbBindings is
+	// empty -> OnPodUpdated must mark NotReady instead of falling through to
+	// NetworkReady with no addresses.
+	plugin := &MultiElbsPlugin{
+		minPort: 6000,
+		maxPort: 6999,
+		cache:   [][]bool{make([]bool, 1000)},
+		podAllocate: map[string]*lbsPorts{
+			"default/test-pod-0": {
+				index:      0,
+				lbIds:      []string{"elb-gone"},
+				lbNames:    []string{""},
+				ports:      []int32{6000},
+				targetPort: []int{80},
+				protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "default",
+			UID:       "pod-uid-1",
+			Annotations: map[string]string{
+				gamekruiseiov1alpha1.GameServerNetworkType:   MultiElbsNetwork,
+				gamekruiseiov1alpha1.GameServerNetworkConf:   `[{"name":"ElbIdNames","value":"elb-1/pool-a"},{"name":"PortProtocols","value":"80/TCP"}]`,
+				gamekruiseiov1alpha1.GameServerNetworkStatus: `{"currentNetworkState":"Ready"}`,
+			},
+		},
+	}
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	updatedPod, err := plugin.OnPodUpdated(fakeClient, pod, context.Background())
+	if err != nil {
+		t.Fatalf("OnPodUpdated returned error: %v", err)
+	}
+	statusStr := updatedPod.Annotations[gamekruiseiov1alpha1.GameServerNetworkStatus]
+	if !strings.Contains(statusStr, "NotReady") {
+		t.Fatalf("expected NetworkNotReady when no binding is resolvable, got %s", statusStr)
+	}
+}
+
+func TestMultiElbsOnPodAddedReadinessGateInjection(t *testing.T) {
+	// Readiness gates are intended only for CCE Turbo passthrough scenarios
+	// with dedicated (performance) ELBs, and the switch defaults to off.
+	cases := []struct {
+		name      string
+		conf      string
+		wantGates bool
+	}{
+		{
+			name:      "switch on + performance -> inject",
+			conf:      `[{"name":"ElbIdNames","value":"elb-1/pool-a,elb-2/pool-b"},{"name":"PortProtocols","value":"80/TCP"},{"name":"ElbClass","value":"performance"},{"name":"ReadinessGate","value":"true"}]`,
+			wantGates: true,
+		},
+		{
+			name:      "switch on + union -> skip",
+			conf:      `[{"name":"ElbIdNames","value":"elb-1/pool-a,elb-2/pool-b"},{"name":"PortProtocols","value":"80/TCP"},{"name":"ElbClass","value":"union"},{"name":"ReadinessGate","value":"true"}]`,
+			wantGates: false,
+		},
+		{
+			name:      "switch off + performance -> skip",
+			conf:      `[{"name":"ElbIdNames","value":"elb-1/pool-a,elb-2/pool-b"},{"name":"PortProtocols","value":"80/TCP"},{"name":"ElbClass","value":"performance"},{"name":"ReadinessGate","value":"false"}]`,
+			wantGates: false,
+		},
+		{
+			name:      "switch omitted (default off) + performance -> skip",
+			conf:      `[{"name":"ElbIdNames","value":"elb-1/pool-a,elb-2/pool-b"},{"name":"PortProtocols","value":"80/TCP"},{"name":"ElbClass","value":"performance"}]`,
+			wantGates: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := &MultiElbsPlugin{}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-0",
+					Namespace: "default",
+					Annotations: map[string]string{
+						gamekruiseiov1alpha1.GameServerNetworkType: MultiElbsNetwork,
+						gamekruiseiov1alpha1.GameServerNetworkConf: tc.conf,
+					},
+				},
+			}
+
+			got, err := plugin.OnPodAdded(nil, pod, context.Background())
+			if err != nil {
+				t.Fatalf("OnPodAdded returned error: %v", err)
+			}
+
+			if !tc.wantGates {
+				if len(got.Spec.ReadinessGates) != 0 {
+					t.Fatalf("expected no readiness gates, got %v", got.Spec.ReadinessGates)
+				}
+				return
+			}
+
+			want := map[corev1.PodConditionType]struct{}{
+				corev1.PodConditionType(PrefixReadyReadinessGate + "test-pod-0-pool-a"): {},
+				corev1.PodConditionType(PrefixReadyReadinessGate + "test-pod-0-pool-b"): {},
+			}
+			if len(got.Spec.ReadinessGates) != len(want) {
+				t.Fatalf("expected %d readiness gates, got %d: %v", len(want), len(got.Spec.ReadinessGates), got.Spec.ReadinessGates)
+			}
+			for _, rg := range got.Spec.ReadinessGates {
+				if _, ok := want[rg.ConditionType]; !ok {
+					t.Fatalf("unexpected readiness gate %q", rg.ConditionType)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessHealthCheckOptionsSkipsMalformedKeepsValid(t *testing.T) {
+	lps := &lbsPorts{
+		ports:      []int32{6000},
+		targetPort: []int{81},
+		protocols:  []corev1.Protocol{corev1.ProtocolTCP},
+	}
+	tests := []struct {
+		name string
+		cfg  string
+	}{
+		{
+			name: "malformed missing colon is skipped",
+			cfg:  `[{"protocol":"tcp","pod_target_port":"TCP:81","monitor_port":"8080"},{"protocol":"tcp","pod_target_port":"badformat","monitor_port":"9090"}]`,
+		},
+		{
+			name: "non-numeric port is skipped",
+			cfg:  `[{"protocol":"tcp","pod_target_port":"TCP:8o","monitor_port":"9090"},{"protocol":"tcp","pod_target_port":"TCP:81","monitor_port":"8080"}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := processHealthCheckOptions(tt.cfg, lps)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var options []HealthCheckOption
+			if err := json.Unmarshal([]byte(got), &options); err != nil {
+				t.Fatalf("failed to unmarshal result %q: %v", got, err)
+			}
+			if len(options) != 1 {
+				t.Fatalf("expected 1 valid option to survive, got %d (result=%s)", len(options), got)
+			}
+			if options[0].TargetServicePort != "TCP:6000" {
+				t.Fatalf("expected target_service_port TCP:6000, got %s", options[0].TargetServicePort)
+			}
+		})
+	}
+}

--- a/cloudprovider/options/hwcloud_options.go
+++ b/cloudprovider/options/hwcloud_options.go
@@ -7,7 +7,8 @@ type HwCloudOptions struct {
 }
 
 type CCEELBOptions struct {
-	ELBOptions ELBOptions `toml:"elb"`
+	ELBOptions      ELBOptions `toml:"elb"`
+	MultiELBOptions ELBOptions `toml:"multi-elb"`
 }
 
 type ELBOptions struct {
@@ -35,7 +36,7 @@ func (e ELBOptions) valid(skipPortRangeCheck bool) bool {
 func (o HwCloudOptions) Valid() bool {
 	elbOptions := o.ELBOptions
 	cceElbOptions := o.CCEELBOptions
-	return elbOptions.valid(false) && cceElbOptions.ELBOptions.valid(true)
+	return elbOptions.valid(false) && cceElbOptions.ELBOptions.valid(true) && cceElbOptions.MultiELBOptions.valid(true)
 }
 
 func (o HwCloudOptions) Enabled() bool {

--- a/cloudprovider/options/hwcloud_options_test.go
+++ b/cloudprovider/options/hwcloud_options_test.go
@@ -1,0 +1,45 @@
+package options
+
+import "testing"
+
+func TestHwCloudOptionsValidRequiresMultiELBOptions(t *testing.T) {
+	options := HwCloudOptions{
+		ELBOptions: ELBOptions{
+			MinPort: 500,
+			MaxPort: 700,
+		},
+		CCEELBOptions: CCEELBOptions{
+			ELBOptions: ELBOptions{
+				MinPort: 32768,
+				MaxPort: 65535,
+			},
+		},
+	}
+
+	if options.Valid() {
+		t.Fatal("expected HwCloudOptions.Valid() to reject missing multi-elb port range")
+	}
+}
+
+func TestHwCloudOptionsValidAcceptsAllELBOptions(t *testing.T) {
+	options := HwCloudOptions{
+		ELBOptions: ELBOptions{
+			MinPort: 500,
+			MaxPort: 700,
+		},
+		CCEELBOptions: CCEELBOptions{
+			ELBOptions: ELBOptions{
+				MinPort: 32768,
+				MaxPort: 65535,
+			},
+			MultiELBOptions: ELBOptions{
+				MinPort: 32700,
+				MaxPort: 65535,
+			},
+		},
+	}
+
+	if !options.Valid() {
+		t.Fatal("expected HwCloudOptions.Valid() to accept complete hwcloud port ranges")
+	}
+}

--- a/config/manager/config.toml
+++ b/config/manager/config.toml
@@ -25,6 +25,10 @@ block_ports = []
 max_port = 65535
 min_port = 32768
 block_ports = []
+[hwcloud.cce.multi-elb]
+max_port = 65535
+min_port = 32700
+block_ports = []
 
 [volcengine]
 enable = true

--- a/docs/en/user_manuals/network.md
+++ b/docs/en/user_manuals/network.md
@@ -144,6 +144,7 @@ OpenKruiseGame supports the following network plugins:
 - Volcengine-EIP
 - HwCloud-ELB
 - HwCloud-CCE-ELB
+- HwCloud-Multi-ELBs
 - HwCloud-CCE-EIP
 
 ---
@@ -2444,6 +2445,184 @@ kubectl get svc |grep hw-cce-elb-auto-performance
 hw-cce-elb-auto-performance-0                    LoadBalancer   10.247.50.xxx    192.168.1.xxx,49.0.251.xxx      1:30918/TCP                       4m29s
 hw-cce-elb-auto-performance-1                    LoadBalancer   10.247.196.xxx   150.40.245.xxx,192.168.1.xxx    1:30942/TCP                       4m29s
 ```
+
+---
+
+### HwCloud-Multi-ELBs
+
+#### Plugin name
+
+`HwCloud-Multi-ELBs`
+
+#### Cloud Provider
+
+HuaweiCloud
+
+#### Plugin description
+
+- HwCloud-Multi-ELBs is applicable to Huawei Cloud CCE Standard and CCE Turbo clusters.
+- It reuses existing Huawei Cloud ELB instances and creates one LoadBalancer Service per selected ELB/name binding for each Pod.
+- It is designed for multi-line access, multi-ISP access, or multiple ELB fault domains. The names in `ElbIdNames` are user-defined logical names, such as `line-a` and `line-b`.
+- This network plugin supports network isolation.
+
+#### Network parameters
+
+ElbIdNames
+
+- Meaning: the ELB instance ID and Name(self-define name). You can fill in multiple ids & names.
+- Value: in the format of `{elb-id-0}/{name-0},{elb-id-1}/{name-1}`. An example value can be: "elb-line-a-0/line-a,elb-line-b-0/line-b"
+- Configuration change supported or not: no.
+
+PortProtocols
+
+- Meaning: the ports in the pod to be exposed and the protocols. You can specify multiple ports and protocols.
+- Value: in the format of port1/protocol1,port2/protocol2,... The protocol names must be in uppercase letters. support protocol types: TCP, UDP, TCPUDP(means use same port for TCP & UDP at same time)
+- Configuration change supported or not: yes.
+
+AllocatePolicy
+
+- Meaning: the allocation policy for selecting an ELB group.
+- Value: default or balanced. Default value is default.
+- Configuration change supported or not: yes.
+
+Fixed
+
+- Meaning: whether the mapping relationship is fixed. If the mapping relationship is fixed, the mapping relationship remains unchanged even if the pod is deleted and recreated.
+- Value: false or true.
+- Configuration change supported or not: yes.
+
+ExternalTrafficPolicyType
+
+- Meaning: Service LB forward type. If Local, Service LB just forwards traffic to local node Pod, and source IP can be preserved without SNAT.
+- Value: Local or Cluster. Default value is Cluster.
+- Configuration change supported or not: no.
+
+AllocateLoadBalancerNodePorts
+
+- Meaning: whether to allocate NodePorts for generated LoadBalancer Services.
+- Value: false or true. Default value is false.
+- Configuration change supported or not: yes.
+
+ElbClass
+
+- Meaning: the ELB instance class.
+- Value: performance or union. Default value is performance.
+- Configuration change supported or not: yes.
+
+ReadinessGate
+
+- Meaning: whether to inject target-health readiness gates into Pods.
+- Value: false or true. Default value is false. Only supported in CCE Turbo passthrough scenarios using dedicated (performance) ELBs.
+- Configuration change supported or not: no.
+
+LBHealthCheckFlag
+
+- Meaning: Whether to enable health check.
+- Value: "on" means on, "off" means off. Default is on.
+- Configuration change supported or not: yes.
+
+LBHealthCheckConfig
+
+- Meaning: health check configuration.
+- Value: JSON array. Use pod_target_port in the GameServerSet config.
+- Configuration change supported or not: yes.
+
+UserDefine
+
+- Meaning: custom annotations for generated Services.
+- Value: JSON object string.
+- Configuration change supported or not: yes.
+
+AllowNotReadyContainers
+
+- Meaning: the container names that are allowed not ready when inplace updating, when traffic will not be cut.
+- Value: {containerName_0},{containerName_1},... Example:sidecar
+- Configuration change supported or not: It cannot be changed during the in-place updating process.
+
+#### Design
+
+1. **ELB grouping**: `ElbIdNames` groups ELBs by logical name. Each Pod gets one allocation group, and the plugin creates one Service for each ELB/name pair in that group.
+2. **Port allocation**: the plugin allocates ports from `[min_port, max_port]` in `[hwcloud.cce.multi-elb]`, skipping `block_ports`. The same allocated Service port is used on every ELB/name pair of the selected group.
+3. **Stable allocation snapshot**: once a Pod is allocated, its ELB IDs, logical names, external ports, target ports, and protocols are kept as a snapshot. Later config changes do not migrate existing Pods to another ELB group or reserve extra ports for them.
+4. **Service naming**: generated Services are named `{podName}-{elbName}` and are labeled with `game.kruise.io/network-type=HwCloud-Multi-ELBs`.
+5. **Network status**: the GameServer becomes `Ready` only after every generated Service has LoadBalancer ingress and the Pod is Ready. `externalAddresses[].endPoint` contains a comma-separated list of `{host}/{elbName}` entries.
+
+#### Plugin configuration
+
+The Multi-ELBs plugin uses `[hwcloud.cce.multi-elb]` as its port allocation range. Keep the other Huawei Cloud ELB option blocks present when enabling the Huawei Cloud provider.
+
+```toml
+[hwcloud]
+enable = true
+
+[hwcloud.elb]
+max_port = 700
+min_port = 500
+block_ports = []
+
+[hwcloud.cce.elb]
+max_port = 65535
+min_port = 32768
+block_ports = []
+
+[hwcloud.cce.multi-elb]
+max_port = 65535
+min_port = 32700
+block_ports = []
+```
+
+#### Example
+
+The following example exposes every Pod through two user-defined logical lines, `line-a` and `line-b`. The first Pod is allocated to one ELB from each line, and the generated Services use the same allocated external port on both ELBs.
+
+```yaml
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  name: hw-multi-elbs-nginx
+  namespace: default
+spec:
+  replicas: 2
+  updateStrategy:
+    rollingUpdate:
+      podUpdatePolicy: InPlaceIfPossible
+  network:
+    networkType: HwCloud-Multi-ELBs
+    networkConf:
+      - name: ElbIdNames
+        value: elb-line-a-0/line-a,elb-line-a-1/line-a,elb-line-b-0/line-b,elb-line-b-1/line-b
+      - name: PortProtocols
+        value: "80/TCPUDP"
+      - name: AllocatePolicy
+        value: balanced
+      - name: ElbClass
+        value: performance
+      - name: ReadinessGate
+        value: "true"
+      - name: LBHealthCheckFlag
+        value: "on"
+      - name: LBHealthCheckConfig
+        value: '[{"protocol":"tcp","pod_target_port":"TCP:80","monitor_port":"8080"}]'
+      - name: UserDefine
+        value: '{"kubernetes.io/elb.lb-algorithm":"ROUND_ROBIN"}'
+  gameServerTemplate:
+    spec:
+      containers:
+        - image: nginx
+          name: nginx
+```
+
+After reconciliation, each Pod has one Service per logical name:
+
+```bash
+kubectl get svc | grep hw-multi-elbs-nginx-0
+hw-multi-elbs-nginx-0-line-a   LoadBalancer   10.247.1.xxx   121.1.1.xxx   32700:30xxx/TCP,32700:30xxx/UDP
+hw-multi-elbs-nginx-0-line-b   LoadBalancer   10.247.2.xxx   122.1.1.xxx   32700:31xxx/TCP,32700:31xxx/UDP
+```
+
+---
+
+### HwCloud-CCE-EIP
 
 #### Plugin Name
 `HwCloud-EIP`

--- a/docs/中文/用户手册/网络模型.md
+++ b/docs/中文/用户手册/网络模型.md
@@ -144,6 +144,7 @@ EOF
 - Volcengine-EIP
 - HwCloud-ELB
 - HwCloud-CCE-ELB
+- HwCloud-Multi-ELBs
 - HwCloud-CCE-EIP
 ---
 
@@ -2560,6 +2561,180 @@ status:
 kubectl get svc |grep hw-cce-elb-auto-performance
 hw-cce-elb-auto-performance-0                    LoadBalancer   10.247.50.xxx    192.168.1.xxx,49.0.251.xxx      1:30918/TCP                       4m29s
 hw-cce-elb-auto-performance-1                    LoadBalancer   10.247.196.xxx   150.40.245.xxx,192.168.1.xxx    1:30942/TCP                       4m29s
+```
+
+---
+
+### HwCloud-Multi-ELBs
+
+#### 插件名称
+
+`HwCloud-Multi-ELBs`
+
+#### Cloud Provider
+
+HuaweiCloud
+
+#### 插件说明
+
+- HwCloud-Multi-ELBs 适用于华为云 CCE Standard 和 CCE Turbo 集群。
+- 该插件复用已有的华为云 ELB，并为每个 Pod 选择到的 ELB/name 绑定创建一个 LoadBalancer Service。
+- 该插件适用于多线路、多运营商或多 ELB 故障域场景。`ElbIdNames` 中的名称是用户自定义逻辑名称，例如 `line-a` 和 `line-b`。
+- 是否支持网络隔离：是。
+
+#### 网络参数
+
+ElbIdNames
+
+- 含义：填写elb的id以及对应名称。可填写多个。
+- 填写格式：{elb-id-0}/{name-0},{elb-id-1}/{name-1}。例如：elb-line-a-0/line-a,elb-line-b-0/line-b,...
+- 是否支持变更：不支持
+
+PortProtocols
+
+- 含义：pod暴露的端口及协议，支持填写多个端口/协议
+- 格式：port1/protocol1,port2/protocol2,...（协议需大写)。支持协议如下：TCP、UDP、TCPUDP（表示同时使用TCP与UDP）。
+- 是否支持变更：支持
+
+AllocatePolicy
+
+- 含义：ELB 分配策略。
+- 填写格式：default 或 balanced，默认为 default
+- 是否支持变更：支持
+
+Fixed
+
+- 含义：是否固定访问IP/端口。若是，即使pod删除重建，网络内外映射关系不会改变
+- 填写格式：false / true
+- 是否支持变更：支持
+
+ExternalTrafficPolicyType
+
+- 含义：Service LB 是否只转发给本地实例。若是 Local，创建 Local 类型 Service，配合 cloud-manager 只配置对应 Node，可以保留客户端源 IP 地址
+- 填写格式：Local/Cluster，默认 Cluster
+- 是否支持变更：不支持
+
+AllocateLoadBalancerNodePorts
+
+- 含义：生成的 LoadBalancer Service 是否分配 NodePort
+- 填写格式：false / true，默认 false
+- 是否支持变更：支持
+
+ElbClass
+
+- 含义：ELB 实例类型
+- 填写格式：performance / union，默认 performance
+- 是否支持变更：支持
+
+ReadinessGate
+
+- 含义：是否向 Pod 注入 target-health readiness gate
+- 填写格式：false / true，默认 false。只支持 CCE Turbo 集群中使用独享型（performance）ELB 的直通场景。
+- 是否支持变更：不支持
+
+LBHealthCheckFlag
+
+- 含义：是否开启健康检查
+- 格式：“on”代表开启，“off”代表关闭。默认为on
+- 是否支持变更：支持
+
+LBHealthCheckConfig
+
+- 含义：健康检查的配置信息
+- 格式：JSON 数组，GameServerSet 配置中使用 pod_target_port
+- 是否支持变更：支持
+
+UserDefine
+
+- 含义：生成 Service 的自定义注解
+- 格式：JSON object 字符串
+- 是否支持变更：支持
+
+AllowNotReadyContainers
+
+- 含义：在容器原地升级时允许不断流的对应容器名称，可填写多个
+- 格式：{containerName_0},{containerName_1},... 例如：sidecar
+- 是否支持变更：在原地升级过程中不可变更。
+
+#### 设计说明
+
+1. **ELB 分组**：`ElbIdNames` 会按逻辑名称对 ELB 分组。每个 Pod 会选择一个分配组，并为该组中的每个 ELB/name 绑定创建一个 Service。
+2. **端口分配**：插件从 `[hwcloud.cce.multi-elb]` 的 `[min_port, max_port]` 中分配端口，并跳过 `block_ports`。同一个分配组内的所有 ELB/name 绑定会使用同一组已分配 Service 端口。
+3. **稳定分配快照**：Pod 完成分配后，会保存 ELB ID、逻辑名称、外部端口、目标端口和协议快照。后续配置变更不会把已有 Pod 迁移到其他 ELB 组，也不会为已有 Pod 额外占用端口。
+4. **Service 命名**：生成的 Service 名称为 `{podName}-{elbName}`，并带有 `game.kruise.io/network-type=HwCloud-Multi-ELBs` 标签。
+5. **网络状态**：只有所有生成的 Service 都有 LoadBalancer ingress 且 Pod Ready 后，GameServer 才会进入 `Ready`。`externalAddresses[].endPoint` 会写入以逗号分隔的 `{host}/{elbName}` 列表。
+
+#### Plugin configuration
+
+Multi-ELBs 插件使用 `[hwcloud.cce.multi-elb]` 作为端口分配范围。启用 Huawei Cloud provider 时，请保留其他 Huawei Cloud ELB option 配置块。
+
+```toml
+[hwcloud]
+enable = true
+
+[hwcloud.elb]
+max_port = 700
+min_port = 500
+block_ports = []
+
+[hwcloud.cce.elb]
+max_port = 65535
+min_port = 32768
+block_ports = []
+
+[hwcloud.cce.multi-elb]
+max_port = 65535
+min_port = 32700
+block_ports = []
+```
+
+#### 示例说明
+
+下面的示例将每个 Pod 同时通过 `line-a` 和 `line-b` 两条用户自定义逻辑线路暴露。第一个 Pod 会从每条线路各选择一个 ELB，生成的多个 Service 会在不同 ELB 上使用同一个分配出的外部端口。
+
+```yaml
+apiVersion: game.kruise.io/v1alpha1
+kind: GameServerSet
+metadata:
+  name: hw-multi-elbs-nginx
+  namespace: default
+spec:
+  replicas: 2
+  updateStrategy:
+    rollingUpdate:
+      podUpdatePolicy: InPlaceIfPossible
+  network:
+    networkType: HwCloud-Multi-ELBs
+    networkConf:
+      - name: ElbIdNames
+        value: elb-line-a-0/line-a,elb-line-a-1/line-a,elb-line-b-0/line-b,elb-line-b-1/line-b
+      - name: PortProtocols
+        value: "80/TCPUDP"
+      - name: AllocatePolicy
+        value: balanced
+      - name: ElbClass
+        value: performance
+      - name: ReadinessGate
+        value: "true"
+      - name: LBHealthCheckFlag
+        value: "on"
+      - name: LBHealthCheckConfig
+        value: '[{"protocol":"tcp","pod_target_port":"TCP:80","monitor_port":"8080"}]'
+      - name: UserDefine
+        value: '{"kubernetes.io/elb.lb-algorithm":"ROUND_ROBIN"}'
+  gameServerTemplate:
+    spec:
+      containers:
+        - image: nginx
+          name: nginx
+```
+
+完成 reconcile 后，每个 Pod 会生成一个对应每个逻辑名称的 Service：
+
+```bash
+kubectl get svc | grep hw-multi-elbs-nginx-0
+hw-multi-elbs-nginx-0-line-a   LoadBalancer   10.247.1.xxx   121.1.1.xxx   32700:30xxx/TCP,32700:30xxx/UDP
+hw-multi-elbs-nginx-0-line-b   LoadBalancer   10.247.2.xxx   122.1.1.xxx   32700:31xxx/TCP,32700:31xxx/UDP
 ```
 
 ### HwCloud-CCE-EIP


### PR DESCRIPTION
## Description

### What this PR does

Adds a new Huawei Cloud network plugin `HwCloud-Multi-ELBs` for CCE clusters.
It reuses existing Huawei Cloud ELB instances and creates one LoadBalancer 
Service per selected ELB/name binding for each Pod,
targeting multi-line / multi-ISP / multi-ELB-fault-domain access scenarios.

`ElbIdNames` groups ELBs by user-defined logical name (e.g. `line-a`,
`line-b`). Each Pod is allocated to one group; the plugin creates one Service
per ELB/name pair in that group, all sharing the same allocated external port
drawn from the `[hwcloud.cce.multi-elb]` port range.

### Config

Adds a `[hwcloud.cce.multi-elb]` port-range block. The other Huawei Cloud ELB
option blocks must remain present when the Huawei Cloud provider is enabled.

```toml
[hwcloud.cce.multi-elb]
max_port = 65535
min_port = 32700
block_ports = []
```

### Verification

- `go build ./cloudprovider/...`
- `go vet ./cloudprovider/hwcloud/...`
- `golangci-lint run ./cloudprovider/hwcloud/...` (0 issues)
- `go test ./cloudprovider/hwcloud/... ./cloudprovider/options/...`

### Docs

- `docs/en/user_manuals/network.md`
- `docs/中文/用户手册/网络模型.md`

### Checklist

- [x] Code generated (`make generate` not needed — no API/CRD change)
- [x] Lint golang code
- [x] Unit tests
- [x] User manuals updated (EN + ZH)

