### PR TITLE
fix: add RBAC markers for AutoNLBs-V2 plugin to grant NLB/EIP CRD permissions

### DIFF
--- a/cloudprovider/alibabacloud/auto_nlbs_v2.go
+++ b/cloudprovider/alibabacloud/auto_nlbs_v2.go
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//+kubebuilder:rbac:groups=nlboperator.alibabacloud.com,resources=nlbs;servergroups;listeners,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=nlboperator.alibabacloud.com,resources=nlbs/status;servergroups/status;listeners/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=eip.alibabacloud.com,resources=eips,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=eip.alibabacloud.com,resources=eips/status,verbs=get;list;watch
+
 package alibabacloud
 
 import (

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,6 +111,26 @@ rules:
   - patch
   - update
 - apiGroups:
+  - eip.alibabacloud.com
+  resources:
+  - eips
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - eip.alibabacloud.com
+  resources:
+  - eips/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - elbv2.k8s.aws
   resources:
   - targetgroupbindings
@@ -201,6 +221,30 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - nlboperator.alibabacloud.com
+  resources:
+  - listeners
+  - nlbs
+  - servergroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nlboperator.alibabacloud.com
+  resources:
+  - listeners/status
+  - nlbs/status
+  - servergroups/status
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - nlbpool.alibabacloud.com
   resources:


### PR DESCRIPTION
## Problem

The `AlibabaCloud-AutoNLBs-V2` network plugin directly creates and manages NLB and EIP custom resources (via `nlboperator.alibabacloud.com` and `eip.alibabacloud.com` API groups), but the required RBAC permissions were missing from `config/rbac/role.yaml`.

This caused:
1. `Timeout: failed waiting for *v1.NLB Informer to sync` - NLB Informer cannot list/watch due to missing permissions
2. `Timeout: failed waiting for *v1alpha1.EIP Informer to sync` - EIP Informer cannot list/watch
3. `cannot create resource "nlbs" ... is forbidden` - NLB CR creation denied
4. Webhook execution timeout (`MutatingTimeout`) leading to GameServer network state stuck at NotReady

## Root Cause

The `auto_nlbs_v2.go` file lacked kubebuilder RBAC markers, so `make manifests` (controller-gen) did not generate the corresponding RBAC rules. Unlike standard controllers that declare permissions via `//+kubebuilder:rbac` annotations, this cloud provider plugin was missing these declarations.

## Fix

Added kubebuilder RBAC markers to `cloudprovider/alibabacloud/auto_nlbs_v2.go` and regenerated manifests:

- `nlboperator.alibabacloud.com`: nlbs, servergroups, listeners (full CRUD)
- `nlboperator.alibabacloud.com`: nlbs/status, servergroups/status, listeners/status (read-only)
- `eip.alibabacloud.com`: eips (full CRUD)
- `eip.alibabacloud.com`: eips/status (read-only)

## Changes

- `cloudprovider/alibabacloud/auto_nlbs_v2.go`: Added 4 RBAC marker annotations
- `config/rbac/role.yaml`: Auto-generated by `make manifests` (+44 lines)