### PR TITLE
feat(cloudprovider): support configurable EIP bandwidth in AutoNLBs-V2 plugin

### DIFF
--- a/cloudprovider/alibabacloud/auto_nlbs.go
+++ b/cloudprovider/alibabacloud/auto_nlbs.go
@@ -50,6 +50,7 @@ const (
 	BlockPortsConfigName    = "BlockPorts"
 	// EIP 高防护相关配置
 	SecurityProtectionTypesConfigName = "SecurityProtectionTypes" // EIP 安全防护类型，多个用逗号分隔
+	EipBandwidthConfigName            = "EipBandwidth"            // EIP 带宽，单位 Mbps，默认 5
 
 	NLBZoneMapsServiceAnnotationKey = "service.beta.kubernetes.io/alibaba-cloud-loadbalancer-zone-maps"
 	NLBAddressTypeAnnotationKey     = "service.beta.kubernetes.io/alibaba-cloud-loadbalancer-address-type"
@@ -75,6 +76,7 @@ type autoNLBsConfig struct {
 	externalTrafficPolicy   corev1.ServiceExternalTrafficPolicyType
 	retainNLBOnDelete       bool     // 是否在 GSS 删除时保留 NLB 和 EIP 资源（默认 true）
 	securityProtectionTypes []string // EIP 安全防护类型（如 AntiDDoS_Enhanced）
+	eipBandwidth           string   // EIP 带宽，单位 Mbps，默认 "5"
 	*nlbHealthConfig
 }
 
@@ -475,6 +477,7 @@ func parseAutoNLBsConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) (*autoNL
 	minPort := int32(1000)
 	maxPort := int32(1499)
 	securityProtectionTypes := make([]string, 0) // 默认为空，不启用高防护
+	eipBandwidth := "5"                           // 默认带宽 5Mbps
 
 	for _, c := range conf {
 		switch c.Name {
@@ -532,6 +535,10 @@ func parseAutoNLBsConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) (*autoNL
 					securityProtectionTypes[i] = strings.TrimSpace(securityProtectionTypes[i])
 				}
 			}
+		case EipBandwidthConfigName:
+			if c.Value != "" {
+				eipBandwidth = c.Value
+			}
 		}
 	}
 
@@ -566,5 +573,6 @@ func parseAutoNLBsConfig(conf []gamekruiseiov1alpha1.NetworkConfParams) (*autoNL
 		externalTrafficPolicy:   externalTrafficPolicy,
 		retainNLBOnDelete:       retainNLBOnDelete,
 		securityProtectionTypes: securityProtectionTypes,
+		eipBandwidth:           eipBandwidth,
 	}, nil
 }

--- a/cloudprovider/alibabacloud/auto_nlbs_v2.go
+++ b/cloudprovider/alibabacloud/auto_nlbs_v2.go
@@ -1263,7 +1263,7 @@ func (a *AutoNLBsV2Plugin) ensureEIPCR(ctx context.Context, c client.Client, nam
 		},
 		Spec: eipv1.EIPSpec{
 			Name:                    eipName,
-			Bandwidth:               "5",                // 默认带宽 5Mbps，可以后续通过配置调整
+			Bandwidth:               config.eipBandwidth, // 带宽可通过 EipBandwidth 参数配置，默认 5Mbps
 			InternetChargeType:      internetChargeType, // 根据 ISP 类型选择计费方式
 			ISP:                     eipIspType,         // 设置 ISP 线路类型（支持单线 EIP）
 			ReleaseStrategy:         "OnDelete",         // CR 删除时释放 EIP


### PR DESCRIPTION
## What
Add `EipBandwidth` parameter support to the AlibabaCloud-AutoNLBs-V2 network plugin, allowing users to customize EIP bandwidth through GameServerSet networkConf.

## Why
Previously the EIP bandwidth was hardcoded to 5 Mbps in `ensureEIPCR()`. Users had no way to configure bandwidth through the standard GameServerSet interface and had to manually edit EIP CRs after creation.

## Changes
- Added `EipBandwidthConfigName` constant and `eipBandwidth` field to `autoNLBsConfig` struct
- Added parsing logic in `parseAutoNLBsConfig()` with default value "5"
- Replaced hardcoded bandwidth in `ensureEIPCR()` with configurable value from config

## Usage
```yaml
network:
  networkConf:
    - name: EipBandwidth
      value: '100'
```

## Backward Compatibility
When `EipBandwidth` is not specified, the default value remains "5" Mbps, maintaining the same behavior as before.